### PR TITLE
Error for when an expression is implicitly discarded

### DIFF
--- a/crates/aiken-lang/src/tipo/error.rs
+++ b/crates/aiken-lang/src/tipo/error.rs
@@ -50,6 +50,9 @@ pub enum Error {
     #[error("I found a data type that has a function type in it. This is not allowed.")]
     FunctionTypeInData { location: Span },
 
+    #[error("I found a discarded expression not bound to a variable.")]
+    ImplicityDiscardedExpression { location: Span },
+
     #[error("I saw a {} fields in a context where there should be {}.\n", given.purple(), expected.purple())]
     IncorrectFieldsArity {
         location: Span,
@@ -372,6 +375,9 @@ impl Diagnostic for Error {
             Self::DuplicateName { .. } => Some(Box::new("duplicate_name")),
             Self::DuplicateTypeName { .. } => Some(Box::new("duplicate_type_name")),
             Self::FunctionTypeInData { .. } => Some(Box::new("function_type_in_data")),
+            Self::ImplicityDiscardedExpression { .. } => {
+                Some(Box::new("implicitly_discarded_expr"))
+            }
             Self::IncorrectFieldsArity { .. } => Some(Box::new("incorrect_fields_arity")),
             Self::IncorrectFunctionCallArity { .. } => Some(Box::new("incorrect_fn_arity")),
             Self::IncorrectPatternArity { .. } => Some(Box::new("incorrect_pattern_arity")),
@@ -488,6 +494,7 @@ impl Diagnostic for Error {
 
             Self::FunctionTypeInData { .. } => Some(Box::new("Data types can't have functions in them due to how Plutus Data works.")),
 
+            Self::ImplicityDiscardedExpression { .. } => Some(Box::new("Everything is an expression and returns a value.\nTry assigning this expression to a variable.")),
             Self::IncorrectFieldsArity { .. } => None,
 
             Self::IncorrectFunctionCallArity { expected, .. } => Some(Box::new(formatdoc! {
@@ -1149,6 +1156,10 @@ impl Diagnostic for Error {
             Self::FunctionTypeInData { location } => Some(Box::new(
                 vec![LabeledSpan::new_with_span(None, *location)].into_iter(),
             )),
+
+            Self::ImplicityDiscardedExpression { location, .. } => Some(Box::new(
+                vec![LabeledSpan::new_with_span(None, *location)].into_iter(),
+            )),
             Self::IncorrectFieldsArity { location, .. } => Some(Box::new(
                 vec![LabeledSpan::new_with_span(None, *location)].into_iter(),
             )),
@@ -1282,6 +1293,7 @@ impl Diagnostic for Error {
             Self::DuplicateName { .. } => None,
             Self::DuplicateTypeName { .. } => None,
             Self::FunctionTypeInData { .. } => None,
+            Self::ImplicityDiscardedExpression { .. } => None,
             Self::IncorrectFieldsArity { .. } => Some(Box::new(
                 "https://aiken-lang.org/language-tour/custom-types",
             )),

--- a/crates/aiken-lang/src/tipo/expr.rs
+++ b/crates/aiken-lang/src/tipo/expr.rs
@@ -171,7 +171,7 @@ impl<'a, 'b> ExprTyper<'a, 'b> {
     /// Emit a warning if the given expressions should not be discarded.
     /// e.g. because it's a literal (why was it made in the first place?)
     /// e.g. because it's of the `Result` type (errors should be handled)
-    fn expression_discarded(&mut self, discarded: &TypedExpr) {
+    fn _expression_discarded(&mut self, discarded: &TypedExpr) {
         if discarded.is_literal() {
             self.environment.warnings.push(Warning::UnusedLiteral {
                 location: discarded.location(),
@@ -1684,9 +1684,16 @@ impl<'a, 'b> ExprTyper<'a, 'b> {
             let expression = self.infer(expression)?;
             // This isn't the final expression in the sequence, so call the
             // `expression_discarded` function to see if anything is being
-            // discarded that we think shouldn't be.
+            // discarded that we think shouldn't be. We also want to make sure
+            // that there are no implicitly discarded expressions
             if i < count - 1 {
-                self.expression_discarded(&expression);
+                // self.expression_discarded(&expression);
+
+                if !matches!(expression, TypedExpr::Assignment { .. }) {
+                    return Err(Error::ImplicityDiscardedExpression {
+                        location: expression.location(),
+                    });
+                }
             }
 
             expressions.push(expression);

--- a/crates/aiken/src/lib.rs
+++ b/crates/aiken/src/lib.rs
@@ -32,21 +32,29 @@ where
         warning.report()
     }
 
+    let plural = if warning_count == 1 { "" } else { "s" };
+
     if let Err(err) = build_result {
         err.report();
         println!("\n{}", "Summary".purple().bold());
-        println!(
-            "    {} error(s), {}",
-            err.len(),
-            format!("{warning_count} warning(s)").yellow(),
-        );
+
+        let warning_text = format!("{warning_count} warning{}", plural);
+
+        let plural = if err.len() == 1 { "" } else { "s" };
+
+        let error_text = format!("{} error{}", err.len(), plural);
+
+        let full_summary = format!("    {}, {}", error_text.red(), warning_text.yellow());
+
+        println!("{}", full_summary);
+
         process::exit(1);
     } else {
         println!("\n{}", "Summary".purple().bold());
-        println!(
-            "    0 error, {}",
-            format!("{warning_count} warning(s)").yellow(),
-        );
+
+        let warning_text = format!("{warning_count} warning{}", plural);
+
+        println!("    0 errors, {}", warning_text.yellow(),);
     }
     Ok(())
 }


### PR DESCRIPTION
closes #271 

Implicitly discarded expressions make no sense to allow

```
pub fn stuff() -> Int {
  do_other_stuff()
 
  1
}
```
<img width="877" alt="Screenshot 2023-01-16 at 2 51 44 PM" src="https://user-images.githubusercontent.com/12070598/212756735-f18a3fe2-f2cf-4697-aee8-6432449a28d4.png">

Currently the underlined area seems to be incorrect, will need to investigate that further

