### PR TITLE
Fix acceptance 021: allow registering type aliases in any order.

### DIFF
--- a/crates/lang/src/tipo/error.rs
+++ b/crates/lang/src/tipo/error.rs
@@ -271,6 +271,13 @@ pub enum Error {
         name: String,
     },
 
+    #[error("Cyclic type definition detected: {}\n", types.join(" -> "))]
+    CyclicTypeDefinitions {
+        #[label]
+        location: Span,
+        types: Vec<String>,
+    },
+
     #[error("Recursive type detected\n")]
     RecursiveType {
         #[label]

--- a/crates/lang/src/tipo/infer.rs
+++ b/crates/lang/src/tipo/infer.rs
@@ -48,9 +48,12 @@ impl UntypedModule {
 
         // Register types so they can be used in constructors and functions
         // earlier in the module.
-        for def in self.definitions() {
-            environment.register_types(def, &name, &mut hydrators, &mut type_names)?;
-        }
+        environment.register_types(
+            self.definitions.iter().collect(),
+            &name,
+            &mut hydrators,
+            &mut type_names,
+        )?;
 
         // Register values so they can be used in functions earlier in the module.
         for def in self.definitions() {


### PR DESCRIPTION
  This is the most intuitive thing I could come up with: since the
  problem is mainly due to the order in which we try declaring the
  aliases, then it suffices to simply try as much as we can, and retry
  on failure until there's no more failure.

  Note that it's important to detect cycles if we do such thing (which
  we can by noticing that a given iteration didn't make any progress).

  It works pretty well in the end and even allow us to define a new kind
  of type error should there be a cyclic definition.

<img width="441" alt="Screenshot 2022-12-20 at 23 16 12" src="https://user-images.githubusercontent.com/5680256/208779124-8f7fa541-6e9e-453d-95a6-aea5d119a110.png">
