### PR TITLE
Chevron for Generics

### DIFF
--- a/crates/lang/src/parser.rs
+++ b/crates/lang/src/parser.rs
@@ -336,13 +336,11 @@ fn constant_value_parser() -> impl Parser<Token, ast::UntypedConstant, Error = P
                 }
             });
 
-        let constant_tuple_parser = just(Token::Hash)
-            .ignore_then(
-                r.clone()
-                    .separated_by(just(Token::Comma))
-                    .allow_trailing()
-                    .delimited_by(just(Token::LeftParen), just(Token::RightParen)),
-            )
+        let constant_tuple_parser = r
+            .clone()
+            .separated_by(just(Token::Comma))
+            .allow_trailing()
+            .delimited_by(just(Token::LeftParen), just(Token::RightParen))
             .map_with_span(|elements, span| ast::UntypedConstant::Tuple {
                 location: span,
                 elements,
@@ -851,13 +849,11 @@ pub fn expr_parser(
                 label,
             });
 
-        let tuple = just(Token::Hash)
-            .ignore_then(
-                r.clone()
-                    .separated_by(just(Token::Comma))
-                    .allow_trailing()
-                    .delimited_by(just(Token::LeftParen), just(Token::RightParen)),
-            )
+        let tuple = r
+            .clone()
+            .separated_by(just(Token::Comma))
+            .allow_trailing()
+            .delimited_by(just(Token::LeftParen), just(Token::RightParen))
             .map_with_span(|elems, span| expr::UntypedExpr::Tuple {
                 location: span,
                 elems,
@@ -1301,13 +1297,11 @@ pub fn type_parser() -> impl Parser<Token, ast::Annotation, Error = ParseError> 
                     name,
                 }
             }),
-            just(Token::Hash)
-                .ignore_then(
-                    r.clone()
-                        .separated_by(just(Token::Comma))
-                        .allow_trailing()
-                        .delimited_by(just(Token::LeftParen), just(Token::RightParen)),
-                )
+            // Tuple
+            r.clone()
+                .separated_by(just(Token::Comma))
+                .allow_trailing()
+                .delimited_by(just(Token::LeftParen), just(Token::RightParen))
                 .map_with_span(|elems, span| ast::Annotation::Tuple {
                     location: span,
                     elems,
@@ -1528,13 +1522,10 @@ pub fn pattern_parser() -> impl Parser<Token, ast::UntypedPattern, Error = Parse
                     value,
                 }
             }),
-            just(Token::Hash)
-                .ignore_then(
-                    r.clone()
-                        .separated_by(just(Token::Comma))
-                        .allow_trailing()
-                        .delimited_by(just(Token::LeftParen), just(Token::RightParen)),
-                )
+            r.clone()
+                .separated_by(just(Token::Comma))
+                .allow_trailing()
+                .delimited_by(just(Token::LeftParen), just(Token::RightParen))
                 .map_with_span(|elems, span| ast::UntypedPattern::Tuple {
                     location: span,
                     elems,

--- a/crates/lang/src/parser.rs
+++ b/crates/lang/src/parser.rs
@@ -1333,7 +1333,7 @@ pub fn type_parser() -> impl Parser<Token, ast::Annotation, Error = ParseError> 
                     r.clone()
                         .separated_by(just(Token::Comma))
                         .allow_trailing()
-                        .delimited_by(just(Token::LeftParen), just(Token::RightParen))
+                        .delimited_by(just(Token::Less), just(Token::Greater))
                         .or_not(),
                 )
                 .map_with_span(|(name, arguments), span| ast::Annotation::Constructor {
@@ -1399,7 +1399,7 @@ pub fn type_name_with_args() -> impl Parser<Token, (String, Option<Vec<String>>)
             select! {Token::Name { name } => name}
                 .separated_by(just(Token::Comma))
                 .allow_trailing()
-                .delimited_by(just(Token::LeftParen), just(Token::RightParen))
+                .delimited_by(just(Token::Less), just(Token::Greater))
                 .or_not(),
         ),
     )

--- a/crates/lang/src/tests/parser.rs
+++ b/crates/lang/src/tests/parser.rs
@@ -92,7 +92,7 @@ fn import_alias() {
 #[test]
 fn custom_type() {
     let code = indoc! {r#"
-        type Option(a) {
+        type Option<a> {
           Some(a, Int)
           None
           Wow { name: Int, age: Int }
@@ -225,7 +225,7 @@ fn opaque_type() {
 #[test]
 fn type_alias() {
     let code = indoc! {r#"
-        type Thing = Option(Int)
+        type Thing = Option<Int>
     "#};
 
     assert_definition(
@@ -255,7 +255,7 @@ fn type_alias() {
 #[test]
 fn pub_type_alias() {
     let code = indoc! {r#"
-        pub type Me = Option(String)
+        pub type Me = Option<String>
     "#};
 
     assert_definition(

--- a/examples/sample/validators/swap.ak
+++ b/examples/sample/validators/swap.ak
@@ -2,13 +2,9 @@ use sample
 
 pub fn spend(datum: sample.Datum, rdmr: sample.Redeemer, _ctx: Nil) -> Bool {
   let x = (datum, rdmr, #[244])
-
   let y = [(#[222], #[222]), (#[233], #[52])]
-
   let [z, f, ..g] = y
-
   let (a, b, _) = x
-
   z == (#[222], #[222])
 }
 

--- a/examples/sample/validators/swap.ak
+++ b/examples/sample/validators/swap.ak
@@ -1,15 +1,15 @@
 use sample
 
 pub fn spend(datum: sample.Datum, rdmr: sample.Redeemer, _ctx: Nil) -> Bool {
-  let _x = #(datum, rdmr, #[244])
+  let x = (datum, rdmr, #[244])
 
-  let y = [#(#[222], #[222]), #(#[233], #[52])]
+  let y = [(#[222], #[222]), (#[233], #[52])]
 
   let [z, f, ..g] = y
 
-  let #(a, b) = x
+  let (a, b, _) = x
 
-  z == #(#[222], #[222])
+  z == (#[222], #[222])
 }
 
 test foo() {


### PR DESCRIPTION
* generics now use chevrons `Option<Int>`
* no longer need a `#` in front of tuples `(1, 2, 3)`