### PR TITLE
Add --match-tests to 'check' cmd

### DIFF
--- a/crates/cli/src/cmd/check.rs
+++ b/crates/cli/src/cmd/check.rs
@@ -10,13 +10,18 @@ pub struct Args {
     /// Skip tests; run only the type-checker
     #[clap(short, long)]
     skip_tests: bool,
+
+    /// Only run tests if their path + name match the given string
+    #[clap(short, long)]
+    match_tests: Option<String>,
 }
 
 pub fn exec(
     Args {
         directory,
         skip_tests,
+        match_tests,
     }: Args,
 ) -> miette::Result<()> {
-    crate::with_project(directory, |p| p.check(skip_tests))
+    crate::with_project(directory, |p| p.check(skip_tests, match_tests.clone()))
 }

--- a/crates/project/src/lib.rs
+++ b/crates/project/src/lib.rs
@@ -534,13 +534,8 @@ where
         for test in tests {
             let path = format!("{}{}", test.module, test.name);
 
-            match match_tests.clone() {
-                None => {}
-                Some(search_str) => {
-                    if !path.to_string().contains(&search_str) {
-                        continue;
-                    }
-                }
+            if matches!(&match_tests, Some(search_str) if !path.to_string().contains(search_str)) {
+                continue;
             }
 
             match test.program.eval(initial_budget) {

--- a/crates/project/src/options.rs
+++ b/crates/project/src/options.rs
@@ -3,7 +3,7 @@ pub struct Options {
 }
 
 pub enum CodeGenMode {
-    Test,
+    Test(Option<String>),
     Build(bool),
     NoOp,
 }


### PR DESCRIPTION
For running only tests matching a certain pattern. Useful when doing TDD.

For example:

```
aiken check --match-tests list
```