### PR TITLE
Deps and cache manipulation

### DIFF
--- a/crates/aiken-project/src/deps/downloader.rs
+++ b/crates/aiken-project/src/deps/downloader.rs
@@ -3,7 +3,11 @@ use std::{io::Cursor, path::Path};
 use futures::future;
 use reqwest::Client;
 
-use crate::{config::PackageName, error::Error, paths};
+use crate::{
+    config::PackageName,
+    error::Error,
+    paths::{self, CacheKey},
+};
 
 use super::manifest::Package;
 
@@ -41,15 +45,20 @@ impl<'a> Downloader<'a> {
         &self,
         package: &Package,
     ) -> Result<bool, Error> {
-        self.ensure_package_downloaded(package).await?;
-        self.extract_package_from_cache(&package.name, &package.version)
+        let cache_key = paths::CacheKey::new(&self.http, package).await?;
+        self.ensure_package_downloaded(package, &cache_key).await?;
+        self.extract_package_from_cache(&package.name, &cache_key)
             .await
     }
 
-    pub async fn ensure_package_downloaded(&self, package: &Package) -> Result<bool, Error> {
+    pub async fn ensure_package_downloaded(
+        &self,
+        package: &Package,
+        cache_key: &CacheKey,
+    ) -> Result<bool, Error> {
         let packages_cache_path = paths::packages_cache();
-        let zipball_path =
-            paths::package_cache_zipball(&package.name, &package.version.to_string());
+
+        let zipball_path = paths::package_cache_zipball(cache_key);
 
         if !packages_cache_path.exists() {
             tokio::fs::create_dir_all(packages_cache_path).await?;
@@ -83,7 +92,7 @@ impl<'a> Downloader<'a> {
     pub async fn extract_package_from_cache(
         &self,
         name: &PackageName,
-        version: &str,
+        cache_key: &CacheKey,
     ) -> Result<bool, Error> {
         let destination = self.root_path.join(paths::build_deps_package(name));
 
@@ -94,9 +103,7 @@ impl<'a> Downloader<'a> {
 
         tokio::fs::create_dir_all(&destination).await?;
 
-        let zipball_path = self
-            .root_path
-            .join(paths::package_cache_zipball(name, version));
+        let zipball_path = self.root_path.join(paths::package_cache_zipball(cache_key));
 
         let zipball = tokio::fs::read(zipball_path).await?;
 

--- a/crates/aiken-project/src/deps/manifest.rs
+++ b/crates/aiken-project/src/deps/manifest.rs
@@ -87,7 +87,7 @@ impl Manifest {
     }
 }
 
-#[derive(Deserialize, Serialize)]
+#[derive(Deserialize, Serialize, Clone)]
 pub struct Package {
     pub name: PackageName,
     pub version: String,

--- a/crates/aiken-project/src/error.rs
+++ b/crates/aiken-project/src/error.rs
@@ -1,4 +1,4 @@
-use crate::{pretty, script::EvalHint};
+use crate::{deps::manifest::Package, pretty, script::EvalHint};
 use aiken_lang::{
     ast::{BinOp, Span},
     parser::error::ParseError,
@@ -106,6 +106,14 @@ pub enum Error {
         src: String,
         evaluation_hint: Option<EvalHint>,
     },
+
+    #[error(
+        "I was unable to resolve '{}' for {}/{}",
+        package.version,
+        package.name.owner,
+        package.name.repo
+    )]
+    UnknownPackageVersion { package: Package },
 }
 
 impl Error {
@@ -187,6 +195,7 @@ impl Error {
             Error::Http(_) => None,
             Error::ZipExtract(_) => None,
             Error::JoinError(_) => None,
+            Error::UnknownPackageVersion { .. } => None,
         }
     }
 
@@ -208,6 +217,7 @@ impl Error {
             Error::Http(_) => None,
             Error::ZipExtract(_) => None,
             Error::JoinError(_) => None,
+            Error::UnknownPackageVersion { .. } => None,
         }
     }
 }
@@ -257,6 +267,7 @@ impl Diagnostic for Error {
             Error::Http(_) => Some(Box::new("aiken::deps")),
             Error::ZipExtract(_) => None,
             Error::JoinError(_) => None,
+            Error::UnknownPackageVersion { .. } => Some(Box::new("aiken::deps")),
         }
     }
 
@@ -312,6 +323,7 @@ impl Diagnostic for Error {
             Error::Http(_) => None,
             Error::ZipExtract(_) => None,
             Error::JoinError(_) => None,
+            Error::UnknownPackageVersion{..} => None,
         }
     }
 
@@ -345,6 +357,7 @@ impl Diagnostic for Error {
             Error::Http(_) => None,
             Error::ZipExtract(_) => None,
             Error::JoinError(_) => None,
+            Error::UnknownPackageVersion { .. } => None,
         }
     }
 
@@ -366,6 +379,7 @@ impl Diagnostic for Error {
             Error::Http(_) => None,
             Error::ZipExtract(_) => None,
             Error::JoinError(_) => None,
+            Error::UnknownPackageVersion { .. } => None,
         }
     }
 
@@ -387,6 +401,7 @@ impl Diagnostic for Error {
             Error::Http { .. } => None,
             Error::ZipExtract { .. } => None,
             Error::JoinError { .. } => None,
+            Error::UnknownPackageVersion { .. } => None,
         }
     }
 }

--- a/crates/aiken/src/cmd/deps/clear_cache.rs
+++ b/crates/aiken/src/cmd/deps/clear_cache.rs
@@ -1,0 +1,38 @@
+use aiken_project::{paths, pretty};
+use miette::IntoDiagnostic;
+use owo_colors::OwoColorize;
+use std::fs;
+
+pub fn exec() -> miette::Result<()> {
+    let dir = paths::packages_cache();
+    println!(
+        "{} {}",
+        pretty::pad_left("Clearing".to_string(), 13, " ")
+            .bold()
+            .purple(),
+        dir.display().bold(),
+    );
+    let packages = fs::read_dir(&dir).into_diagnostic()?;
+    for package in packages {
+        let path = package.into_diagnostic()?.path();
+        println!(
+            "{} {}",
+            pretty::pad_left("Removing".to_string(), 13, " ")
+                .bold()
+                .purple(),
+            path.file_name()
+                .unwrap_or_default()
+                .to_str()
+                .unwrap_or_default()
+                .bright_blue(),
+        );
+        fs::remove_file(path).into_diagnostic()?;
+    }
+    println!(
+        "{}",
+        pretty::pad_left("Done".to_string(), 13, " ")
+            .bold()
+            .purple()
+    );
+    Ok(())
+}

--- a/crates/aiken/src/cmd/deps/mod.rs
+++ b/crates/aiken/src/cmd/deps/mod.rs
@@ -1,0 +1,17 @@
+pub mod clear_cache;
+
+use clap::Subcommand;
+
+/// Managing project dependencies
+#[derive(Subcommand)]
+#[clap(setting(clap::AppSettings::DeriveDisplayOrder))]
+pub enum Cmd {
+    /// Clear the system-wide dependencies cache
+    ClearCache,
+}
+
+pub fn exec(cmd: Cmd) -> miette::Result<()> {
+    match cmd {
+        Cmd::ClearCache => clear_cache::exec(),
+    }
+}

--- a/crates/aiken/src/cmd/mod.rs
+++ b/crates/aiken/src/cmd/mod.rs
@@ -1,5 +1,6 @@
 pub mod build;
 pub mod check;
+pub mod deps;
 pub mod docs;
 pub mod error;
 pub mod fmt;

--- a/crates/aiken/src/main.rs
+++ b/crates/aiken/src/main.rs
@@ -1,4 +1,4 @@
-use aiken::cmd::{build, check, docs, fmt, lsp, new, tx, uplc};
+use aiken::cmd::{build, check, deps, docs, fmt, lsp, new, tx, uplc};
 use clap::Parser;
 
 /// Aiken: a smart-contract language and toolchain for Cardano
@@ -13,14 +13,17 @@ pub enum Cmd {
     Check(check::Args),
     Docs(docs::Args),
 
-    #[clap(hide = true)]
-    Lsp(lsp::Args),
+    #[clap(subcommand)]
+    Deps(deps::Cmd),
 
     #[clap(subcommand)]
     Tx(tx::Cmd),
 
     #[clap(subcommand)]
     Uplc(uplc::Cmd),
+
+    #[clap(hide = true)]
+    Lsp(lsp::Args),
 }
 
 impl Default for Cmd {
@@ -36,6 +39,7 @@ fn main() -> miette::Result<()> {
         Cmd::Fmt(args) => fmt::exec(args),
         Cmd::Build(args) => build::exec(args),
         Cmd::Docs(args) => docs::exec(args),
+        Cmd::Deps(args) => deps::exec(args),
         Cmd::Check(args) => check::exec(args),
         Cmd::Lsp(args) => lsp::exec(args),
         Cmd::Tx(sub_cmd) => tx::exec(sub_cmd),


### PR DESCRIPTION
- :round_pushpin: **Invalidate cache using etag for deps by branch**
    Aiken's build system uses an internal global cache system to avoid
  downloading the same packages over and over across projects. However,
  prior to this commit, the cache key would be based of the dependency
  version which can be either:

  - A commit hash
  - A branch or tag name

  However, in the latter case, it means that the very first time we end
  up fetching a dependency will lock its version forever (or until the
  cache is cleared). This was inconvenient.

  This commit changes that so that we use not only a branch name as
  cache key, but additionally, the etag returned by the GitHub API
  server. The etag is part of the HTTP headers, so it can be fetched
  quickly using a simple HEAD request. It changes whenever the content
  behind the endpoint changes -- which happens to be exactly what we
  want. With this, we can quickly check whether an upstream package has
  been updated and download the latest version should users have
  specified a branch name as a version number.

  For example, my current cache now looks as follow:

  ```
   /Users/ktorz/Library/Caches/aiken/packages/
   ├── aiken-lang-stdlib-1cedbe85b7c7e9c4036d63d45cad4ced27b0d50b.zip
   ├── aiken-lang-stdlib-6b482fa00ec37fe936c93155e8c670f32288a686.zip
   ├── aiken-lang-stdlib-7ca9e659688ea88e1cfdc439b6c20c4c7fae9985.zip
   └── aiken-lang-stdlib-main@04eb45df3c77f6611bbdff842a0e311be2c56390f0fa01f020d69c93ff567fe5.zip
  ```

- :round_pushpin: **Add new command group 'deps' and 'clear-cache' command.**
    This allows in case of issues with dependencies to at least safely
  remove cached packages. Before that, it could be hard to know where
  are even located the cached files without looking at the source code.

  ```
     Clearing /Users/ktorz/Library/Caches/aiken/packages
     Removing aiken-lang-stdlib-7ca9e659688ea88e1cfdc439b6c20c4c7fae9985.zip
     Removing aiken-lang-stdlib-main@04eb45df3c77f6611bbdff842a0e311be2c56390f0fa01f020d69c93ff567fe5.zip
     Removing aiken-lang-stdlib-6b482fa00ec37fe936c93155e8c670f32288a686.zip
     Removing aiken-lang-stdlib-1cedbe85b7c7e9c4036d63d45cad4ced27b0d50b.zip
         Done
  ```
