### PR TITLE
Better type check errors

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -80,6 +80,7 @@ dependencies = [
  "itertools",
  "miette",
  "ordinal",
+ "owo-colors",
  "pretty_assertions",
  "strum",
  "thiserror",

--- a/crates/aiken-lang/Cargo.toml
+++ b/crates/aiken-lang/Cargo.toml
@@ -13,9 +13,11 @@ authors = ["Lucas Rosa <x@rvcas.dev>", "Kasey White <kwhitemsg@gmail.com>"]
 [dependencies]
 chumsky = "0.8.0"
 indexmap = "1.9.1"
+indoc = "1.0.7"
 itertools = "0.10.5"
 miette = "5.2.0"
 ordinal = "0.3.2"
+owo-colors = "3.5.0"
 strum = "0.24.1"
 thiserror = "1.0.37"
 uplc = { path = '../uplc', version = "0.0.25" }

--- a/crates/aiken-lang/src/format.rs
+++ b/crates/aiken-lang/src/format.rs
@@ -796,7 +796,7 @@ impl<'comments> Formatter<'comments> {
         }
     }
 
-    fn pattern_constructor<'a>(
+    pub fn pattern_constructor<'a>(
         &mut self,
         name: &'a str,
         args: &'a [CallArg<UntypedPattern>],
@@ -1478,7 +1478,7 @@ impl<'comments> Formatter<'comments> {
         list(elements_document, elements.len(), tail)
     }
 
-    fn pattern<'a>(&mut self, pattern: &'a UntypedPattern) -> Document<'a> {
+    pub fn pattern<'a>(&mut self, pattern: &'a UntypedPattern) -> Document<'a> {
         let comments = self.pop_comments(pattern.location().start);
         let doc = match pattern {
             Pattern::Int { value, .. } => value.to_doc(),

--- a/crates/aiken-lang/src/format.rs
+++ b/crates/aiken-lang/src/format.rs
@@ -488,7 +488,7 @@ impl<'comments> Formatter<'comments> {
         .group()
     }
 
-    fn type_arguments<'a>(&mut self, args: &'a [Annotation]) -> Document<'a> {
+    pub fn type_arguments<'a>(&mut self, args: &'a [Annotation]) -> Document<'a> {
         wrap_generics(args.iter().map(|t| self.annotation(t)))
     }
 

--- a/crates/aiken-lang/src/levenshtein.rs
+++ b/crates/aiken-lang/src/levenshtein.rs
@@ -1,0 +1,42 @@
+use std::cmp;
+
+/// Calculate Levenshtein distance for two UTF-8 encoded strings.
+///
+/// Returns a minimum number of edits to transform from source to target string.
+///
+/// Levenshtein distance accepts three edit operations: insertion, deletion,
+/// and substitution.
+///
+/// References:
+///
+/// - [Levenshtein distance in Cargo][1]
+/// - [Ilia Schelokov: Optimizing loop heavy Rust code][2]
+///
+/// [1]: https://github.com/rust-lang/cargo/blob/7d7fe6797ad07f313706380d251796702272b150/src/cargo/util/lev_distance.rs
+/// [2]: https://thaumant.me/optimizing-loop-heavy-rust/
+pub fn distance(source: &str, target: &str) -> usize {
+    if source.is_empty() {
+        return target.len();
+    }
+    if target.is_empty() {
+        return source.len();
+    }
+
+    let mut distances = (0..=target.chars().count()).collect::<Vec<_>>();
+
+    for (i, ch1) in source.chars().enumerate() {
+        let mut sub = i;
+        distances[0] = sub + 1;
+        for (j, ch2) in target.chars().enumerate() {
+            let dist = cmp::min(
+                cmp::min(distances[j], distances[j + 1]) + 1,
+                sub + (ch1 != ch2) as usize,
+            );
+
+            sub = distances[j + 1];
+            distances[j + 1] = dist;
+        }
+    }
+
+    *distances.last().unwrap()
+}

--- a/crates/aiken-lang/src/lib.rs
+++ b/crates/aiken-lang/src/lib.rs
@@ -9,6 +9,7 @@ pub mod builder;
 pub mod builtins;
 pub mod expr;
 pub mod format;
+pub mod levenshtein;
 pub mod parser;
 pub mod pretty;
 pub mod tipo;

--- a/crates/aiken-lang/src/parser/error.rs
+++ b/crates/aiken-lang/src/parser/error.rs
@@ -80,21 +80,12 @@ impl<T: Into<Pattern>> chumsky::Error<T> for ParseError {
 
 #[derive(Debug, PartialEq, Eq, Diagnostic, thiserror::Error)]
 pub enum ErrorKind {
-    #[error("Unexpected end")]
+    #[error("I arrived at the end of the file unexpectedly.")]
     UnexpectedEnd,
     #[error("{0}")]
     #[diagnostic(help("{}", .0.help().unwrap_or_else(|| Box::new(""))))]
     Unexpected(Pattern),
-    #[error("Unclosed {start}")]
-    Unclosed {
-        start: Pattern,
-        #[label]
-        before_span: Span,
-        before: Option<Pattern>,
-    },
-    #[error("No end branch")]
-    NoEndBranch,
-    #[error("Invalid tuple index")]
+    #[error("I discovered an invalid tuple index.")]
     #[diagnostic()]
     InvalidTupleIndex {
         #[help]
@@ -104,39 +95,39 @@ pub enum ErrorKind {
 
 #[derive(Debug, PartialEq, Eq, Hash, Diagnostic, thiserror::Error)]
 pub enum Pattern {
-    #[error("Unexpected {0:?}")]
-    #[diagnostic(help("Try removing it"))]
+    #[error("I found an unexpected char '{0:?}'.")]
+    #[diagnostic(help("Try removing it!"))]
     Char(char),
-    #[error("Unexpected {0}")]
-    #[diagnostic(help("Try removing it"))]
+    #[error("I found an unexpected token '{0}'.")]
+    #[diagnostic(help("Try removing it!"))]
     Token(Token),
-    #[error("Unexpected literal")]
-    #[diagnostic(help("Try removing it"))]
+    #[error("I found an unexpected literal value.")]
+    #[diagnostic(help("Try removing it!"))]
     Literal,
-    #[error("Unexpected type name")]
-    #[diagnostic(help("Try removing it"))]
+    #[error("I found an unexpected type name.")]
+    #[diagnostic(help("Try removing it!"))]
     TypeIdent,
-    #[error("Unexpected indentifier")]
-    #[diagnostic(help("Try removing it"))]
+    #[error("I found an unexpected indentifier.")]
+    #[diagnostic(help("Try removing it!"))]
     TermIdent,
-    #[error("Unexpected end of input")]
+    #[error("I found an unexpected end of input.")]
     End,
-    #[error("Malformed list spread pattern")]
-    #[diagnostic(help("List spread in matches can\nuse have a discard or var"))]
+    #[error("I found a malformed list spread pattern.")]
+    #[diagnostic(help("List spread in matches can use a discard '_' or var."))]
     Match,
-    #[error("Malformed byte literal")]
-    #[diagnostic(help("Bytes must be between 0-255"))]
+    #[error("I found an out-of-bound byte literal.")]
+    #[diagnostic(help("Bytes must be between 0-255."))]
     Byte,
-    #[error("Unexpected pattern")]
+    #[error("I found an unexpected pattern.")]
     #[diagnostic(help(
-        "If no label is provided then only variables\nmatching a field name are allowed"
+        "If no label is provided then only variables\nmatching a field name are allowed."
     ))]
     RecordPunning,
-    #[error("Unexpected label")]
-    #[diagnostic(help("You can only use labels with curly braces"))]
+    #[error("I found an unexpected label.")]
+    #[diagnostic(help("You can only use labels surrounded by curly braces"))]
     Label,
-    #[error("Unexpected hole")]
-    #[diagnostic(help("You can only use capture syntax with functions not constructors"))]
+    #[error("I found an unexpected discard '_'.")]
+    #[diagnostic(help("You can only use capture syntax with functions not constructors."))]
     Discard,
 }
 

--- a/crates/aiken-lang/src/tipo/environment.rs
+++ b/crates/aiken-lang/src/tipo/environment.rs
@@ -315,10 +315,20 @@ impl<'a> Environment<'a> {
         location: Span,
     ) -> Result<&ValueConstructor, Error> {
         match module {
-            None => self.scope.get(name).ok_or_else(|| Error::UnknownVariable {
-                name: name.to_string(),
-                variables: self.local_value_names(),
-                location,
+            None => self.scope.get(name).ok_or_else(|| {
+                if name.chars().into_iter().next().unwrap().is_uppercase() {
+                    Error::UnknownTypeConstructor {
+                        name: name.to_string(),
+                        variables: self.local_value_names(),
+                        location,
+                    }
+                } else {
+                    Error::UnknownVariable {
+                        name: name.to_string(),
+                        variables: self.local_value_names(),
+                        location,
+                    }
+                }
             }),
 
             Some(m) => {

--- a/crates/aiken-lang/src/tipo/environment.rs
+++ b/crates/aiken-lang/src/tipo/environment.rs
@@ -317,19 +317,7 @@ impl<'a> Environment<'a> {
     ) -> Result<&ValueConstructor, Error> {
         match module {
             None => self.scope.get(name).ok_or_else(|| {
-                if name.chars().into_iter().next().unwrap().is_uppercase() {
-                    Error::UnknownTypeConstructor {
-                        name: name.to_string(),
-                        variables: self.local_value_names(),
-                        location,
-                    }
-                } else {
-                    Error::UnknownVariable {
-                        name: name.to_string(),
-                        variables: self.local_value_names(),
-                        location,
-                    }
-                }
+                Error::unknown_variable_or_type(location, name, self.local_value_names())
             }),
 
             Some(m) => {

--- a/crates/aiken-lang/src/tipo/environment.rs
+++ b/crates/aiken-lang/src/tipo/environment.rs
@@ -783,21 +783,13 @@ impl<'a> Environment<'a> {
                         };
                     } else if !value_imported {
                         // Error if no type or value was found with that name
-                        return Err(Error::UnknownModuleField {
-                            location: *location,
-                            name: name.clone(),
-                            module_name: module.join("/"),
-                            value_constructors: module_info
-                                .values
-                                .keys()
-                                .map(|t| t.to_string())
-                                .collect(),
-                            type_constructors: module_info
-                                .types
-                                .keys()
-                                .map(|t| t.to_string())
-                                .collect(),
-                        });
+                        return Err(Error::unknown_module_field(
+                            *location,
+                            name.clone(),
+                            module.join("/"),
+                            module_info.values.keys().map(|t| t.to_string()).collect(),
+                            module_info.types.keys().map(|t| t.to_string()).collect(),
+                        ));
                     }
                 }
 

--- a/crates/aiken-lang/src/tipo/environment.rs
+++ b/crates/aiken-lang/src/tipo/environment.rs
@@ -10,9 +10,10 @@ use crate::{
     ast::{
         Annotation, CallArg, DataType, Definition, Function, ModuleConstant, Pattern,
         RecordConstructor, RecordConstructorArg, Span, TypeAlias, TypedDefinition,
-        UnqualifiedImport, UntypedDefinition, Use, PIPE_VARIABLE,
+        UnqualifiedImport, UntypedDefinition, UntypedPattern, Use, PIPE_VARIABLE,
     },
     builtins::{self, function, generic_var, tuple, unbound_var},
+    format::Formatter,
     tipo::fields::FieldMap,
     IdGenerator,
 };
@@ -1603,12 +1604,53 @@ fn assert_unique_const_name<'a>(
     }
 }
 
+pub(super) fn assert_no_labeled_arguments_in_pattern<'a>(
+    name: &str,
+    args: &[CallArg<UntypedPattern>],
+    module: &'a Option<String>,
+    with_spread: bool,
+) -> Result<(), Error> {
+    for arg in args {
+        if let Some(label) = &arg.label {
+            let fixed_args = args
+                .iter()
+                .map(|arg| CallArg {
+                    label: None,
+                    location: arg.location,
+                    value: arg.value.clone(),
+                })
+                .collect::<Vec<_>>();
+
+            let suggestion = Formatter::new()
+                .pattern_constructor(name, &fixed_args, module, with_spread, false)
+                .to_pretty_string(70);
+
+            let hint = format!(
+                r#"The constructor '{name}' does not have any labeled field. Its fields
+must therefore be matched only by position.
+
+Perhaps, try the following:
+
+╰─▶  {suggestion}"#
+            );
+
+            return Err(Error::UnexpectedLabeledArg {
+                location: arg.location,
+                label: label.to_string(),
+                hint: Some(hint),
+            });
+        }
+    }
+    Ok(())
+}
+
 pub(super) fn assert_no_labeled_arguments<A>(args: &[CallArg<A>]) -> Result<(), Error> {
     for arg in args {
         if let Some(label) = &arg.label {
             return Err(Error::UnexpectedLabeledArg {
                 location: arg.location,
                 label: label.to_string(),
+                hint: None,
             });
         }
     }

--- a/crates/aiken-lang/src/tipo/error.rs
+++ b/crates/aiken-lang/src/tipo/error.rs
@@ -1,216 +1,206 @@
-use std::{collections::HashMap, sync::Arc};
-
-use ordinal::Ordinal;
-
-use miette::Diagnostic;
-
+use super::Type;
 use crate::{
-    ast::{BinOp, CallArg, Span, TodoKind, UntypedPattern},
+    ast::{Annotation, BinOp, CallArg, Span, TodoKind, UntypedPattern},
     format::Formatter,
     levenshtein,
+    pretty::Documentable,
 };
+use indoc::formatdoc;
+use miette::{Diagnostic, LabeledSpan};
+use ordinal::Ordinal;
+use owo_colors::OwoColorize;
+use std::{collections::HashMap, fmt::Display, sync::Arc};
 
-use super::Type;
-
-#[derive(Debug, thiserror::Error, Diagnostic)]
+#[derive(Debug, thiserror::Error)]
 pub enum Error {
-    #[error("Duplicate argument '{label}'\n")]
-    #[diagnostic(help("Try renaming it"))]
-    DuplicateArgument {
-        #[label]
-        location: Span,
-        label: String,
-    },
+    #[error("I found two function arguments both called '{}'.\n", label.purple())]
+    DuplicateArgument { locations: Vec<Span>, label: String },
 
-    #[error("Duplicate const '{name}'\n")]
-    #[diagnostic(help("Try renaming it"))]
+    #[error("I found two top-level constants declared with the same name: '{}'.\n", name.purple())]
     DuplicateConstName {
-        #[label]
         location: Span,
-        #[label]
         previous_location: Span,
         name: String,
     },
 
-    #[error("Duplicate import '{name}'\n")]
-    #[diagnostic(help("Try renaming it"))]
+    #[error("I noticed you were importing '{}' twice.\n", name.purple())]
     DuplicateImport {
-        #[label]
         location: Span,
-        #[label]
         previous_location: Span,
         name: String,
     },
 
-    #[error("Duplicate field '{label}'\n")]
-    #[diagnostic(help("Try renaming it"))]
-    DuplicateField {
-        #[label]
-        location: Span,
-        label: String,
-    },
+    #[error("I stumbled upon the field '{}' twice in a data-type definition.\n", label.purple())]
+    DuplicateField { locations: Vec<Span>, label: String },
 
-    #[error("Duplicate name '{name}'\n")]
-    #[diagnostic(help("Try renaming it"))]
+    #[error("I discovered two top-level objects referred to as '{}'.\n", name.purple())]
     DuplicateName {
-        #[label]
         location: Span,
-        #[label]
         previous_location: Span,
         name: String,
     },
 
-    #[error("Duplicate type name '{name}'\n")]
-    #[diagnostic(help("Try renaming it"))]
+    #[error("I found two types declared with the same name: '{}'.\n", name.purple())]
     DuplicateTypeName {
-        #[label]
         location: Span,
-        #[label]
         previous_location: Span,
         name: String,
     },
 
-    #[error("Incorrect arity\n\nExpected\n\n    {expected}\n\nGiven\n\n    {given}\n")]
-    IncorrectArity {
-        #[label]
+    #[error("I saw a {} fields in a context where there should be {}.\n", given.purple(), expected.purple())]
+    IncorrectFieldsArity {
         location: Span,
         expected: usize,
         given: usize,
         labels: Vec<String>,
     },
 
-    #[error("Incorrect number of clause patterns\n\nExpected\n\n{expected}\n\nGiven\n\n{given}\n")]
-    IncorrectNumClausePatterns {
-        #[label]
+    #[error("I saw a function or constructor that expects {} arguments be called with {} arguments.\n", expected.purple(), given.purple())]
+    IncorrectFunctionCallArity {
         location: Span,
         expected: usize,
         given: usize,
     },
 
-    #[error("Incorrect type arity for `{name}`\n\nExpected\n\n{expected}\n\nGiven\n\n{given}\n")]
+    #[error("I saw a pattern on a constructor that has {} fields be matched with {} arguments.\n", expected.purple(), given.len().purple())]
+    IncorrectPatternArity {
+        location: Span,
+        expected: usize,
+        given: Vec<CallArg<UntypedPattern>>,
+        name: String,
+        module: Option<String>,
+        is_record: bool,
+    },
+
+    // TODO: Since we do not actually support patterns on multiple items, we won't likely ever
+    // encounter that error. We could simplify a bit the type-checker and get rid of that error
+    // eventually.
+    #[error("I counted {} different clauses in a multi-pattern instead of {}.\n", given.purple(), expected.purple())]
+    IncorrectNumClausePatterns {
+        location: Span,
+        expected: usize,
+        given: usize,
+    },
+
+    #[error("I saw a pattern on a {}-tuple be matched into a {}-tuple.\n", expected.purple(), given.purple())]
+    IncorrectTupleArity {
+        location: Span,
+        expected: usize,
+        given: usize,
+    },
+
+    #[error("I noticed a generic data-type with {} type parameters instead of {}.\n", given.purple(), expected.purple())]
     IncorrectTypeArity {
-        #[label]
         location: Span,
         name: String,
         expected: usize,
         given: usize,
     },
 
-    #[error("Non-exhaustive pattern match\n")]
+    #[error("I realized that a given 'when clause' is non-exhaustive.\n")]
     NotExhaustivePatternMatch {
-        #[label]
         location: Span,
         unmatched: Vec<String>,
     },
 
-    #[error("Not a function\n")]
-    NotFn {
-        #[label]
-        location: Span,
-        tipo: Arc<Type>,
-    },
+    #[error("I tripped over a call attempt on something that isn't a function.\n")]
+    NotFn { location: Span, tipo: Arc<Type> },
 
-    #[error("Module '{name}' contains the keyword '{keyword}', which is forbidden\n")]
+    #[error(
+      "I realized the module '{}' contains the keyword '{}', which is forbidden.\n",
+      name.purple(),
+      keyword.purple()
+    )]
     KeywordInModuleName { name: String, keyword: String },
 
-    #[error("Clause guard '{name}' is not local\n")]
-    NonLocalClauseGuardVariable {
-        #[label]
-        location: Span,
-        name: String,
-    },
+    #[error("I stumble upon an invalid (non-local) clause guard '{}'.\n", name.purple())]
+    NonLocalClauseGuardVariable { location: Span, name: String },
 
-    #[error("Positional argument after labeled\n")]
+    #[error("I discovered a positional argument after a label argument.\n")]
     PositionalArgumentAfterLabeled {
-        #[label]
         location: Span,
+        labeled_arg_location: Span,
     },
 
-    #[error("Private type leaked\n")]
-    PrivateTypeLeak {
-        #[label]
-        location: Span,
-        leaked: Type,
-    },
+    #[error("I caught a private value trying to escape.\n")]
+    PrivateTypeLeak { location: Span, leaked: Type },
 
-    #[error("Record access unknown type\n")]
-    RecordAccessUnknownType {
-        #[label]
-        location: Span,
-    },
+    #[error("I couldn't figure out the type of a record you're trying to access.\n")]
+    RecordAccessUnknownType { location: Span },
 
-    #[error("Record update invalid constructor\n")]
-    RecordUpdateInvalidConstructor {
-        #[label]
-        location: Span,
-    },
+    #[error("I tripped over an invalid constructor in a record update.\n")]
+    RecordUpdateInvalidConstructor { location: Span },
 
-    #[error("{name} is a reserved module name\n")]
+    #[error("I realized you used '{}' as a module name, which is reserved (and not available).\n", name.purple())]
     ReservedModuleName { name: String },
 
-    #[error("Unexpected labeled argument '{label}'\n")]
-    #[diagnostic()]
-    UnexpectedLabeledArg {
-        #[label]
+    #[error("I tripped over the following labeled argument: {}.\n", label.purple())]
+    UnexpectedLabeledArg { location: Span, label: String },
+
+    #[error("I tripped over the following labeled argument: {}.\n", label.purple())]
+    UnexpectedLabeledArgInPattern {
         location: Span,
         label: String,
-        #[help]
-        hint: Option<String>,
+        name: String,
+        args: Vec<CallArg<UntypedPattern>>,
+        module: Option<String>,
+        with_spread: bool,
     },
 
-    #[error("Unexpected type hole\n")]
-    UnexpectedTypeHole {
-        #[label]
-        location: Span,
-    },
+    // TODO: Seems like we can't really trigger this error because we allow type holes everywhere
+    // anyway. We need to revise that perhaps.
+    #[error("I stumbled upon an unexpected type hole.\n")]
+    UnexpectedTypeHole { location: Span },
 
-    #[error("Unknown labels\n")]
+    #[error("I tripped over some unknown labels in a pattern or function.\n")]
     UnknownLabels {
         unknown: Vec<(String, Span)>,
         valid: Vec<String>,
         supplied: Vec<String>,
     },
 
-    #[error("Unknown module '{name}'\n")]
+    #[error("I stumble upon a reference to an unknown module: '{}'\n", name.purple())]
     UnknownModule {
-        #[label]
         location: Span,
         name: String,
         imported_modules: Vec<String>,
     },
 
-    #[error("Unknown import '{name}' from module '{module_name}'\n")]
-    #[diagnostic()]
+    #[error(
+        "I found an unknown import '{}' from module '{}'\n",
+        name.purple(),
+        module_name.purple()
+    )]
     UnknownModuleField {
-        #[label]
         location: Span,
         name: String,
         module_name: String,
-        #[help]
-        hint: Option<String>,
+        value_constructors: Vec<String>,
+        type_constructors: Vec<String>,
     },
 
-    #[error("Unknown module value '{name}'\n")]
+    #[error("I tried to find '{}' in '{}' but didn't.\n", name.purple(), module_name.purple())]
     UnknownModuleValue {
-        #[label]
         location: Span,
         name: String,
         module_name: String,
         value_constructors: Vec<String>,
     },
 
-    #[error("Unknown type '{name}' in module '{module_name}'\n")]
+    #[error("I tried to find '{}' in '{}' but didn't.\n", name.purple(), module_name.purple())]
     UnknownModuleType {
-        #[label]
         location: Span,
         name: String,
         module_name: String,
         type_constructors: Vec<String>,
     },
 
-    #[error("Unknown record field\n\n{label}\n")]
+    #[error(
+      "I tried to find the field '{}' in a record of type '{}' but didn't.\n",
+      label.purple(),
+      typ.to_pretty(4).purple()
+    )]
     UnknownRecordField {
-        #[label]
         location: Span,
         typ: Arc<Type>,
         label: String,
@@ -218,54 +208,35 @@ pub enum Error {
         situation: Option<UnknownRecordFieldSituation>,
     },
 
-    #[error("Unknown type '{name}'\n")]
+    #[error("I found a reference to an unknown type: '{}'.\n", name.purple())]
     UnknownType {
-        #[label]
         location: Span,
         name: String,
         types: Vec<String>,
     },
 
-    #[error("Unknown variable '{name}'\n")]
-    #[diagnostic()]
+    #[error("I found a reference to an unknown variable: '{}'.\n", name.purple())]
     UnknownVariable {
-        #[label]
         location: Span,
         name: String,
-        #[help]
-        hint: String,
+        variables: Vec<String>,
     },
 
-    #[error("Unknown data-type constructor '{name}'\n")]
-    #[diagnostic()]
+    #[error("I found a reference to an unknown data-type constructor: '{}'.\n", name.purple())]
     UnknownTypeConstructor {
-        #[label]
         location: Span,
         name: String,
-        #[help]
-        hint: String,
+        constructors: Vec<String>,
     },
 
-    #[error("Unnecessary spread operator\n")]
-    UnnecessarySpreadOperator {
-        #[label]
-        location: Span,
-        arity: usize,
-    },
+    #[error("I discovered a redundant spread operator.\n")]
+    UnnecessarySpreadOperator { location: Span, arity: usize },
 
-    #[error("Cannot update a type with multiple constructors\n")]
-    UpdateMultiConstructorType {
-        #[label]
-        location: Span,
-    },
+    #[error("I tripped over a record-update on a data-type with more than one constructor.\n")]
+    UpdateMultiConstructorType { location: Span },
 
-    #[error(
-        "Type Mismatch\n\nExpected type:\n\n{}\n\nFound type:\n\n{}\n",
-        expected.to_pretty_with_names(rigid_type_names.clone(), 4),
-        given.to_pretty_with_names(rigid_type_names.clone(), 4)
-    )]
+    #[error("I struggled to unify the types of two expressions.\n")]
     CouldNotUnify {
-        #[label]
         location: Span,
         expected: Arc<Type>,
         given: Arc<Type>,
@@ -273,49 +244,32 @@ pub enum Error {
         rigid_type_names: HashMap<u64, String>,
     },
 
-    #[error("")]
-    ExtraVarInAlternativePattern {
-        #[label]
-        location: Span,
-        name: String,
-    },
+    #[error("I tripped over an extra variable in an alternative pattern: {}.\n", name.purple())]
+    ExtraVarInAlternativePattern { location: Span, name: String },
 
-    #[error("")]
-    MissingVarInAlternativePattern {
-        #[label]
-        location: Span,
-        name: String,
-    },
+    #[error("I found a missing variable in an alternative pattern: {}.\n", name.purple())]
+    MissingVarInAlternativePattern { location: Span, name: String },
 
-    #[error("")]
-    DuplicateVarInPattern {
-        #[label]
-        location: Span,
-        name: String,
-    },
+    #[error("I realized the variable '{}' was mentioned more than once in an alternative pattern.\n ", name.purple())]
+    DuplicateVarInPattern { location: Span, name: String },
 
-    #[error("Cyclic type definition detected: {}\n", types.join(" -> "))]
-    CyclicTypeDefinitions {
-        #[label]
-        location: Span,
-        types: Vec<String>,
-    },
+    #[error("I almost got caught in an infinite cycle of type definitions: {}.\n", types.join(" -> "))]
+    CyclicTypeDefinitions { location: Span, types: Vec<String> },
 
-    #[error("Recursive type detected\n")]
-    RecursiveType {
-        #[label]
-        location: Span,
-    },
+    #[error("I almost got caught in an endless loop while inferring a recursive type.\n")]
+    RecursiveType { location: Span },
 
-    #[error("Trying to access tuple elements on something else than a tuple\n")]
-    NotATuple {
-        #[label]
-        location: Span,
-    },
+    #[error(
+        "I tripped over an attempt to access tuple elements on something else than a tuple.\n"
+    )]
+    NotATuple { location: Span, tipo: Arc<Type> },
 
-    #[error("Trying to access the {} element of a {}-tuple\n", Ordinal(*index + 1).to_string(), size)]
+    #[error(
+        "I discovered an attempt to access the {} element of a {}-tuple.\n",
+        Ordinal(*index + 1).to_string().purple(),
+        size.purple()
+    )]
     TupleIndexOutOfBound {
-        #[label]
         location: Span,
         index: usize,
         size: usize,
@@ -354,14 +308,6 @@ impl Error {
             },
             other => other,
         }
-    }
-
-    pub fn inconsistent_try(self, return_value_is_result: bool) -> Self {
-        self.with_unify_error_situation(if return_value_is_result {
-            UnifyErrorSituation::TryErrorMismatch
-        } else {
-            UnifyErrorSituation::TryReturnResult
-        })
     }
 
     pub fn operator_situation(self, binop: BinOp) -> Self {
@@ -403,136 +349,916 @@ impl Error {
             other => other,
         }
     }
+}
 
-    pub fn unknown_module_field(
-        location: Span,
-        name: String,
-        module_name: String,
-        value_constructors: Vec<String>,
-        type_constructors: Vec<String>,
-    ) -> Self {
-        let mut candidates = vec![];
-        candidates.extend(value_constructors);
-        candidates.extend(type_constructors);
+impl Diagnostic for Error {
+    fn severity(&self) -> Option<miette::Severity> {
+        Some(miette::Severity::Error)
+    }
 
-        let hint = candidates
-            .iter()
-            .map(|s| (s, levenshtein::distance(&name, s)))
-            .min_by(|(_, a), (_, b)| a.cmp(b))
-            .and_then(|(suggestion, distance)| {
-                if distance <= 5 {
-                    Some(format!("Did you mean to import '{suggestion}'?"))
-                } else {
-                    None
-                }
-            });
-
-        Self::UnknownModuleField {
-            location,
-            name,
-            module_name,
-            hint,
+    // Unique diagnostic code that can be used to look up more information about this Diagnostic. Ideally also globally unique, and documented in the toplevel crate’s documentation for easy searching. Rust path format (foo::bar::baz) is recommended, but more classic codes like E0123 or enums will work just fine.
+    fn code<'a>(&'a self) -> Option<Box<dyn Display + 'a>> {
+        match self {
+            Self::DuplicateArgument { .. } => Some(Box::new("duplicate_argument")),
+            Self::DuplicateConstName { .. } => Some(Box::new("duplicate_const_name")),
+            Self::DuplicateImport { .. } => Some(Box::new("duplicate_import")),
+            Self::DuplicateField { .. } => Some(Box::new("duplicate_field")),
+            Self::DuplicateName { .. } => Some(Box::new("duplicate_name")),
+            Self::DuplicateTypeName { .. } => Some(Box::new("duplicate_type_name")),
+            Self::IncorrectFieldsArity { .. } => Some(Box::new("incorrect_fields_arity")),
+            Self::IncorrectFunctionCallArity { .. } => Some(Box::new("incorrect_fn_arity")),
+            Self::IncorrectPatternArity { .. } => Some(Box::new("incorrect_pattern_arity")),
+            Self::IncorrectNumClausePatterns { .. } => {
+                Some(Box::new("incorrect_num_clause_patterns"))
+            }
+            Self::IncorrectTupleArity { .. } => Some(Box::new("incorrect_tuple_arity")),
+            Self::IncorrectTypeArity { .. } => Some(Box::new("incorrect_type_arity")),
+            Self::NotExhaustivePatternMatch { .. } => {
+                Some(Box::new("non_exhaustive_pattern_match"))
+            }
+            Self::NotFn { .. } => Some(Box::new("not_fn")),
+            Self::KeywordInModuleName { .. } => Some(Box::new("keyword_in_module_name")),
+            Self::NonLocalClauseGuardVariable { .. } => {
+                Some(Box::new("non_local_clause_guard_variable"))
+            }
+            Self::PositionalArgumentAfterLabeled { .. } => {
+                Some(Box::new("positional_argument_after_labeled"))
+            }
+            Self::PrivateTypeLeak { .. } => Some(Box::new("private_type_leak")),
+            Self::RecordAccessUnknownType { .. } => Some(Box::new("record_access_unknown_type")),
+            Self::RecordUpdateInvalidConstructor { .. } => {
+                Some(Box::new("record_update_invalid_constructor"))
+            }
+            Self::ReservedModuleName { .. } => Some(Box::new("reserved_module_name")),
+            Self::UnexpectedLabeledArg { .. } => Some(Box::new("unexpected_labeled_arg")),
+            Self::UnexpectedLabeledArgInPattern { .. } => {
+                Some(Box::new("unexpected_labeled_arg_in_pattern"))
+            }
+            Self::UnexpectedTypeHole { .. } => Some(Box::new("unexpected_type_hole")),
+            Self::UnknownLabels { .. } => Some(Box::new("unknown_labels")),
+            Self::UnknownModule { .. } => Some(Box::new("unknown_module")),
+            Self::UnknownModuleField { .. } => Some(Box::new("unknown_module_field")),
+            Self::UnknownModuleValue { .. } => Some(Box::new("unknown_module_value")),
+            Self::UnknownModuleType { .. } => Some(Box::new("unknown_module_type")),
+            Self::UnknownRecordField { .. } => Some(Box::new("unknown_record_field")),
+            Self::UnknownType { .. } => Some(Box::new("unknown_type")),
+            Self::UnknownVariable { .. } => Some(Box::new("unknown_variable")),
+            Self::UnknownTypeConstructor { .. } => Some(Box::new("unknown_type_constructor")),
+            Self::UnnecessarySpreadOperator { .. } => Some(Box::new("unnecessary_spread_operator")),
+            Self::UpdateMultiConstructorType { .. } => {
+                Some(Box::new("update_multi_constructor_type"))
+            }
+            Self::CouldNotUnify { .. } => Some(Box::new("could_not_unify")),
+            Self::ExtraVarInAlternativePattern { .. } => {
+                Some(Box::new("extra_var_in_alternative_pattern"))
+            }
+            Self::MissingVarInAlternativePattern { .. } => {
+                Some(Box::new("missing_var_in_alternative_pattern"))
+            }
+            Self::DuplicateVarInPattern { .. } => Some(Box::new("duplicate_var_in_pattern")),
+            Self::CyclicTypeDefinitions { .. } => Some(Box::new("cyclic_type_definitions")),
+            Self::RecursiveType { .. } => Some(Box::new("recursive_type")),
+            Self::NotATuple { .. } => Some(Box::new("not_a_tuple")),
+            Self::TupleIndexOutOfBound { .. } => Some(Box::new("tuple_index_out_of_bound")),
         }
     }
 
-    pub fn unknown_variable_or_type(location: Span, name: &str, variables: Vec<String>) -> Self {
-        let hint = variables
-            .iter()
-            .map(|s| (s, levenshtein::distance(name, s)))
-            .min_by(|(_, a), (_, b)| a.cmp(b))
-            .and_then(|(suggestion, distance)| {
-                if distance <= 3 {
-                    Some(format!("Did you mean '{suggestion}'?"))
+    // Additional help text related to this Diagnostic. Do you have any advice for the poor soul who’s just run into this issue?
+    fn help<'a>(&'a self) -> Option<Box<dyn Display + 'a>> {
+        match self {
+            Self::DuplicateArgument { .. } => {
+                // TODO: Suggest names based on types when the duplicate argument is `_`
+                Some(Box::new(formatdoc! {
+                    r#"Function arguments cannot have the same name. You can use '_' and
+                       numbers to distinguish between similar names.
+                    "#
+                }))
+            },
+
+            Self::DuplicateConstName { .. } => Some(Box::new(formatdoc! {
+                r#"Top-level constants of a same module cannot have the same name.
+                   You can use '_' and numbers to distinguish between similar names.
+                "#
+            })),
+
+            Self::DuplicateImport { .. } => Some(Box::new(formatdoc! {
+                r#"The best thing to do from here is to remove one of them.
+                "#
+            })),
+
+            Self::DuplicateField { .. } => Some(Box::new(formatdoc! {
+                r#"Data-types must have fields with strictly different names. You can
+                   use '_' and numbers to distinguish between similar names.
+
+                   Note that it is also possible to declare data-types with positional
+                   (nameless) fields only. For example:
+
+                     ┍━━━━━━━━━━━━━━━━━━━━━━━
+                     │ pub type Point {{
+                     │   Point(Int, Int, Int)
+                     │ }}
+                "#
+            })),
+
+            Self::DuplicateName { .. } => Some(Box::new(formatdoc! {
+                r#"Top-level definitions cannot have the same name, even if they
+                   refer to objects with different natures (e.g. function and test).
+
+                   You can use '_' and numbers to distinguish between similar names.
+                "#
+            })),
+
+            Self::DuplicateTypeName { .. } => Some(Box::new(formatdoc! {
+                r#"Types cannot have the same top-level name. You {} use '_' in
+                   types name, but you can use numbers to distinguish between similar
+                   names.
+                "#, "cannot".red()
+            })),
+
+            Self::IncorrectFieldsArity { .. } => None,
+
+            Self::IncorrectFunctionCallArity { expected, .. } => Some(Box::new(formatdoc! {
+                r#"Functions (and constructors) must always be called with all their
+                   arguments (comma-separated, between brackets).
+
+                   Here, the function or constructor needs {} arguments.
+
+                   Note that Aiken supports argument capturing using '_' as placeholder
+                   for arguments that aren't yet defined. This is like currying in some
+                   other languages.
+
+                   For example, imagine the following function:
+
+                     ┍━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+                     │ fn add(x :Int, y: Int) -> Int
+
+                   From there, you can define 'increment', a function that takes a
+                   single argument and adds one to it, as such:
+
+                     ┍━━━━━━━━━━━━━━━━━━━━━━━━━━
+                     │ let increment = add(1, _)
+                "#,
+                expected.purple()
+            })),
+
+            Self::IncorrectPatternArity {
+                name,
+                given,
+                expected,
+                module,
+                is_record,
+                ..
+            } => {
+                let pattern = Formatter::new()
+                    .pattern_constructor(name, given, module, true, *is_record)
+                    .to_pretty_string(70);
+
+                let suggestion = if expected > &given.len() {
+                    formatdoc! {
+                        r#" Perhaps, try the following:
+
+                            ╰─▶  {pattern}
+                        "#
+                    }
                 } else {
-                    None
+                    String::new()
+                };
+
+                Some(Box::new(formatdoc! {
+                    r#"When pattern-matching on constructors, you must either match the
+                       exact number of fields, or use the spread operator. Note that unused
+                       fields must be discarded by prefixing their name with '_'.{suggestion}
+                    "#
+                }))
+            },
+
+            Self::IncorrectNumClausePatterns { .. } => None,
+
+            Self::IncorrectTupleArity { .. } => Some(Box::new(formatdoc! {
+                r#"When pattern matching on a tuple, you must match all
+                   of its elements. Note that unused fields must be
+                   discarded by prefixing their name with '_'.
+                "#
+            })),
+
+            Self::IncorrectTypeArity { expected, name, .. } => {
+                let mut args = vec![];
+                for i in 0..*expected {
+                    args.push(Annotation::Var {
+                        name: char::from_u32(97 + i as u32).unwrap_or('?').to_string(),
+                        location: Span::empty(),
+                    });
                 }
-            });
 
-        if name.chars().into_iter().next().unwrap().is_uppercase() {
-            let hint = hint.unwrap_or_else(|| {
-                r#"Did you forget to import it?
+                let suggestion = name
+                    .to_doc()
+                    .append(Formatter::new().type_arguments(&args))
+                    .to_pretty_string(70);
 
-Data-type constructors are not automatically imported, even if their type
-is imported. So, if a module `aiken/pet` defines the following type:
+                Some(Box::new(formatdoc! {
+                    r#"Data-types that are generic in one or more types must be written
+                       with all their generic types in type annotations.
 
- ┍━ aiken/pet.ak ━━━━━━━━
- │ pub type Pet {{
- │   Cat
- │   Dog
- │ }}
+                       Generic types must be indicated between chevrons '<' and '>'.
 
-You must import its constructors explicitly to use them, or prefix them
-with the module's name.
+                       Perhaps, try the following:
 
- ┍━ foo.ak ━━━━━━━━
- │ use aiken/pet.{{Pet, Dog}}
- │
- │ fn foo(pet : Pet) {{
- │   when pet is {{
- │     pet.Cat -> // ...
- │     Dog -> // ...
- │   }}
- │ }}"#
-                    .to_string()
-            });
+                       ╰─▶  {suggestion}
+                    "#
+                }))
+            },
 
-            Self::UnknownTypeConstructor {
-                name: name.to_string(),
-                hint,
-                location,
-            }
-        } else {
-            let hint = hint.unwrap_or_else(|| "Did you forget to import it?".to_string());
+            Self::NotExhaustivePatternMatch { unmatched, .. } => {
+                let missing = unmatched
+                    .iter()
+                    .map(|s| format!("─▶ {s}"))
+                    .collect::<Vec<_>>()
+                    .join("\n");
+
+                Some(Box::new(formatdoc! {
+                    r#"When clauses must be exhaustive -- that is, they must cover all possible
+                       cases of the type they match. While it is recommended to have an explicit
+                       branch for each constructor, you can also use the wildcard '_' as a last
+                       branch to match any remaining result.
+
+                       In this particular instance, the following cases are missing:
+
+                       {missing}
+                    "#
+                }))
+            },
+
+            Self::NotFn { tipo, .. } => {
+                let inference = tipo.to_pretty(4);
+                Some(Box::new(formatdoc! {
+                    r#"It seems like you're trying to call something that isn't a function.
+                       I am inferring the following type:
+
+                       ╰─▶  {inference}
+                    "#
+                }))
+            },
+
+            Self::KeywordInModuleName { .. } => Some(Box::new(formatdoc! {
+                r#"You cannot use keywords as part of a module path name. As a quick
+                   reminder, here's a list of all the keywords (and thus, of invalid
+                   module path names):
+
+                   as, assert, check, const, else, fn, if, is, let, opaque, pub, test,
+                   todo, trace, type, use, when,
+                "#
+            })),
+
+            Self::NonLocalClauseGuardVariable { .. } => Some(Box::new(formatdoc! {
+                r#"There are some conditions regarding what can be used in a guard.
+                   Values must be either local to the function, or defined as module
+                   constants. You can't use functions or records in there.
+                "#
+            })),
+
+            Self::PositionalArgumentAfterLabeled { .. } => Some(Box::new(formatdoc! {
+                r#"You can mix positional and labeled arguments, but you must put all
+                   positional arguments (i.e. without label) at the front.
+
+                   To fix this, you'll need to either turn that argument as a labeled
+                   argument, or make the next one positional.
+                "#
+            })),
+
+            Self::PrivateTypeLeak { leaked, .. } => Some(Box::new(formatdoc! {
+                r#"I found a public value that is making use of a private type.
+                   This would prevent other modules from actually using that value
+                   because they wouldn't know what this type refer to.
+
+                   The culprit is:
+
+                     {type_info}
+
+                   Maybe you meant to turn it public using the 'pub' keyword?
+                "#
+            , type_info = leaked.to_pretty(4) })),
+
+            Self::RecordAccessUnknownType { .. } => Some(Box::new(formatdoc! {
+                r#"I do my best to infer types of any expression; yet sometimes I
+                   need help (don't we all?).
+
+                   Take for example the following expression:
+
+                     ┍━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+                     │ let foo = fn(x) {{ x.transaction }}
+
+                   At this stage, I can't quite figure out whether 'x' has indeed a
+                   field 'transaction', because I don't know what the type of 'x' is.
+                   You can help me by providing a type-annotation for 'x', as such:
+
+                     ┍━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+                     │ let foo = fn(x: ScriptContext) {{ x.transaction }}
+                "#
+            })),
+
+            // TODO: Come back to this one once we support record updates.
+            Self::RecordUpdateInvalidConstructor { .. } => None,
+
+            Self::ReservedModuleName { .. } => Some(Box::new(formatdoc! {
+                r#"Some module names are reserved for internal use. This the case
+                   of:
+
+                   - aiken: where the prelude is located;
+                   - aiken/builtin: where I store low-level Plutus builtins.
+
+                   Note that 'aiken' is also imported by default; but you can refer to
+                   it explicitly to disambiguate with a local value that would clash
+                   with one from that module.
+                "#
+            })),
+
+            Self::UnexpectedLabeledArg { .. } => None,
+
+            Self::UnexpectedLabeledArgInPattern {
+                args,
+                module,
+                name,
+                with_spread,
+                ..
+            } => {
+                let fixed_args = args
+                    .iter()
+                    .map(|arg| CallArg {
+                        label: None,
+                        location: arg.location,
+                        value: arg.value.clone(),
+                    })
+                    .collect::<Vec<_>>();
+
+                let suggestion = Formatter::new()
+                    .pattern_constructor(name, &fixed_args, module, *with_spread, false)
+                    .to_pretty_string(70);
+
+                Some(Box::new(formatdoc! {
+                    r#"The constructor '{name}' does not have any labeled field. Its
+                       fields must therefore be matched only by position.
+
+                       Perhaps, try the following:
+
+                       ╰─▶  {suggestion}
+                    "#
+                }))
+            },
+
+            Self::UnexpectedTypeHole { .. } => None,
+
+            Self::UnknownLabels { valid, .. } => {
+                let known_labels = valid
+                    .iter()
+                    .map(|s| format!("─▶ {s}"))
+                    .collect::<Vec<_>>()
+                    .join("\n");
+                Some(Box::new(formatdoc! {
+                    r#"I don't know some of the labels used in this expression. I've
+                       highlighted them just above.
+
+                       Here's a list of all the (valid) labels that I know of:
+
+                       {known_labels}
+                    "#
+                }))
+            },
+
+            Self::UnknownModule {
+                name,
+                imported_modules,
+                ..
+            } => Some(
+                imported_modules
+                    .iter()
+                    .map(|s| (s, levenshtein::distance(name, s)))
+                    .min_by(|(_, a), (_, b)| a.cmp(b))
+                    .and_then(|(suggestion, distance)| {
+                        if distance <= 4 {
+                            Some(Box::new(format!("Did you mean '{suggestion}'?")))
+                        } else {
+                            None
+                        }
+                    })
+                    .unwrap_or_else(|| Box::new("Did you forget to import it?".to_string())),
+            ),
+
+            Self::UnknownModuleField {
+                name,
+                value_constructors,
+                type_constructors,
+                ..
+            } => {
+                let mut candidates = vec![];
+                candidates.extend(value_constructors);
+                candidates.extend(type_constructors);
+                Some(
+                    candidates
+                        .iter()
+                        .map(|s| (s, levenshtein::distance(name, s)))
+                        .min_by(|(_, a), (_, b)| a.cmp(b))
+                        .and_then(|(suggestion, distance)| {
+                            if distance <= 4 {
+                                Some(Box::new(format!("Did you mean to import '{suggestion}'?")))
+                            } else {
+                                None
+                            }
+                        })
+                        .unwrap_or_else(|| {
+                            Box::new(formatdoc! {
+                                r#"Did you forget to make this value public?
+
+                                   Values from module must be exported using the keyword 'pub' in order to
+                                   be available from other modules.
+
+                                   For example:
+
+                                     ┍━ aiken/foo.ak ━━━━━━━━
+                                     │ fn foo () {{ "foo" }}
+                                     │
+                                     │ pub type Bar {{
+                                     │   Bar
+                                     │ }}
+
+                                   The function 'foo' is private and can't be accessed from outside of the
+                                   'aiken/foo' module. But the data-type 'Bar' is public and available.
+                                "#
+                            })
+                        }),
+                )
+            },
+
+            Self::UnknownModuleValue {
+                name,
+                value_constructors,
+                ..
+            } => Some(
+                value_constructors
+                    .iter()
+                    .map(|s| (s, levenshtein::distance(name, s)))
+                    .min_by(|(_, a), (_, b)| a.cmp(b))
+                    .and_then(|(suggestion, distance)| {
+                        if distance <= 4 {
+                            Some(Box::new(format!("Did you mean '{suggestion}'?")))
+                        } else {
+                            None
+                        }
+                    })
+                    .unwrap_or_else(|| {
+                        Box::new(formatdoc! {
+                            r#"Did you forget to make this value public?
+
+                               Values from module must be exported using the keyword 'pub' in order to
+                               be available from other modules.
+
+                               For example:
+
+                                 ┍━ aiken/foo.ak ━━━━━━━━
+                                 │ fn foo () {{ "foo" }}
+                                 │
+                                 │ pub type Bar {{
+                                 │   Bar
+                                 │ }}
+
+                               The function 'foo' is private and can't be accessed from outside of the
+                               'aiken/foo' module. But the data-type 'Bar' is public and available.
+                            "#
+                        })
+                    }),
+            ),
+
+            Self::UnknownModuleType {
+                name,
+                type_constructors,
+                ..
+            } => Some(
+                type_constructors
+                    .iter()
+                    .map(|s| (s, levenshtein::distance(name, s)))
+                    .min_by(|(_, a), (_, b)| a.cmp(b))
+                    .and_then(|(suggestion, distance)| {
+                        if distance <= 4 {
+                            Some(Box::new(format!("Did you mean '{suggestion}'?")))
+                        } else {
+                            None
+                        }
+                    })
+                    .unwrap_or_else(|| {
+                        Box::new(formatdoc! {
+                            r#"Did you forget to make this value public?
+
+                               Values from module must be exported using the keyword 'pub' in order to
+                               be available from other modules.
+
+                               For example:
+
+                                 ┍━ aiken/foo.ak ━━━━━━━━
+                                 │ fn foo () {{ "foo" }}
+                                 │
+                                 │ pub type Bar {{
+                                 │   Bar
+                                 │ }}
+
+                               The function 'foo' is private and can't be accessed from outside of the
+                               'aiken/foo' module. But the data-type 'Bar' is public and available.
+                            "#
+                        })
+                    })
+            ),
+
+            Self::UnknownRecordField { label, fields, .. } => Some(fields
+                .iter()
+                .map(|s| (s, levenshtein::distance(label, s)))
+                .min_by(|(_, a), (_, b)| a.cmp(b))
+                .and_then(|(suggestion, distance)| {
+                    if distance <= 4 {
+                        Some(Box::new(format!("Did you mean '{suggestion}'?")))
+                    } else {
+                        None
+                    }
+                })
+                .unwrap_or_else(|| Box::new("Did you forget to make the field public?".to_string()))
+            ),
+
+            Self::UnknownType { name, types, .. } => Some(
+                types
+                    .iter()
+                    .map(|s| (s, levenshtein::distance(name, s)))
+                    .min_by(|(_, a), (_, b)| a.cmp(b))
+                    .and_then(|(suggestion, distance)| {
+                        if distance <= 4 {
+                            Some(Box::new(format!("Did you mean '{suggestion}'?")))
+                        } else {
+                            None
+                        }
+                    })
+                    .unwrap_or_else(|| Box::new("Did you forget to import it?".to_string())),
+            ),
+
             Self::UnknownVariable {
-                name: name.to_string(),
-                location,
-                hint,
+                name, variables, ..
+            } => {
+                let hint = variables
+                    .iter()
+                    .map(|s| (s, levenshtein::distance(name, s)))
+                    .min_by(|(_, a), (_, b)| a.cmp(b))
+                    .and_then(|(suggestion, distance)| {
+                        if distance <= 4 {
+                            Some(Box::new(format!("Did you mean '{suggestion}'?")))
+                        } else {
+                            None
+                        }
+                    });
+
+                if name.chars().into_iter().next().unwrap().is_uppercase() {
+                    Some(hint.unwrap_or_else(||
+                        Box::new(formatdoc! {
+                            r#"Did you forget to import it?
+
+                               Data-type constructors are not automatically imported, even if their type
+                               is imported. So, if a module 'aiken/pet' defines the following type:
+
+                                 ┍━ aiken/pet.ak ━━━━━━━━
+                                 │ pub type Pet {{
+                                 │   Cat
+                                 │   Dog
+                                 │ }}
+
+                               You must import its constructors explicitly to use them, or prefix them
+                               with the module's name.
+
+                                 ┍━ foo.ak ━━━━━━━━
+                                 │ use aiken/pet.{{Pet, Dog}}
+                                 │
+                                 │ fn foo(pet : Pet) {{
+                                 │   when pet is {{
+                                 │     pet.Cat -> // ...
+                                 │     Dog -> // ...
+                                 │   }}
+                                 │ }}"
+                            "#
+                        })
+                    ))
+                } else {
+                    Some(hint.unwrap_or_else(|| Box::new("Did you forget to import it?".to_string())))
+                }
             }
+
+            Self::UnknownTypeConstructor { name, constructors, .. } => Some(
+                constructors
+                    .iter()
+                    .map(|s| (s, levenshtein::distance(name, s)))
+                    .min_by(|(_, a), (_, b)| a.cmp(b))
+                    .and_then(|(suggestion, distance)| {
+                        if distance <= 4 {
+                            Some(Box::new(format!("Did you mean '{suggestion}'?")))
+                        } else {
+                            None
+                        }
+                    })
+                    .unwrap_or_else(|| Box::new("Did you forget to import it?".to_string()))
+            ),
+
+            Self::UnnecessarySpreadOperator { arity, .. } => Some(Box::new(formatdoc! {
+                r#"The spread operator comes in handy when matching on some fields of
+                   a constructor. However, here you've matched all {arity} fields of the
+                   constructor which makes the spread operator redundant.
+
+                   The best thing to do from here is to remove it.
+                "# })
+            ),
+
+            // TODO: Come and refine this once we support record updates.
+            Self::UpdateMultiConstructorType {..} => None,
+
+            Self::CouldNotUnify { expected, given, situation, rigid_type_names, .. } => {
+                let expected = expected.to_pretty_with_names(rigid_type_names.clone(), 4);
+                let given = given.to_pretty_with_names(rigid_type_names.clone(), 4);
+                Some(Box::new(
+                    match situation {
+                        Some(UnifyErrorSituation::CaseClauseMismatch) => formatdoc! {
+                            r#"While comparing branches from a 'when/is' expression, I realized
+                               not all branches have the same type.
+
+                               I am expecting all of them to have the following type:
+
+                               {}
+
+                               but I found some with type:
+
+                               {}
+
+                               Note that I infer the type of the entire 'when/is' expression
+                               based on the type of the first branch I encounter.
+                             "#,
+                             expected.green(),
+                             given.red()
+                        },
+                        Some(UnifyErrorSituation::ReturnAnnotationMismatch) => formatdoc! {
+                            r#"While comparing the return annotation of a function with
+                               its actual return type, I realized that both don't match.
+
+                               I am inferring the function should return:
+
+                               {}
+
+                               but I found that it returns:
+
+                               {}
+
+                               Either, fix the annotation or adjust the function body to
+                               return the expected type.
+                             "#,
+                             expected.green(),
+                             given.red()
+                        },
+                        Some(UnifyErrorSituation::PipeTypeMismatch) => formatdoc! {
+                            r#"As I was looking at a pipeline you have defined, I realized
+                               that one of the pipe isn't valid.
+
+                               I am expecting the pipe to send into something of type:
+
+                               {}
+
+                               but it is typed:
+
+                               {}
+
+                               Either, fix the input or change the target so that both match.
+                            "#,
+                            expected.green(),
+                            given.red()
+                        },
+                        Some(UnifyErrorSituation::Operator(op)) => formatdoc! {
+                            r#"While checking operands of a binary operator, I realized
+                               that at least one of them doesn't have the expected type.
+
+                               The '{}' operator expects operands of type:
+
+                               {}
+
+                               but I discovered the following instead:
+
+                               {}
+                            "#,
+                            op.to_doc().to_pretty_string(70),
+                            expected.green(),
+                            given.red()
+                        },
+                        None => formatdoc! {
+                            r#"I am inferring the following type:
+
+                               {}
+
+                               but I found an expression with a different type:
+
+                               {}
+
+                               Either, add type-annotation to improve my inference, or
+                               adjust the expression to have the expected type.
+                            "#,
+                            expected.green(),
+                            given.red()
+                        },
+                    }
+                ))
+            },
+
+            Self::ExtraVarInAlternativePattern { .. } => None,
+
+            Self::MissingVarInAlternativePattern { .. } => None,
+
+            Self::DuplicateVarInPattern { .. } => None,
+
+            Self::CyclicTypeDefinitions { .. } => None,
+
+            Self::RecursiveType { .. } => Some(Box::new(formatdoc! {
+                r#"I have several aptitudes, but inferring recursive types isn't one them.
+                   It is still possible to define recursive types just fine, but I will
+                   need a little help in the form of type annotation to infer their types
+                   should they show up.
+                "#
+            })),
+
+            Self::NotATuple { tipo, .. } => Some(Box::new(formatdoc! {
+                r#"Because you used a tuple-index on an element, I assumed it had to
+                   be a tuple or some kind, but instead I found:
+
+                   {type_info}
+                "#,
+                type_info = tipo.to_pretty(4)
+            })),
+
+            Self::TupleIndexOutOfBound { .. } => None,
         }
     }
 
-    pub fn unexpected_labeled_arg<'a>(location: Span, label: String) -> Self {
-        Self::UnexpectedLabeledArg {
-            location,
-            label,
-            hint: None,
-        }
-    }
-
-    pub fn unexpected_labeled_arg_in_pattern(
-        location: Span,
-        label: String,
-        name: &str,
-        args: &[CallArg<UntypedPattern>],
-        module: &Option<String>,
-        with_spread: bool,
-    ) -> Self {
-        let fixed_args = args
-            .iter()
-            .map(|arg| CallArg {
-                label: None,
-                location: arg.location,
-                value: arg.value.clone(),
-            })
-            .collect::<Vec<_>>();
-
-        let suggestion = Formatter::new()
-            .pattern_constructor(name, &fixed_args, module, with_spread, false)
-            .to_pretty_string(70);
-
-        let hint = format!(
-            r#"The constructor '{name}' does not have any labeled field. Its fields
-must therefore be matched only by position.
-
-Perhaps, try the following:
-
-╰─▶  {suggestion}"#
-        );
-
-        Self::UnexpectedLabeledArg {
-            location,
-            label: label.to_string(),
-            hint: Some(hint),
+    // Labels to apply to this Diagnostic’s Diagnostic::source_code
+    fn labels(&self) -> Option<Box<dyn Iterator<Item = LabeledSpan> + '_>> {
+        match self {
+            Self::DuplicateArgument { locations, .. } => Some(Box::new(
+                locations
+                    .into_iter()
+                    .map(|l| LabeledSpan::new_with_span(None, *l)),
+            )),
+            Self::DuplicateConstName {
+                location,
+                previous_location,
+                ..
+            } => Some(Box::new(
+                vec![
+                    LabeledSpan::new_with_span(None, *location),
+                    LabeledSpan::new_with_span(None, *previous_location),
+                ]
+                .into_iter(),
+            )),
+            Self::DuplicateImport {
+                location,
+                previous_location,
+                ..
+            } => Some(Box::new(
+                vec![
+                    LabeledSpan::new_with_span(None, *location),
+                    LabeledSpan::new_with_span(None, *previous_location),
+                ]
+                .into_iter(),
+            )),
+            Self::DuplicateField { locations, .. } => Some(Box::new(
+                locations
+                    .into_iter()
+                    .map(|l| LabeledSpan::new_with_span(None, *l)),
+            )),
+            Self::DuplicateName {
+                location,
+                previous_location,
+                ..
+            } => Some(Box::new(
+                vec![
+                    LabeledSpan::new_with_span(None, *location),
+                    LabeledSpan::new_with_span(None, *previous_location),
+                ]
+                .into_iter(),
+            )),
+            Self::DuplicateTypeName { location, .. } => Some(Box::new(
+                vec![LabeledSpan::new_with_span(None, *location)].into_iter(),
+            )),
+            Self::IncorrectFieldsArity { location, .. } => Some(Box::new(
+                vec![LabeledSpan::new_with_span(None, *location)].into_iter(),
+            )),
+            Self::IncorrectFunctionCallArity { location, .. } => Some(Box::new(
+                vec![LabeledSpan::new_with_span(None, *location)].into_iter(),
+            )),
+            Self::IncorrectPatternArity { location, .. } => Some(Box::new(
+                vec![LabeledSpan::new_with_span(None, *location)].into_iter(),
+            )),
+            Self::IncorrectNumClausePatterns { location, .. } => Some(Box::new(
+                vec![LabeledSpan::new_with_span(None, *location)].into_iter(),
+            )),
+            Self::IncorrectTupleArity { location, .. } => Some(Box::new(
+                vec![LabeledSpan::new_with_span(None, *location)].into_iter(),
+            )),
+            Self::IncorrectTypeArity { location, .. } => Some(Box::new(
+                vec![LabeledSpan::new_with_span(None, *location)].into_iter(),
+            )),
+            Self::NotExhaustivePatternMatch { location, .. } => Some(Box::new(
+                vec![LabeledSpan::new_with_span(None, *location)].into_iter(),
+            )),
+            Self::NotFn { location, .. } => Some(Box::new(
+                vec![LabeledSpan::new_with_span(None, *location)].into_iter(),
+            )),
+            Self::KeywordInModuleName { .. } => None,
+            Self::NonLocalClauseGuardVariable { location, .. } => Some(Box::new(
+                vec![LabeledSpan::new_with_span(None, *location)].into_iter(),
+            )),
+            Self::PositionalArgumentAfterLabeled {
+                location,
+                labeled_arg_location,
+                ..
+            } => Some(Box::new(
+                vec![
+                    LabeledSpan::new_with_span(Some("positional".to_string()), *location),
+                    LabeledSpan::new_with_span(Some("labeled".to_string()), *labeled_arg_location),
+                ]
+                .into_iter(),
+            )),
+            Self::PrivateTypeLeak { location, .. } => Some(Box::new(
+                vec![LabeledSpan::new_with_span(None, *location)].into_iter(),
+            )),
+            Self::RecordAccessUnknownType { location, .. } => Some(Box::new(
+                vec![LabeledSpan::new_with_span(None, *location)].into_iter(),
+            )),
+            Self::RecordUpdateInvalidConstructor { location, .. } => Some(Box::new(
+                vec![LabeledSpan::new_with_span(None, *location)].into_iter(),
+            )),
+            Self::ReservedModuleName { .. } => None,
+            Self::UnexpectedLabeledArg { location, .. } => Some(Box::new(
+                vec![LabeledSpan::new_with_span(None, *location)].into_iter(),
+            )),
+            Self::UnexpectedLabeledArgInPattern { location, .. } => Some(Box::new(
+                vec![LabeledSpan::new_with_span(None, *location)].into_iter(),
+            )),
+            Self::UnexpectedTypeHole { location, .. } => Some(Box::new(
+                vec![LabeledSpan::new_with_span(None, *location)].into_iter(),
+            )),
+            Self::UnknownLabels { unknown, .. } => {
+                Some(Box::new(unknown.iter().map(|(lbl, span)| {
+                    LabeledSpan::new_with_span(Some(lbl.clone()), *span)
+                })))
+            }
+            Self::UnknownModule { location, .. } => Some(Box::new(
+                vec![LabeledSpan::new_with_span(None, *location)].into_iter(),
+            )),
+            Self::UnknownModuleField { location, .. } => Some(Box::new(
+                vec![LabeledSpan::new_with_span(None, *location)].into_iter(),
+            )),
+            Self::UnknownModuleValue { location, .. } => Some(Box::new(
+                vec![LabeledSpan::new_with_span(None, *location)].into_iter(),
+            )),
+            Self::UnknownModuleType { location, .. } => Some(Box::new(
+                vec![LabeledSpan::new_with_span(None, *location)].into_iter(),
+            )),
+            Self::UnknownRecordField { location, .. } => Some(Box::new(
+                vec![LabeledSpan::new_with_span(None, *location)].into_iter(),
+            )),
+            Self::UnknownType { location, .. } => Some(Box::new(
+                vec![LabeledSpan::new_with_span(None, *location)].into_iter(),
+            )),
+            Self::UnknownVariable { location, .. } => Some(Box::new(
+                vec![LabeledSpan::new_with_span(None, *location)].into_iter(),
+            )),
+            Self::UnknownTypeConstructor { location, .. } => Some(Box::new(
+                vec![LabeledSpan::new_with_span(None, *location)].into_iter(),
+            )),
+            Self::UnnecessarySpreadOperator { location, .. } => Some(Box::new(
+                vec![LabeledSpan::new_with_span(None, *location)].into_iter(),
+            )),
+            Self::UpdateMultiConstructorType { location, .. } => Some(Box::new(
+                vec![LabeledSpan::new_with_span(None, *location)].into_iter(),
+            )),
+            Self::CouldNotUnify { location, .. } => Some(Box::new(
+                vec![LabeledSpan::new_with_span(None, *location)].into_iter(),
+            )),
+            Self::ExtraVarInAlternativePattern { location, .. } => Some(Box::new(
+                vec![LabeledSpan::new_with_span(None, *location)].into_iter(),
+            )),
+            Self::MissingVarInAlternativePattern { location, .. } => Some(Box::new(
+                vec![LabeledSpan::new_with_span(None, *location)].into_iter(),
+            )),
+            Self::DuplicateVarInPattern { location, .. } => Some(Box::new(
+                vec![LabeledSpan::new_with_span(None, *location)].into_iter(),
+            )),
+            Self::CyclicTypeDefinitions { location, .. } => Some(Box::new(
+                vec![LabeledSpan::new_with_span(None, *location)].into_iter(),
+            )),
+            Self::RecursiveType { location, .. } => Some(Box::new(
+                vec![LabeledSpan::new_with_span(None, *location)].into_iter(),
+            )),
+            Self::NotATuple { location, .. } => Some(Box::new(
+                vec![LabeledSpan::new_with_span(None, *location)].into_iter(),
+            )),
+            Self::TupleIndexOutOfBound { location, .. } => Some(Box::new(
+                vec![LabeledSpan::new_with_span(None, *location)].into_iter(),
+            )),
         }
     }
 }
@@ -636,12 +1362,6 @@ pub enum UnifyErrorSituation {
 
     /// The operands of a binary operator were incorrect.
     Operator(BinOp),
-
-    /// A try expression returned a different error type to the previous try.
-    TryErrorMismatch,
-
-    /// The final value of a try expression was not a Result.
-    TryReturnResult,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]

--- a/crates/aiken-lang/src/tipo/error.rs
+++ b/crates/aiken-lang/src/tipo/error.rs
@@ -144,11 +144,14 @@ pub enum Error {
     #[error("{name} is a reserved module name\n")]
     ReservedModuleName { name: String },
 
-    #[error("Unexpected labeled argument\n\n{label}\n")]
+    #[error("Unexpected labeled argument '{label}'\n")]
+    #[diagnostic()]
     UnexpectedLabeledArg {
         #[label]
         location: Span,
         label: String,
+        #[help]
+        hint: Option<String>,
     },
 
     #[error("Unexpected type hole\n")]
@@ -229,8 +232,8 @@ pub enum Error {
     #[diagnostic(help(
         r#"Did you forget to import it?
 
-Data-type constructors are not automatically imported, even if their type is
-imported. So, if a module `aiken/pet` defines the following type:
+Data-type constructors are not automatically imported, even if their type
+is imported. So, if a module `aiken/pet` defines the following type:
 
  ┍━ aiken/pet.ak ━━━━━━━━
  │ pub type Pet {{

--- a/crates/aiken-lang/src/tipo/error.rs
+++ b/crates/aiken-lang/src/tipo/error.rs
@@ -97,7 +97,7 @@ pub enum Error {
         given: usize,
     },
 
-    #[error("I realized that a given 'when clause' is non-exhaustive.\n")]
+    #[error("I realized that a given 'when/is' expression is non-exhaustive.\n")]
     NotExhaustivePatternMatch {
         location: Span,
         unmatched: Vec<String>,
@@ -1098,7 +1098,7 @@ impl Diagnostic for Error {
         match self {
             Self::DuplicateArgument { locations, .. } => Some(Box::new(
                 locations
-                    .into_iter()
+                    .iter()
                     .map(|l| LabeledSpan::new_with_span(None, *l)),
             )),
             Self::DuplicateConstName {
@@ -1125,7 +1125,7 @@ impl Diagnostic for Error {
             )),
             Self::DuplicateField { locations, .. } => Some(Box::new(
                 locations
-                    .into_iter()
+                    .iter()
                     .map(|l| LabeledSpan::new_with_span(None, *l)),
             )),
             Self::DuplicateName {
@@ -1258,6 +1258,102 @@ impl Diagnostic for Error {
             )),
             Self::TupleIndexOutOfBound { location, .. } => Some(Box::new(
                 vec![LabeledSpan::new_with_span(None, *location)].into_iter(),
+            )),
+        }
+    }
+
+    fn url<'a>(&'a self) -> Option<Box<dyn Display + 'a>> {
+        match self {
+            Self::DuplicateArgument { .. } => None,
+            Self::DuplicateConstName { .. } => None,
+            Self::DuplicateImport { .. } => None,
+            Self::DuplicateField { .. } => None,
+            Self::DuplicateName { .. } => None,
+            Self::DuplicateTypeName { .. } => None,
+            Self::IncorrectFieldsArity { .. } => Some(Box::new(
+                "https://aiken-lang.org/language-tour/custom-types",
+            )),
+            Self::IncorrectFunctionCallArity { .. } => Some(Box::new(
+                "https://aiken-lang.org/language-tour/functions#named-functions",
+            )),
+            Self::IncorrectPatternArity { .. } => Some(Box::new(
+                "https://aiken-lang.org/language-tour/control-flow#matching",
+            )),
+            Self::IncorrectNumClausePatterns { .. } => None,
+            Self::IncorrectTupleArity { .. } => Some(Box::new(
+                "https://aiken-lang.org/language-tour/control-flow#destructuring",
+            )),
+            Self::IncorrectTypeArity { .. } => Some(Box::new(
+                "https://aiken-lang.org/language-tour/custom-types#generics",
+            )),
+            Self::NotExhaustivePatternMatch { .. } => Some(Box::new(
+                "https://aiken-lang.org/language-tour/control-flow#matching",
+            )),
+            Self::NotFn { .. } => None,
+            Self::KeywordInModuleName { .. } => Some(Box::new(
+                "https://aiken-lang.org/language-tour/modules"
+            )),
+            Self::NonLocalClauseGuardVariable { .. } => Some(Box::new(
+                "https://aiken-lang.org/language-tour/control-flow#checking-equality-and-ordering-in-patterns"
+            )),
+            Self::PositionalArgumentAfterLabeled { .. } => Some(Box::new(
+                "https://aiken-lang.org/language-tour/functions#labeled-arguments"
+            )),
+            Self::PrivateTypeLeak { .. } => Some(Box::new(
+                "https://aiken-lang.org/language-tour/modules"
+            )),
+            Self::RecordAccessUnknownType { .. } => Some(Box::new(
+                "https://aiken-lang.org/language-tour/variables-and-constants#type-annotations"
+            )),
+            Self::RecordUpdateInvalidConstructor { .. } => Some(Box::new(
+                "https://aiken-lang.org/language-tour/custom-types#record-updates"
+            )),
+            Self::ReservedModuleName { .. } => None,
+            Self::UnexpectedLabeledArg { .. } => Some(Box::new(
+                "https://aiken-lang.org/language-tour/functions#labeled-arguments"
+            )),
+            Self::UnexpectedLabeledArgInPattern { .. } => Some(Box::new(
+                "https://aiken-lang.org/language-tour/custom-types#named-accessors"
+            )),
+            Self::UnexpectedTypeHole { .. } => None,
+            Self::UnknownLabels { .. } => None,
+            Self::UnknownModule { .. } => None,
+            Self::UnknownModuleField { .. } => None,
+            Self::UnknownModuleValue { .. } => None,
+            Self::UnknownModuleType { .. } => None,
+            Self::UnknownRecordField { .. } => None,
+            Self::UnknownType { .. } => None,
+            Self::UnknownVariable { .. } => None,
+            Self::UnknownTypeConstructor { .. } => None,
+            Self::UnnecessarySpreadOperator { .. } => Some(Box::new(
+                "https://aiken-lang.org/language-tour/control-flow#destructuring"
+            )),
+            Self::UpdateMultiConstructorType { .. } => Some(Box::new(
+                "https://aiken-lang.org/language-tour/custom-types#record-updates"
+            )),
+            Self::CouldNotUnify { .. } => Some(Box::new(
+                "https://aiken-lang.org/language-tour/primitive-types"
+            )),
+            Self::ExtraVarInAlternativePattern { .. } => Some(Box::new(
+                "https://aiken-lang.org/language-tour/control-flow#alternative-clause-patterns"
+            )),
+            Self::MissingVarInAlternativePattern { .. } => Some(Box::new(
+                "https://aiken-lang.org/language-tour/control-flow#alternative-clause-patterns"
+            )),
+            Self::DuplicateVarInPattern { .. } => Some(Box::new(
+                "https://aiken-lang.org/language-tour/control-flow#alternative-clause-patterns"
+            )),
+            Self::CyclicTypeDefinitions { .. } => Some(Box::new(
+                "https://aiken-lang.org/language-tour/custom-types#type-aliases"
+            )),
+            Self::RecursiveType { .. } => Some(Box::new(
+                "https://aiken-lang.org/language-tour/variables-and-constants#type-annotations"
+            )),
+            Self::NotATuple { .. } => Some(Box::new(
+                "https://aiken-lang.org/language-tour/primitive-types#tuples"
+            )),
+            Self::TupleIndexOutOfBound { .. } => Some(Box::new(
+                "https://aiken-lang.org/language-tour/primitive-types#tuples"
             )),
         }
     }

--- a/crates/aiken-lang/src/tipo/error.rs
+++ b/crates/aiken-lang/src/tipo/error.rs
@@ -14,7 +14,7 @@ use super::Type;
 
 #[derive(Debug, thiserror::Error, Diagnostic)]
 pub enum Error {
-    #[error("Duplicate argument\n\n{label}\n")]
+    #[error("Duplicate argument '{label}'\n")]
     #[diagnostic(help("Try renaming it"))]
     DuplicateArgument {
         #[label]
@@ -22,7 +22,7 @@ pub enum Error {
         label: String,
     },
 
-    #[error("Duplicate const\n\n{name}\n")]
+    #[error("Duplicate const '{name}'\n")]
     #[diagnostic(help("Try renaming it"))]
     DuplicateConstName {
         #[label]
@@ -32,7 +32,7 @@ pub enum Error {
         name: String,
     },
 
-    #[error("Duplicate import\n\n{name}\n")]
+    #[error("Duplicate import '{name}'\n")]
     #[diagnostic(help("Try renaming it"))]
     DuplicateImport {
         #[label]
@@ -42,7 +42,7 @@ pub enum Error {
         name: String,
     },
 
-    #[error("Duplicate field\n\n{label}\n")]
+    #[error("Duplicate field '{label}'\n")]
     #[diagnostic(help("Try renaming it"))]
     DuplicateField {
         #[label]
@@ -50,7 +50,7 @@ pub enum Error {
         label: String,
     },
 
-    #[error("Duplicate name\n\n{name}\n")]
+    #[error("Duplicate name '{name}'\n")]
     #[diagnostic(help("Try renaming it"))]
     DuplicateName {
         #[label]
@@ -60,7 +60,7 @@ pub enum Error {
         name: String,
     },
 
-    #[error("Duplicate type name\n\n{name}\n")]
+    #[error("Duplicate type name '{name}'\n")]
     #[diagnostic(help("Try renaming it"))]
     DuplicateTypeName {
         #[label]
@@ -103,17 +103,17 @@ pub enum Error {
         unmatched: Vec<String>,
     },
 
-    #[error("Not a function")]
+    #[error("Not a function\n")]
     NotFn {
         #[label]
         location: Span,
         tipo: Arc<Type>,
     },
 
-    #[error("Module\n\n{name}\n\ncontains keyword\n\n{keyword}\n")]
+    #[error("Module '{name}' contains the keyword '{keyword}', which is forbidden\n")]
     KeywordInModuleName { name: String, keyword: String },
 
-    #[error("Clause guard {name} is not local\n")]
+    #[error("Clause guard '{name}' is not local\n")]
     NonLocalClauseGuardVariable {
         #[label]
         location: Span,
@@ -171,7 +171,7 @@ pub enum Error {
         supplied: Vec<String>,
     },
 
-    #[error("Unknown module\n\n{name}\n")]
+    #[error("Unknown module '{name}'\n")]
     UnknownModule {
         #[label]
         location: Span,
@@ -190,7 +190,7 @@ pub enum Error {
         hint: Option<String>,
     },
 
-    #[error("Unknown module value\n\n{name}\n")]
+    #[error("Unknown module value '{name}'\n")]
     UnknownModuleValue {
         #[label]
         location: Span,
@@ -199,7 +199,7 @@ pub enum Error {
         value_constructors: Vec<String>,
     },
 
-    #[error("Unknown type\n\n{name}\n\nin module\n\n{module_name}\n")]
+    #[error("Unknown type '{name}' in module '{module_name}'\n")]
     UnknownModuleType {
         #[label]
         location: Span,
@@ -218,7 +218,7 @@ pub enum Error {
         situation: Option<UnknownRecordFieldSituation>,
     },
 
-    #[error("Unknown type\n\n{name}\n")]
+    #[error("Unknown type '{name}'\n")]
     UnknownType {
         #[label]
         location: Span,

--- a/crates/aiken-lang/src/tipo/error.rs
+++ b/crates/aiken-lang/src/tipo/error.rs
@@ -225,6 +225,40 @@ pub enum Error {
         variables: Vec<String>,
     },
 
+    #[error("Unknown data-type constructor '{name}'\n")]
+    #[diagnostic(help(
+        r#"Did you forget to import it?
+
+Data-type constructors are not automatically imported, even if their type is
+imported. So, if a module `aiken/pet` defines the following type:
+
+ ┍━ aiken/pet.ak ━━━━━━━━
+ │ pub type Pet {{
+ │   Cat
+ │   Dog
+ │ }}
+
+You must import its constructors explicitly to use them, or prefix them
+with the module's name.
+
+ ┍━ foo.ak ━━━━━━━━
+ │ use aiken/pet.{{Pet, Dog}}
+ │
+ │ fn foo(pet : Pet) {{
+ │   when pet is {{
+ │     pet.Cat -> // ...
+ │     Dog -> // ...
+ │   }}
+ │ }}
+"#
+    ))]
+    UnknownTypeConstructor {
+        #[label]
+        location: Span,
+        name: String,
+        variables: Vec<String>,
+    },
+
     #[error("Unnecessary spread operator\n")]
     UnnecessarySpreadOperator {
         #[label]

--- a/crates/aiken-lang/src/tipo/expr.rs
+++ b/crates/aiken-lang/src/tipo/expr.rs
@@ -111,7 +111,9 @@ impl<'a, 'b> ExprTyper<'a, 'b> {
             Some(field_map) => field_map.reorder(&mut args, location)?,
 
             // The fun has no field map and so we error if arguments have been labelled
-            None => assert_no_labeled_arguments(&args)?,
+            None => assert_no_labeled_arguments(&args)
+                .map(|(location, label)| Err(Error::unexpected_labeled_arg(location, label)))
+                .unwrap_or(Ok(()))?,
         }
 
         // Extract the type of the fun, ensuring it actually is a function
@@ -1350,7 +1352,11 @@ impl<'a, 'b> ExprTyper<'a, 'b> {
                     Some(field_map) => field_map.reorder(&mut args, location)?,
 
                     // The fun has no field map and so we error if arguments have been labelled
-                    None => assert_no_labeled_arguments(&args)?,
+                    None => assert_no_labeled_arguments(&args)
+                        .map(|(location, label)| {
+                            Err(Error::unexpected_labeled_arg(location, label))
+                        })
+                        .unwrap_or(Ok(()))?,
                 }
 
                 let (mut args_types, return_type) = self.environment.match_fun_type(

--- a/crates/aiken-lang/src/tipo/expr.rs
+++ b/crates/aiken-lang/src/tipo/expr.rs
@@ -1781,10 +1781,12 @@ impl<'a, 'b> ExprTyper<'a, 'b> {
                     self.environment
                         .get_variable(name)
                         .cloned()
-                        .ok_or_else(|| Error::UnknownVariable {
-                            location: *location,
-                            name: name.to_string(),
-                            variables: self.environment.local_value_names(),
+                        .ok_or_else(|| {
+                            Error::unknown_variable_or_type(
+                                *location,
+                                name,
+                                self.environment.local_value_names(),
+                            )
                         })?;
 
                 // Note whether we are using an ungeneralised function so that we can

--- a/crates/aiken-lang/src/tipo/pattern.rs
+++ b/crates/aiken-lang/src/tipo/pattern.rs
@@ -9,7 +9,9 @@ use std::{
 use itertools::Itertools;
 
 use super::{
-    environment::{assert_no_labeled_arguments, collapse_links, EntityKind, Environment},
+    environment::{
+        assert_no_labeled_arguments_in_pattern, collapse_links, EntityKind, Environment,
+    },
     error::Error,
     hydrator::Hydrator,
     PatternConstructor, Type, ValueConstructor, ValueConstructorVariant,
@@ -483,7 +485,12 @@ impl<'a, 'b> PatternTyper<'a, 'b> {
                     }
 
                     // The fun has no field map and so we error if arguments have been labelled
-                    None => assert_no_labeled_arguments(&pattern_args)?,
+                    None => assert_no_labeled_arguments_in_pattern(
+                        &name,
+                        &pattern_args,
+                        &module,
+                        with_spread,
+                    )?,
                 }
 
                 let constructor_typ = cons.tipo.clone();

--- a/crates/aiken-lang/src/tipo/pattern.rs
+++ b/crates/aiken-lang/src/tipo/pattern.rs
@@ -242,10 +242,12 @@ impl<'a, 'b> PatternTyper<'a, 'b> {
                     .environment
                     .get_variable(&name)
                     .cloned()
-                    .ok_or_else(|| Error::UnknownVariable {
-                    location,
-                    name: name.to_string(),
-                    variables: self.environment.local_value_names(),
+                    .ok_or_else(|| {
+                    Error::unknown_variable_or_type(
+                        location,
+                        &name,
+                        self.environment.local_value_names(),
+                    )
                 })?;
 
                 self.environment.increment_usage(&name);

--- a/crates/aiken-lang/src/uplc.rs
+++ b/crates/aiken-lang/src/uplc.rs
@@ -972,7 +972,8 @@ impl<'a> CodeGenerator<'a> {
                         .iter()
                         .map(|item| {
                             let label = item.label.clone().unwrap_or_default();
-                            let field_index = field_map.fields.get(&label).unwrap_or(&0);
+                            let field_index =
+                                field_map.fields.get(&label).map(|x| &x.0).unwrap_or(&0);
                             let (discard, var_name) = match &item.value {
                                 Pattern::Var { name, .. } => (false, name.clone()),
                                 Pattern::Discard { .. } => (true, "".to_string()),
@@ -1316,7 +1317,8 @@ impl<'a> CodeGenerator<'a> {
                         .iter()
                         .map(|item| {
                             let label = item.label.clone().unwrap_or_default();
-                            let field_index = field_map.fields.get(&label).unwrap_or(&0);
+                            let field_index =
+                                field_map.fields.get(&label).map(|x| &x.0).unwrap_or(&0);
                             let (discard, var_name) = match &item.value {
                                 Pattern::Var { name, .. } => (false, name.clone()),
                                 Pattern::Discard { .. } => (true, "".to_string()),
@@ -2031,7 +2033,11 @@ impl<'a> CodeGenerator<'a> {
                                 for field in field_map
                                     .fields
                                     .iter()
-                                    .sorted_by(|item1, item2| item1.1.cmp(item2.1))
+                                    .sorted_by(|item1, item2| {
+                                        let (a, _) = item1.1;
+                                        let (b, _) = item2.1;
+                                        a.cmp(b)
+                                    })
                                     .zip(&args_type)
                                     .rev()
                                 {
@@ -2092,7 +2098,11 @@ impl<'a> CodeGenerator<'a> {
                                 for field in field_map
                                     .fields
                                     .iter()
-                                    .sorted_by(|item1, item2| item1.1.cmp(item2.1))
+                                    .sorted_by(|item1, item2| {
+                                        let (a, _) = item1.1;
+                                        let (b, _) = item2.1;
+                                        a.cmp(b)
+                                    })
                                     .rev()
                                 {
                                     term = Term::Lambda {

--- a/crates/aiken-project/src/error.rs
+++ b/crates/aiken-project/src/error.rs
@@ -18,17 +18,17 @@ use zip_extract::ZipExtractError;
 #[allow(dead_code)]
 #[derive(thiserror::Error)]
 pub enum Error {
-    #[error("Duplicate module\n\n{module}")]
+    #[error("I just found two modules with the same name: '{module}'")]
     DuplicateModule {
         module: String,
         first: PathBuf,
         second: PathBuf,
     },
 
-    #[error("File operation failed")]
+    #[error("Some operation on the file-system did fail.")]
     FileIo { error: io::Error, path: PathBuf },
 
-    #[error("Source code incorrectly formatted")]
+    #[error("I found some files with incorrectly formatted source code.")]
     Format { problem_files: Vec<Unformatted> },
 
     #[error(transparent)]
@@ -52,29 +52,26 @@ pub enum Error {
         help: String,
     },
 
-    #[error("Missing 'aiken.toml' manifest in {path}")]
+    #[error("I couldn't find any 'aiken.toml' manifest in {path}.")]
     MissingManifest { path: PathBuf },
 
-    #[error("Cyclical module imports")]
+    #[error("I just found a cycle in module hierarchy!")]
     ImportCycle { modules: Vec<String> },
 
     /// Useful for returning many [`Error::Parse`] at once
     #[error("A list of errors")]
     List(Vec<Self>),
 
-    #[error("Parsing")]
+    #[error("While parsing files...")]
     Parse {
         path: PathBuf,
-
         src: String,
-
         named: NamedSource,
-
         #[source]
         error: Box<ParseError>,
     },
 
-    #[error("Type-checking")]
+    #[error("While trying to make sense of your code...")]
     Type {
         path: PathBuf,
         src: String,
@@ -246,7 +243,10 @@ impl Diagnostic for Error {
             Error::ImportCycle { .. } => Some(Box::new("aiken::module::cyclical")),
             Error::List(_) => None,
             Error::Parse { .. } => Some(Box::new("aiken::parser")),
-            Error::Type { .. } => Some(Box::new("aiken::check")),
+            Error::Type { error, .. } => Some(Box::new(format!(
+                "err::aiken::check{}",
+                error.code().map(|s| format!("::{s}")).unwrap_or_default()
+            ))),
             Error::StandardIo(_) => None,
             Error::MissingManifest { .. } => None,
             Error::TomlLoading { .. } => Some(Box::new("aiken::loading::toml")),

--- a/crates/aiken-project/src/error.rs
+++ b/crates/aiken-project/src/error.rs
@@ -368,6 +368,27 @@ impl Diagnostic for Error {
             Error::JoinError(_) => None,
         }
     }
+
+    fn url<'a>(&'a self) -> Option<Box<dyn Display + 'a>> {
+        match self {
+            Error::DuplicateModule { .. } => None,
+            Error::FileIo { .. } => None,
+            Error::ImportCycle { .. } => None,
+            Error::List { .. } => None,
+            Error::Parse { .. } => None,
+            Error::Type { error, .. } => error.url(),
+            Error::StandardIo(_) => None,
+            Error::MissingManifest { .. } => None,
+            Error::TomlLoading { .. } => None,
+            Error::Format { .. } => None,
+            Error::ValidatorMustReturnBool { .. } => None,
+            Error::WrongValidatorArity { .. } => None,
+            Error::TestFailure { .. } => None,
+            Error::Http { .. } => None,
+            Error::ZipExtract { .. } => None,
+            Error::JoinError { .. } => None,
+        }
+    }
 }
 
 #[derive(thiserror::Error)]

--- a/crates/aiken-project/src/error.rs
+++ b/crates/aiken-project/src/error.rs
@@ -74,7 +74,7 @@ pub enum Error {
         error: Box<ParseError>,
     },
 
-    #[error("Checking")]
+    #[error("Type-checking")]
     Type {
         path: PathBuf,
         src: String,


### PR DESCRIPTION
- :round_pushpin: **Better errors when using unknown data-type constructor.**
    ## Before

  ```
    × Checking
    ╰─▶ Unknown variable

            Finite

      ╭─[../stdlib/validators/tmp.ak:10:1]
   10 │   let now = when context.transaction.validity_range.lower_bound.bound_type is {
   11 │     Finite { t } -> t
      ·     ────────────
   12 │     NegativeInfinity -> 0
      ╰────
  ```

  ## After

  ```
    × Type-checking
    ╰─▶ Unknown data-type constructor 'Finite'

      ╭─[../stdlib/validators/tmp.ak:10:1]
   10 │   let now = when context.transaction.validity_range.lower_bound.bound_type is {
   11 │     Finite { t } -> t
      ·     ────────────
   12 │     NegativeInfinity -> 0
      ╰────
    help: Did you forget to import it?

          Data-type constructors are not automatically imported, even if their type is
          imported. So, if a module `aiken/pet` defines the following type:

           ┍━ aiken/pet.ak ━━━━━━━━
           │ pub type Pet {
           │   Cat
           │   Dog
           │ }

          You must import its constructors explicitly to use them, or prefix them
          with the module's name.

           ┍━ foo.ak ━━━━━━━━
           │ use aiken/pet.{Pet, Dog}
           │
           │ fn foo(pet : Pet) {
           │   when pet is {
           │     pet.Cat -> // ...
           │     Dog -> // ...
           │   }
           │ }
  ```

- :round_pushpin: **Make 'UnexpectedLabelArg' errors more helpful**
    ## Before

  ```
   × Checking
   ╰─▶ Unexpected labeled argument

       t

     ╭─[/Users/mati/Devel/OpenSource/time_lock_aiken/validators/time_lock.ak:13:1]
  13 │   let now = when context.transaction.validity_range.lower_bound.bound_type is {
  14 │     Finite { t } -> t
     ·              ─
  15 │     NegativeInfinity -> 0
     ╰────
  ```

  ## After

  ```
    × Type-checking
    ╰─▶ Unexpected labeled argument 't'

      ╭─[../stdlib/validators/tmp.ak:10:1]
   10 │   let now = when context.transaction.validity_range.lower_bound.bound_type is {
   11 │     interval.Finite { t } -> t
      ·                       ─
   12 │     interval.NegativeInfinity -> 0
      ╰────
    help: The constructor 'Finite' does not have any labeled field. Its fields
          must therefore be matched only by position.

          Perhaps, try the following:

          ╰─▶  interval.Finite(t)
  ```

- :round_pushpin: **Add function to calculate lenvenshtein distance of two strings**
    Will be useful to make import or usage suggestions.

- :round_pushpin: **Suggest possible candidate on unknown imports.**
    ## Before

  ```
  × Type-checking
  ╰─▶ Unknown module field 'ValidityRaneg' in module 'aiken/transaction'
  ```

  ## After

  ```
    × Type-checking
    ╰─▶ Unknown import 'ValidityRaneg' from module 'aiken/transaction'

     ╭─[../stdlib/validators/tmp.ak:2:1]
   2 │ use aiken/interval.{Interval, IntervalBound, IntervalBoundType}
   3 │ use aiken/transaction.{ScriptContext, ValidityRaneg}
     ·                                       ─────────────
   4 │
     ╰────
    help: Did you mean to import 'ValidityRange'?
  ```

- :round_pushpin: **Refactor 'UnknownVariable' and 'UnknownTypeConstructor' as smart-constructor.**
  
- :round_pushpin: **Use smart-constructor for UnexpectedLabeledArg errors.**
    Reduce duplications and keep the formatting of the error inside the error module.

- :round_pushpin: **Show most type-checking error on a single line; reads better.**
  