### PR TITLE
Properly capture empty lines

### DIFF
--- a/crates/lang/src/parser.rs
+++ b/crates/lang/src/parser.rs
@@ -51,6 +51,7 @@ pub fn module(
 
             false
         }
+        Token::NewLine => false,
         _ => true,
     });
 

--- a/crates/lang/src/parser/token.rs
+++ b/crates/lang/src/parser/token.rs
@@ -55,6 +55,7 @@ pub enum Token {
     DocComment,
     ModuleComment,
     EmptyLine,
+    NewLine,
     // Keywords (alphabetically):
     As,
     Assert,
@@ -130,6 +131,7 @@ impl fmt::Display for Token {
             Token::DocComment => "///",
             Token::ModuleComment => "////",
             Token::EmptyLine => "EMPTYLINE",
+            Token::NewLine => "NEWLINE",
             Token::As => "as",
             Token::Assert => "assert",
             Token::Check => "check",

--- a/crates/lang/src/tests/lexer.rs
+++ b/crates/lang/src/tests/lexer.rs
@@ -21,6 +21,7 @@ fn tokens() {
             Token::Type,
             Token::Pipe,
             Token::GreaterEqual,
+            Token::NewLine,
             Token::LeftBrace,
             Token::UpName {
                 name: "Thing".to_string()

--- a/examples/sample/validators/swap.ak
+++ b/examples/sample/validators/swap.ak
@@ -1,10 +1,17 @@
 use sample
 
+// Stuff
+
+/// Spend validator
 pub fn spend(datum: sample.Datum, rdmr: sample.Redeemer, _ctx: Nil) -> Bool {
   let x = #(datum, rdmr, #[244])
+
   let y = [#(#[222], #[222]), #(#[233], #[52])]
+
   let [z, f, ..g] = y
+
   let #(a, b, _) = x
+
   z == #(#[222], #[222])
 }
 


### PR DESCRIPTION
thanks to https://github.com/zesterer/chumsky/issues/230#issuecomment-1350845091

padded_by does mostly what padded would do but now instead we capture newlines ("\n") and emptylines ("\n\n") as special tokens.

EmptyLine's `span.start` goes into the ModuleExtra info.

NewLine token is simply filtered out while collecting comments and empty lines into ModuleExtra.