### PR TITLE
`aiken check` make match tests flag fancier

### DIFF
--- a/crates/aiken-project/src/options.rs
+++ b/crates/aiken-project/src/options.rs
@@ -4,7 +4,7 @@ pub struct Options {
 
 pub enum CodeGenMode {
     Test {
-        match_tests: Option<String>,
+        match_tests: Option<Vec<String>>,
         verbose: bool,
     },
     Build(bool),

--- a/crates/aiken-project/src/options.rs
+++ b/crates/aiken-project/src/options.rs
@@ -6,6 +6,7 @@ pub enum CodeGenMode {
     Test {
         match_tests: Option<Vec<String>>,
         verbose: bool,
+        exact_match: bool,
     },
     Build(bool),
     NoOp,

--- a/crates/aiken/src/cmd/check.rs
+++ b/crates/aiken/src/cmd/check.rs
@@ -16,7 +16,7 @@ pub struct Args {
 
     /// Only run tests if their path + name match the given string
     #[clap(short, long)]
-    match_tests: Option<String>,
+    match_tests: Option<Vec<String>>,
 }
 
 pub fn exec(

--- a/crates/aiken/src/cmd/check.rs
+++ b/crates/aiken/src/cmd/check.rs
@@ -14,9 +14,16 @@ pub struct Args {
     #[clap(long)]
     debug: bool,
 
-    /// Only run tests if their path + name match the given string
+    /// Only run tests if they match any of these strings.
+    /// You can match a module with `-m aiken/list` or `-m list`.
+    /// You can match a test with `-m "aiken/list.{map}"` or `-m "aiken/option.{flatten_1}"`
     #[clap(short, long)]
     match_tests: Option<Vec<String>>,
+
+    /// This is meant to be used with `--match-tests`.
+    /// It forces test names to match exactly
+    #[clap(short, long)]
+    exact_match: bool,
 }
 
 pub fn exec(
@@ -25,9 +32,10 @@ pub fn exec(
         skip_tests,
         debug,
         match_tests,
+        exact_match,
     }: Args,
 ) -> miette::Result<()> {
     crate::with_project(directory, |p| {
-        p.check(skip_tests, match_tests.clone(), debug)
+        p.check(skip_tests, match_tests.clone(), debug, exact_match)
     })
 }


### PR DESCRIPTION
`--match-tests` idea

allow it to take a list of what looks like a regular aiken import

`aiken check --match-tests "aiken/option.{flatten, map}" --match-tests aiken/list`

### Behaviors

- can match an entire module `aiken/list`
- can match on an exact test name `aiken/option.{flatten_2}`
- can do a fuzzy match on test names `aiken/option.{flatten}`
  - this would run all 4 flatten tests
  
 <img width="981" alt="Screenshot 2023-01-10 at 10 15 56 AM" src="https://user-images.githubusercontent.com/12070598/211590943-410a6620-66b6-4e1e-b4bd-8122fb60a26a.png">
 
 
<img width="676" alt="Screenshot 2023-01-10 at 10 23 05 AM" src="https://user-images.githubusercontent.com/12070598/211591234-8f551125-362e-4c26-97de-79efa574afd9.png">

  
 