### PR TITLE
All function args are now labeled implicitly

### DIFF
--- a/crates/aiken-lang/src/format.rs
+++ b/crates/aiken-lang/src/format.rs
@@ -1585,7 +1585,11 @@ impl<'a> Documentable<'a> for &'a ArgName {
             ArgName::Named { name, .. } | ArgName::Discard { name, .. } => name.to_doc(),
             ArgName::LabeledDiscard { label, name, .. }
             | ArgName::NamedLabeled { label, name, .. } => {
-                docvec![label, " ", name]
+                if label == name {
+                    name.to_doc()
+                } else {
+                    docvec![label, " ", name]
+                }
             }
         }
     }

--- a/crates/aiken-lang/src/parser.rs
+++ b/crates/aiken-lang/src/parser.rs
@@ -514,9 +514,12 @@ pub fn fn_param_parser() -> impl Parser<Token, ast::UntypedArg, Error = ParseErr
                 name,
                 location: span,
             }),
-        select! {Token::Name {name} => name}.map_with_span(|name, span| ast::ArgName::Named {
-            name,
-            location: span,
+        select! {Token::Name {name} => name}.map_with_span(|name, span| {
+            ast::ArgName::NamedLabeled {
+                label: name.clone(),
+                name,
+                location: span,
+            }
         }),
     ))
     .then(just(Token::Colon).ignore_then(type_parser()).or_not())

--- a/crates/aiken-lang/src/tests/parser.rs
+++ b/crates/aiken-lang/src/tests/parser.rs
@@ -320,7 +320,8 @@ fn plus_binop() {
         code,
         ast::UntypedDefinition::Fn(Function {
             arguments: vec![ast::Arg {
-                arg_name: ast::ArgName::Named {
+                arg_name: ast::ArgName::NamedLabeled {
+                    label: "a".to_string(),
                     name: "a".to_string(),
                     location: Span::new((), 15..16),
                 },
@@ -537,7 +538,8 @@ fn let_bindings() {
         code,
         ast::UntypedDefinition::Fn(Function {
             arguments: vec![ast::Arg {
-                arg_name: ast::ArgName::Named {
+                arg_name: ast::ArgName::NamedLabeled {
+                    label: "a".to_string(),
                     name: "a".to_string(),
                     location: Span::new((), 11..12),
                 },
@@ -661,7 +663,8 @@ fn block() {
         code,
         ast::UntypedDefinition::Fn(Function {
             arguments: vec![ast::Arg {
-                arg_name: ast::ArgName::Named {
+                arg_name: ast::ArgName::NamedLabeled {
+                    label: "a".to_string(),
                     name: "a".to_string(),
                     location: Span::new((), 12..13),
                 },
@@ -754,7 +757,8 @@ fn when() {
         code,
         ast::UntypedDefinition::Fn(Function {
             arguments: vec![ast::Arg {
-                arg_name: ast::ArgName::Named {
+                arg_name: ast::ArgName::NamedLabeled {
+                    label: "a".to_string(),
                     name: "a".to_string(),
                     location: Span::new((), 12..13),
                 },
@@ -982,7 +986,8 @@ fn field_access() {
         code,
         ast::UntypedDefinition::Fn(Function {
             arguments: vec![ast::Arg {
-                arg_name: ast::ArgName::Named {
+                arg_name: ast::ArgName::NamedLabeled {
+                    label: "user".to_string(),
                     name: "user".to_string(),
                     location: Span::new((), 8..12),
                 },
@@ -1186,7 +1191,8 @@ fn record_update() {
         ast::UntypedDefinition::Fn(Function {
             arguments: vec![
                 ast::Arg {
-                    arg_name: ast::ArgName::Named {
+                    arg_name: ast::ArgName::NamedLabeled {
+                        label: "user".to_string(),
                         name: "user".to_string(),
                         location: Span::new((), 15..19),
                     },
@@ -1200,7 +1206,8 @@ fn record_update() {
                     tipo: (),
                 },
                 ast::Arg {
-                    arg_name: ast::ArgName::Named {
+                    arg_name: ast::ArgName::NamedLabeled {
+                        label: "name".to_string(),
                         name: "name".to_string(),
                         location: Span::new((), 27..31),
                     },

--- a/examples/sample/validators/swap.ak
+++ b/examples/sample/validators/swap.ak
@@ -3,21 +3,22 @@ use aiken/string
 use aiken/hash.{Blake2b_224, Hash}
 use aiken/transaction.{ScriptContext}
 use aiken/transaction/credential.{VerificationKey}
- 
+
 pub type Datum {
   owner: Hash<Blake2b_224, VerificationKey>,
 }
- 
+
 pub type Redeemer {
   msg: ByteArray,
 }
- 
+
 pub fn spend(datum: Datum, redeemer: Redeemer, context: ScriptContext) -> Bool {
   let must_say_hello = string.from_bytearray(redeemer.msg) == "Hello, World!"
+
   let must_be_signed =
     context.transaction.extra_signatories
     |> list.any(fn(vk) { vk == datum.owner })
- 
+
   must_say_hello && must_be_signed
 }
 


### PR DESCRIPTION
Implicitly parse function params are `NamedLabeled`

closes #205 