### PR TITLE
Forbid assignment as last expression

### DIFF
--- a/crates/aiken-lang/src/format.rs
+++ b/crates/aiken-lang/src/format.rs
@@ -647,7 +647,7 @@ impl<'comments> Formatter<'comments> {
         }
     }
 
-    fn expr<'a>(&mut self, expr: &'a UntypedExpr) -> Document<'a> {
+    pub fn expr<'a>(&mut self, expr: &'a UntypedExpr) -> Document<'a> {
         let comments = self.pop_comments(expr.start_byte_index());
 
         let document = match expr {

--- a/crates/aiken-lang/src/tipo/error.rs
+++ b/crates/aiken-lang/src/tipo/error.rs
@@ -494,7 +494,12 @@ impl Diagnostic for Error {
 
             Self::FunctionTypeInData { .. } => Some(Box::new("Data types can't have functions in them due to how Plutus Data works.")),
 
-            Self::ImplicityDiscardedExpression { .. } => Some(Box::new("Everything is an expression and returns a value.\nTry assigning this expression to a variable.")),
+            Self::ImplicityDiscardedExpression { .. } => Some(Box::new(formatdoc! {
+                r#"A function can contain a sequence of expressions. However, any expression but the last one must be assign to a variable using the {let_keyword} keyword. If you really wish to discard an expression that is unused, you can prefix its name with '{discard}'.
+                "#
+                , let_keyword = "let".yellow()
+                , discard = "_".yellow()
+            })),
             Self::IncorrectFieldsArity { .. } => None,
 
             Self::IncorrectFunctionCallArity { expected, .. } => Some(Box::new(formatdoc! {

--- a/crates/aiken-lang/src/tipo/error.rs
+++ b/crates/aiken-lang/src/tipo/error.rs
@@ -51,7 +51,7 @@ pub enum Error {
     FunctionTypeInData { location: Span },
 
     #[error("I found a discarded expression not bound to a variable.")]
-    ImplicityDiscardedExpression { location: Span },
+    ImplicitlyDiscardedExpression { location: Span },
 
     #[error("I saw a {} fields in a context where there should be {}.\n", given.purple(), expected.purple())]
     IncorrectFieldsArity {
@@ -375,7 +375,7 @@ impl Diagnostic for Error {
             Self::DuplicateName { .. } => Some(Box::new("duplicate_name")),
             Self::DuplicateTypeName { .. } => Some(Box::new("duplicate_type_name")),
             Self::FunctionTypeInData { .. } => Some(Box::new("function_type_in_data")),
-            Self::ImplicityDiscardedExpression { .. } => {
+            Self::ImplicitlyDiscardedExpression { .. } => {
                 Some(Box::new("implicitly_discarded_expr"))
             }
             Self::IncorrectFieldsArity { .. } => Some(Box::new("incorrect_fields_arity")),
@@ -494,7 +494,7 @@ impl Diagnostic for Error {
 
             Self::FunctionTypeInData { .. } => Some(Box::new("Data types can't have functions in them due to how Plutus Data works.")),
 
-            Self::ImplicityDiscardedExpression { .. } => Some(Box::new(formatdoc! {
+            Self::ImplicitlyDiscardedExpression { .. } => Some(Box::new(formatdoc! {
                 r#"A function can contain a sequence of expressions. However, any expression but the last one must be assign to a variable using the {let_keyword} keyword. If you really wish to discard an expression that is unused, you can prefix its name with '{discard}'.
                 "#
                 , let_keyword = "let".yellow()
@@ -1162,7 +1162,7 @@ impl Diagnostic for Error {
                 vec![LabeledSpan::new_with_span(None, *location)].into_iter(),
             )),
 
-            Self::ImplicityDiscardedExpression { location, .. } => Some(Box::new(
+            Self::ImplicitlyDiscardedExpression { location, .. } => Some(Box::new(
                 vec![LabeledSpan::new_with_span(None, *location)].into_iter(),
             )),
             Self::IncorrectFieldsArity { location, .. } => Some(Box::new(
@@ -1298,7 +1298,7 @@ impl Diagnostic for Error {
             Self::DuplicateName { .. } => None,
             Self::DuplicateTypeName { .. } => None,
             Self::FunctionTypeInData { .. } => None,
-            Self::ImplicityDiscardedExpression { .. } => None,
+            Self::ImplicitlyDiscardedExpression { .. } => None,
             Self::IncorrectFieldsArity { .. } => Some(Box::new(
                 "https://aiken-lang.org/language-tour/custom-types",
             )),

--- a/crates/aiken-lang/src/tipo/expr.rs
+++ b/crates/aiken-lang/src/tipo/expr.rs
@@ -193,7 +193,7 @@ impl<'a, 'b> ExprTyper<'a, 'b> {
 
     fn assert_assignment(&self, expr: &TypedExpr) -> Result<(), Error> {
         if !matches!(*expr, TypedExpr::Assignment { .. }) {
-            return Err(Error::ImplicityDiscardedExpression {
+            return Err(Error::ImplicitlyDiscardedExpression {
                 location: expr.location(),
             });
         }


### PR DESCRIPTION
- :round_pushpin: **Remove dead-code and fix comment about discarded expressions**
    While Gleam originally allowed various kinds of expressions to be discarded in a sequence, we simply do not allow expressions to be discarded implicitly. So any non-final expression in a sequence must be a let-binding. This prevents silly mistakes.

- :round_pushpin: **slightly rework hint for 'ImpliclyDiscardedExpression'**
  
- :round_pushpin: **Fix typo in variant name: Implicity -> Implicitly**
  
- :round_pushpin: **Forbid let-binding as last expression of a sequence**
    Fixes #283

<img width="736" alt="Screenshot 2023-01-19 at 18 04 02" src="https://user-images.githubusercontent.com/5680256/213517454-63ac7ca1-7a7f-44c1-81ab-877dd542cad8.png">