### PR TITLE
Some fixes

### DIFF
--- a/crates/lang/src/parser.rs
+++ b/crates/lang/src/parser.rs
@@ -47,7 +47,6 @@ pub fn module(
             false
         }
         Token::EmptyLine => {
-            println!("{:?}", span);
             extra.empty_lines.push(span.start);
 
             false

--- a/crates/lang/src/tipo/environment.rs
+++ b/crates/lang/src/tipo/environment.rs
@@ -995,6 +995,7 @@ impl<'a> Environment<'a> {
             }
 
             Definition::Test(Function { name, location, .. }) => {
+                assert_unique_value_name(names, name, location)?;
                 hydrators.insert(name.clone(), Hydrator::new());
                 let arg_types = vec![];
                 let return_type = builtins::bool();

--- a/crates/lang/src/uplc.rs
+++ b/crates/lang/src/uplc.rs
@@ -1903,7 +1903,7 @@ impl<'a> CodeGenerator<'a> {
                                 argument: left.into(),
                             }
                             .into(),
-                            argument: Term::Delay(Term::Constant(UplcConstant::Bool(false)).into())
+                            argument: Term::Delay(Term::Constant(UplcConstant::Bool(true)).into())
                                 .into(),
                         }
                         .into(),


### PR DESCRIPTION
This fixes ~two~ three things:

- :round_pushpin: **Enforce unique top-level names for tests too.**
    This prevents the compiler from crashing later on. Test names should be unique and not clash with function names.

- :round_pushpin: **Preserve newlines after blocks of comments.**
    This is an example of output from the formatter now:

  ```
  //// Some module documentation

  // foo
  const a: Int = 42

  // Some comment block
  // For which newlines are respected.
  // Foo

  // Another one

  /// add_one documentation
  pub fn add_one(n: Int) -> Int {
    // n + 1
    n + 1
  }
  ```

  before this commit, comments would all be collapsed into one group
  above the function as:

  ```
  // Some comment block
  // For which newlines are respected.
  // Foo
  // Another one
  /// add_one documentation
  pub fn add_one(n: Int) -> Int {
  ```

- :round_pushpin: **Fix codegen for binary operator 'or'**
    a && b → if a { b } else { false }
  a || b → if a { true } else { b }

