### PR TITLE
Error Keyword

### DIFF
--- a/crates/aiken-lang/src/air.rs
+++ b/crates/aiken-lang/src/air.rs
@@ -205,6 +205,7 @@ pub enum Air {
     ErrorTerm {
         scope: Vec<u64>,
         tipo: Arc<Type>,
+        label: Option<String>,
     },
 
     Trace {

--- a/crates/aiken-lang/src/air.rs
+++ b/crates/aiken-lang/src/air.rs
@@ -202,6 +202,11 @@ pub enum Air {
         tipo: Arc<Type>,
     },
 
+    ErrorTerm {
+        scope: Vec<u64>,
+        tipo: Arc<Type>,
+    },
+
     Trace {
         scope: Vec<u64>,
         text: Option<String>,
@@ -263,6 +268,7 @@ impl Air {
             | Air::FieldsExpose { scope, .. }
             | Air::Tuple { scope, .. }
             | Air::Todo { scope, .. }
+            | Air::ErrorTerm { scope, .. }
             | Air::Record { scope, .. }
             | Air::RecordUpdate { scope, .. }
             | Air::Negate { scope, .. }

--- a/crates/aiken-lang/src/expr.rs
+++ b/crates/aiken-lang/src/expr.rs
@@ -151,6 +151,7 @@ pub enum TypedExpr {
     ErrorTerm {
         location: Span,
         tipo: Arc<Type>,
+        label: Option<String>,
     },
 
     RecordUpdate {
@@ -425,6 +426,7 @@ pub enum UntypedExpr {
 
     ErrorTerm {
         location: Span,
+        label: Option<String>,
     },
 
     RecordUpdate {

--- a/crates/aiken-lang/src/expr.rs
+++ b/crates/aiken-lang/src/expr.rs
@@ -148,6 +148,11 @@ pub enum TypedExpr {
         tipo: Arc<Type>,
     },
 
+    ErrorTerm {
+        location: Span,
+        tipo: Arc<Type>,
+    },
+
     RecordUpdate {
         location: Span,
         tipo: Arc<Type>,
@@ -170,6 +175,7 @@ impl TypedExpr {
             Self::Fn { tipo, .. }
             | Self::Int { tipo, .. }
             | Self::Todo { tipo, .. }
+            | Self::ErrorTerm { tipo, .. }
             | Self::When { tipo, .. }
             | Self::List { tipo, .. }
             | Self::Call { tipo, .. }
@@ -214,6 +220,7 @@ impl TypedExpr {
             | TypedExpr::Call { .. }
             | TypedExpr::When { .. }
             | TypedExpr::Todo { .. }
+            | TypedExpr::ErrorTerm { .. }
             | TypedExpr::BinOp { .. }
             | TypedExpr::Tuple { .. }
             | TypedExpr::Negate { .. }
@@ -252,6 +259,7 @@ impl TypedExpr {
             | Self::Var { location, .. }
             | Self::Trace { location, .. }
             | Self::Todo { location, .. }
+            | Self::ErrorTerm { location, .. }
             | Self::When { location, .. }
             | Self::Call { location, .. }
             | Self::List { location, .. }
@@ -287,6 +295,7 @@ impl TypedExpr {
             | Self::Trace { location, .. }
             | Self::Var { location, .. }
             | Self::Todo { location, .. }
+            | Self::ErrorTerm { location, .. }
             | Self::When { location, .. }
             | Self::Call { location, .. }
             | Self::If { location, .. }
@@ -372,11 +381,13 @@ pub enum UntypedExpr {
         kind: AssignmentKind,
         annotation: Option<Annotation>,
     },
+
     Trace {
         location: Span,
         then: Box<Self>,
         text: Option<String>,
     },
+
     When {
         location: Span,
         subjects: Vec<Self>,
@@ -410,6 +421,10 @@ pub enum UntypedExpr {
         kind: TodoKind,
         location: Span,
         label: Option<String>,
+    },
+
+    ErrorTerm {
+        location: Span,
     },
 
     RecordUpdate {
@@ -482,6 +497,7 @@ impl UntypedExpr {
             | Self::Var { location, .. }
             | Self::Int { location, .. }
             | Self::Todo { location, .. }
+            | Self::ErrorTerm { location, .. }
             | Self::When { location, .. }
             | Self::Call { location, .. }
             | Self::List { location, .. }

--- a/crates/aiken-lang/src/format.rs
+++ b/crates/aiken-lang/src/format.rs
@@ -783,7 +783,9 @@ impl<'comments> Formatter<'comments> {
                     .append((index + 1).to_doc())
                     .append(suffix)
             }
+            UntypedExpr::ErrorTerm { .. } => "error".to_doc(),
         };
+
         commented(document, comments)
     }
 

--- a/crates/aiken-lang/src/parser.rs
+++ b/crates/aiken-lang/src/parser.rs
@@ -851,6 +851,10 @@ pub fn expr_parser(
                 label,
             });
 
+        let error_parser = just(Token::ErrorTerm)
+            .ignored()
+            .map_with_span(|_, span| expr::UntypedExpr::ErrorTerm { location: span });
+
         let tuple = just(Token::Hash)
             .ignore_then(
                 r.clone()
@@ -1065,6 +1069,7 @@ pub fn expr_parser(
             field_access_constructor,
             var_parser,
             todo_parser,
+            error_parser,
             tuple,
             bytearray,
             list_parser,

--- a/crates/aiken-lang/src/parser.rs
+++ b/crates/aiken-lang/src/parser.rs
@@ -852,8 +852,15 @@ pub fn expr_parser(
             });
 
         let error_parser = just(Token::ErrorTerm)
-            .ignored()
-            .map_with_span(|_, span| expr::UntypedExpr::ErrorTerm { location: span });
+            .ignore_then(
+                select! {Token::String {value} => value}
+                    .delimited_by(just(Token::LeftParen), just(Token::RightParen))
+                    .or_not(),
+            )
+            .map_with_span(|label, span| expr::UntypedExpr::ErrorTerm {
+                location: span,
+                label,
+            });
 
         let tuple = just(Token::Hash)
             .ignore_then(

--- a/crates/aiken-lang/src/parser/lexer.rs
+++ b/crates/aiken-lang/src/parser/lexer.rs
@@ -95,6 +95,7 @@ pub fn lexer() -> impl Parser<char, Vec<(Token, Span)>, Error = ParseError> {
 
     let keyword = text::ident().map(|s: String| match s.as_str() {
         "trace" => Token::Trace,
+        "error" => Token::ErrorTerm,
         "as" => Token::As,
         "assert" => Token::Assert,
         "check" => Token::Assert,

--- a/crates/aiken-lang/src/parser/token.rs
+++ b/crates/aiken-lang/src/parser/token.rs
@@ -75,6 +75,7 @@ pub enum Token {
     Type,
     When,
     Trace,
+    ErrorTerm,
 }
 
 impl fmt::Display for Token {
@@ -154,6 +155,7 @@ impl fmt::Display for Token {
             Token::Trace => "trace",
             Token::Type => "type",
             Token::Test => "test",
+            Token::ErrorTerm => "error",
         };
         write!(f, "\"{}\"", s)
     }

--- a/crates/aiken-lang/src/tipo/expr.rs
+++ b/crates/aiken-lang/src/tipo/expr.rs
@@ -236,6 +236,8 @@ impl<'a, 'b> ExprTyper<'a, 'b> {
                 ..
             } => Ok(self.infer_todo(location, kind, label)),
 
+            UntypedExpr::ErrorTerm { location } => Ok(self.infer_error_term(location)),
+
             UntypedExpr::Var { location, name, .. } => self.infer_var(name, location),
 
             UntypedExpr::Int {
@@ -1757,6 +1759,12 @@ impl<'a, 'b> ExprTyper<'a, 'b> {
             label,
             tipo,
         }
+    }
+
+    fn infer_error_term(&mut self, location: Span) -> TypedExpr {
+        let tipo = self.new_unbound_var();
+
+        TypedExpr::ErrorTerm { location, tipo }
     }
 
     fn infer_trace(

--- a/crates/aiken-lang/src/tipo/expr.rs
+++ b/crates/aiken-lang/src/tipo/expr.rs
@@ -236,7 +236,9 @@ impl<'a, 'b> ExprTyper<'a, 'b> {
                 ..
             } => Ok(self.infer_todo(location, kind, label)),
 
-            UntypedExpr::ErrorTerm { location } => Ok(self.infer_error_term(location)),
+            UntypedExpr::ErrorTerm { location, label } => {
+                Ok(self.infer_error_term(location, label))
+            }
 
             UntypedExpr::Var { location, name, .. } => self.infer_var(name, location),
 
@@ -1761,10 +1763,14 @@ impl<'a, 'b> ExprTyper<'a, 'b> {
         }
     }
 
-    fn infer_error_term(&mut self, location: Span) -> TypedExpr {
+    fn infer_error_term(&mut self, location: Span, label: Option<String>) -> TypedExpr {
         let tipo = self.new_unbound_var();
 
-        TypedExpr::ErrorTerm { location, tipo }
+        TypedExpr::ErrorTerm {
+            location,
+            tipo,
+            label,
+        }
     }
 
     fn infer_trace(

--- a/crates/aiken-lang/src/tipo/infer.rs
+++ b/crates/aiken-lang/src/tipo/infer.rs
@@ -476,6 +476,8 @@ fn str_to_keyword(word: &str) -> Option<Token> {
         "todo" => Some(Token::Todo),
         "type" => Some(Token::Type),
         "trace" => Some(Token::Trace),
+        "test" => Some(Token::Test),
+        "error" => Some(Token::ErrorTerm),
         _ => None,
     }
 }

--- a/crates/aiken-lang/src/uplc.rs
+++ b/crates/aiken-lang/src/uplc.rs
@@ -536,6 +536,13 @@ impl<'a> CodeGenerator<'a> {
             TypedExpr::TupleIndex { .. } => {
                 todo!("Tuple indexing not implementing yet");
             }
+
+            TypedExpr::ErrorTerm { tipo, .. } => {
+                ir_stack.push(Air::ErrorTerm {
+                    scope,
+                    tipo: tipo.clone(),
+                });
+            }
         }
     }
 
@@ -3732,6 +3739,7 @@ impl<'a> CodeGenerator<'a> {
 
                 arg_stack.push(term);
             }
+            Air::ErrorTerm { .. } => arg_stack.push(Term::Error),
         }
     }
 }

--- a/crates/aiken/src/cmd/new.rs
+++ b/crates/aiken/src/cmd/new.rs
@@ -75,13 +75,13 @@ fn create_lib_folder(root: &Path, package_name: &PackageName) -> miette::Result<
     let lib = root.join("lib");
     fs::create_dir_all(&lib).into_diagnostic()?;
     let nested_path = lib.join(&package_name.repo);
-    fs::create_dir_all(&nested_path).into_diagnostic()?;
+    fs::create_dir_all(nested_path).into_diagnostic()?;
     Ok(())
 }
 
 fn create_validators_folder(root: &Path) -> miette::Result<()> {
     let validators = root.join("validators");
-    fs::create_dir_all(&validators).into_diagnostic()?;
+    fs::create_dir_all(validators).into_diagnostic()?;
     Ok(())
 }
 


### PR DESCRIPTION
* this adds the ability to say some branch of code should intentionally fail

```gleam
fn is_one(n: Int) -> Bool {
  if n == 1 {
    True
  } else {
    error
  }
}
```

 In a way this is similar to `todo` but it won't raise a compiler warning. Although the behavior of both are the same, they convey different "meaning"/intention to the programmer. `todo` should mean "I'll finish this later so it raises a warning". `error` should mean "this intentionally fails here".
 
 closes #214 