### PR TITLE
fix: correct V1 to_plutus_data() for post-alonzo txout with no datum hash

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
 ### Changed
 
 - **aiken**: `check` now also runs and reports on any `test` found in the project
+- **aiken**: fix Plutus V1 `to_plutus_data()` for post-alonzo txout with no datum hash
 
 ### Removed
 

--- a/crates/uplc/src/tx/to_plutus_data.rs
+++ b/crates/uplc/src/tx/to_plutus_data.rs
@@ -296,7 +296,7 @@ impl ToPlutusData for TxOut {
                         post_alonzo_output.value.to_plutus_data(),
                         match post_alonzo_output.datum_option {
                             Some(DatumOption::Hash(hash)) => Some(hash).to_plutus_data(),
-                            _ => None::<DatumOption>.to_plutus_data(),
+                            _ => None::<Option<Hash<32>>>.to_plutus_data(),
                         },
                     ],
                 ),

--- a/crates/uplc/src/tx/to_plutus_data.rs
+++ b/crates/uplc/src/tx/to_plutus_data.rs
@@ -296,7 +296,7 @@ impl ToPlutusData for TxOut {
                         post_alonzo_output.value.to_plutus_data(),
                         match post_alonzo_output.datum_option {
                             Some(DatumOption::Hash(hash)) => Some(hash).to_plutus_data(),
-                            _ => None::<Option<Hash<32>>>.to_plutus_data(),
+                            _ => None::<Hash<32>>.to_plutus_data(),
                         },
                     ],
                 ),


### PR DESCRIPTION
Currently, `to_plutus_data()` for a post-Alonzo TxOut using a V1 script results in an incorrect PlutusData TxInfo as the tag on the datum part of the output is `121` when it should be `122`. This is because the code currently treats no datum hash as a `None::<DatumOption>`, but DatumOption did not exist in V1. Instead it should use the general `Option<A>` `to_plutus_data()` which this PR does (choose Hash<32> as this just aligns with the other match arm). At least, this is my understanding, but I am not 100% confident!