### PR TITLE
IncorrectArity - the expected arity with hardcoded to 0

### DIFF
--- a/crates/aiken-lang/src/tipo/error.rs
+++ b/crates/aiken-lang/src/tipo/error.rs
@@ -62,7 +62,7 @@ pub enum Error {
         given: usize,
     },
 
-    #[error("I saw a pattern on a constructor that has {} fields be matched with {} arguments.\n", expected.purple(), given.len().purple())]
+    #[error("I saw a pattern on a constructor that has {} field(s) be matched with {} arguments.\n", expected.purple(), given.len().purple())]
     IncorrectPatternArity {
         location: Span,
         expected: usize,

--- a/crates/aiken-lang/src/tipo/pattern.rs
+++ b/crates/aiken-lang/src/tipo/pattern.rs
@@ -555,7 +555,7 @@ impl<'a, 'b> PatternTyper<'a, 'b> {
                             Err(Error::IncorrectPatternArity {
                                 location,
                                 given: pattern_args,
-                                expected: 0,
+                                expected: args.len(),
                                 name: name.clone(),
                                 module: module.clone(),
                                 is_record,


### PR DESCRIPTION
We just need to set it to `args.len()`

`I saw a pattern on a constructor that has 1 fields be matched with 0 arguments.`