### PR TITLE
Fix errors on aiken build

### DIFF
--- a/crates/cli/src/cmd/new.rs
+++ b/crates/cli/src/cmd/new.rs
@@ -54,7 +54,7 @@ impl Creator {
         write(
             self.validators.join("always_true.ak"),
             indoc! {"
-                pub fn spend() -> Bool {
+                pub fn spend(_datum, _redeemer, _context) -> Bool {
                     True
                 }
             "},
@@ -76,7 +76,7 @@ impl Creator {
         write(
             self.project_lib.join("context.ak"),
             indoc! {"
-                pub type ScriptContext(purpose) {
+                pub type ScriptContext<purpose> {
                     tx_info: TxInfo,
                     script_purpose: purpose,
                 }


### PR DESCRIPTION
Small updates to the template files used by `aiken new`. I noticed that running `aiken build` would generate errors, so I made the following updates:

- Update generics syntax
- Add required args to default validator function

This allows running a successful `aiken build` directly after `aiken new`.