### PR TITLE
Error for when a validator module is imported

### DIFF
--- a/crates/aiken-lang/src/tipo/environment.rs
+++ b/crates/aiken-lang/src/tipo/environment.rs
@@ -680,9 +680,16 @@ impl<'a> Environment<'a> {
                         .get(&name)
                         .ok_or_else(|| Error::UnknownModule {
                             location: *location,
-                            name,
+                            name: name.clone(),
                             imported_modules: self.imported_modules.keys().cloned().collect(),
                         })?;
+
+                if module_info.kind.is_validator() {
+                    return Err(Error::ValidatorImported {
+                        location: *location,
+                        name,
+                    });
+                }
 
                 // Determine local alias of imported module
                 let module_name = as_name

--- a/crates/aiken-lang/src/tipo/error.rs
+++ b/crates/aiken-lang/src/tipo/error.rs
@@ -116,7 +116,7 @@ pub enum Error {
     )]
     KeywordInModuleName { name: String, keyword: String },
 
-    #[error("I stumble upon an invalid (non-local) clause guard '{}'.\n", name.purple())]
+    #[error("I stumbled upon an invalid (non-local) clause guard '{}'.\n", name.purple())]
     NonLocalClauseGuardVariable { location: Span, name: String },
 
     #[error("I discovered a positional argument after a label argument.\n")]
@@ -162,7 +162,7 @@ pub enum Error {
         supplied: Vec<String>,
     },
 
-    #[error("I stumble upon a reference to an unknown module: '{}'\n", name.purple())]
+    #[error("I stumbled upon a reference to an unknown module: '{}'\n", name.purple())]
     UnknownModule {
         location: Span,
         name: String,

--- a/crates/aiken-lang/src/tipo/error.rs
+++ b/crates/aiken-lang/src/tipo/error.rs
@@ -277,6 +277,9 @@ pub enum Error {
         index: usize,
         size: usize,
     },
+
+    #[error("I discovered an attempt to import a validator module: '{}'\n", name.purple())]
+    ValidatorImported { location: Span, name: String },
 }
 
 impl Error {
@@ -424,6 +427,7 @@ impl Diagnostic for Error {
             Self::RecursiveType { .. } => Some(Box::new("recursive_type")),
             Self::NotATuple { .. } => Some(Box::new("not_a_tuple")),
             Self::TupleIndexOutOfBound { .. } => Some(Box::new("tuple_index_out_of_bound")),
+            Self::ValidatorImported { .. } => Some(Box::new("validator_imported")),
         }
     }
 
@@ -1088,6 +1092,8 @@ impl Diagnostic for Error {
             })),
 
             Self::TupleIndexOutOfBound { .. } => None,
+
+            Self::ValidatorImported { .. } => Some(Box::new(format!("If you are trying to share code defined in\na validator then move it to a module in {}", "lib/".purple())))
         }
     }
 
@@ -1260,6 +1266,10 @@ impl Diagnostic for Error {
             Self::TupleIndexOutOfBound { location, .. } => Some(Box::new(
                 vec![LabeledSpan::new_with_span(None, *location)].into_iter(),
             )),
+
+            Self::ValidatorImported { location, .. } => Some(Box::new(
+                vec![LabeledSpan::new_with_span(None, *location)].into_iter(),
+            )),
         }
     }
 
@@ -1357,6 +1367,7 @@ impl Diagnostic for Error {
             Self::TupleIndexOutOfBound { .. } => Some(Box::new(
                 "https://aiken-lang.org/language-tour/primitive-types#tuples"
             )),
+            Self::ValidatorImported { .. } => None
         }
     }
 }


### PR DESCRIPTION
closes #81 

We do not want to allow users to import validator modules. They are special modules for defining validator functions that correspond to one of the four script purposes.

I've also added a help message that instructs people to move the code they want to share to a new module in `lib/`.

<img width="785" alt="Screenshot 2023-01-15 at 6 43 22 PM" src="https://user-images.githubusercontent.com/12070598/212574171-f15e861b-ff58-44c6-b6d4-2f8e2c1b99da.png">
