### PR TITLE
error fmt was removing label

### DIFF
--- a/crates/aiken-lang/src/format.rs
+++ b/crates/aiken-lang/src/format.rs
@@ -783,7 +783,10 @@ impl<'comments> Formatter<'comments> {
                     .append((index + 1).to_doc())
                     .append(suffix)
             }
-            UntypedExpr::ErrorTerm { .. } => "error".to_doc(),
+
+            UntypedExpr::ErrorTerm { label: None, .. } => "error".to_doc(),
+
+            UntypedExpr::ErrorTerm { label: Some(l), .. } => docvec!["error(\"", l, "\")"],
         };
 
         commented(document, comments)


### PR DESCRIPTION
- `error("some message")` was getting formatted to `error` which is rather rude of the formatter