### PR TITLE
Windows capture carriage return properly

### DIFF
--- a/crates/aiken-lang/src/parser/lexer.rs
+++ b/crates/aiken-lang/src/parser/lexer.rs
@@ -52,8 +52,8 @@ pub fn lexer() -> impl Parser<char, Vec<(Token, Span)>, Error = ParseError> {
         just('|').to(Token::Vbar),
         just("&&").to(Token::AmperAmper),
         just('#').to(Token::Hash),
-        just("\n\n").to(Token::EmptyLine),
-        just("\n").to(Token::NewLine),
+        choice((just("\n\n"), just("\r\n\r\n"))).to(Token::EmptyLine),
+        choice((just("\n"), just("\r\n"))).to(Token::NewLine),
     ));
 
     let grouping = choice((

--- a/crates/aiken-lang/src/tests/parser.rs
+++ b/crates/aiken-lang/src/tests/parser.rs
@@ -23,6 +23,22 @@ fn assert_definitions(code: &str, definitions: Vec<ast::UntypedDefinition>) {
 }
 
 #[test]
+fn windows_newline() {
+    let code = "use aiken/list\r\n";
+
+    assert_definitions(
+        code,
+        vec![ast::UntypedDefinition::Use(Use {
+            location: Span::new((), 0..14),
+            module: vec!["aiken".to_string(), "list".to_string()],
+            as_name: None,
+            unqualified: vec![],
+            package: (),
+        })],
+    )
+}
+
+#[test]
 fn import() {
     let code = indoc! {r#"
         use std/list


### PR DESCRIPTION
closes #309 

* This should fix the parser issues on windows
  * `\r\n` needed to be captured as a NewLine
  * `\r\n\r\n` needed to be captured as an empty line
* I do not have access to a windows machine to test this