### PR TITLE
Assert data type to type cast

### DIFF
--- a/crates/aiken-lang/src/air.rs
+++ b/crates/aiken-lang/src/air.rs
@@ -98,12 +98,21 @@ pub enum Air {
     // Assignment
     Assert {
         scope: Vec<u64>,
-        constr_index: usize,
+        tipo: Arc<Type>,
+        value_is_data: bool,
     },
 
     Let {
         scope: Vec<u64>,
         name: String,
+    },
+
+    ListAssert {
+        scope: Vec<u64>,
+        tipo: Arc<Type>,
+        names: Vec<String>,
+        tail: bool,
+        value_is_data: bool,
     },
 
     // When
@@ -260,6 +269,7 @@ impl Air {
             | Air::BinOp { scope, .. }
             | Air::UnOp { scope, .. }
             | Air::Assert { scope, .. }
+            | Air::ListAssert { scope, .. }
             | Air::Let { scope, .. }
             | Air::When { scope, .. }
             | Air::Clause { scope, .. }
@@ -338,6 +348,8 @@ impl Air {
             | Air::Call { tipo, .. }
             | Air::Builtin { tipo, .. }
             | Air::BinOp { tipo, .. }
+            | Air::Assert { tipo, .. }
+            | Air::ListAssert { tipo, .. }
             | Air::When { tipo, .. }
             | Air::Clause { tipo, .. }
             | Air::ListClause { tipo, .. }
@@ -358,7 +370,6 @@ impl Air {
 
             Air::DefineFunc { .. }
             | Air::Fn { .. }
-            | Air::Assert { .. }
             | Air::Let { .. }
             | Air::WrapClause { .. }
             | Air::Finally { .. }

--- a/crates/aiken-lang/src/air.rs
+++ b/crates/aiken-lang/src/air.rs
@@ -107,6 +107,11 @@ pub enum Air {
         name: String,
     },
 
+    UnWrapData {
+        scope: Vec<u64>,
+        tipo: Arc<Type>,
+    },
+
     ListAssert {
         scope: Vec<u64>,
         tipo: Arc<Type>,
@@ -271,6 +276,7 @@ impl Air {
             | Air::Assert { scope, .. }
             | Air::ListAssert { scope, .. }
             | Air::Let { scope, .. }
+            | Air::UnWrapData { scope, .. }
             | Air::When { scope, .. }
             | Air::Clause { scope, .. }
             | Air::ListClause { scope, .. }
@@ -350,6 +356,7 @@ impl Air {
             | Air::BinOp { tipo, .. }
             | Air::Assert { tipo, .. }
             | Air::ListAssert { tipo, .. }
+            | Air::UnWrapData { tipo, .. }
             | Air::When { tipo, .. }
             | Air::Clause { tipo, .. }
             | Air::ListClause { tipo, .. }

--- a/crates/aiken-lang/src/air.rs
+++ b/crates/aiken-lang/src/air.rs
@@ -10,6 +10,7 @@ use crate::{
 
 #[derive(Debug, Clone)]
 pub enum Air {
+    // Primitives
     Int {
         scope: Vec<u64>,
         value: String,
@@ -30,17 +31,6 @@ pub enum Air {
         value: bool,
     },
 
-    Var {
-        scope: Vec<u64>,
-        constructor: ValueConstructor,
-        name: String,
-        variant_name: String,
-    },
-
-    Fn {
-        scope: Vec<u64>,
-        params: Vec<String>,
-    },
     List {
         scope: Vec<u64>,
         count: usize,
@@ -48,46 +38,28 @@ pub enum Air {
         tail: bool,
     },
 
-    ListAccessor {
+    Tuple {
         scope: Vec<u64>,
         tipo: Arc<Type>,
-        names: Vec<String>,
-        tail: bool,
+        count: usize,
     },
 
-    ListExpose {
+    Void {
         scope: Vec<u64>,
-        tipo: Arc<Type>,
-        tail_head_names: Vec<(String, String)>,
-        tail: Option<(String, String)>,
     },
 
+    Var {
+        scope: Vec<u64>,
+        constructor: ValueConstructor,
+        name: String,
+        variant_name: String,
+    },
+
+    // Functions
     Call {
         scope: Vec<u64>,
         count: usize,
-    },
-
-    Builtin {
-        scope: Vec<u64>,
-        func: DefaultFunction,
         tipo: Arc<Type>,
-    },
-
-    BinOp {
-        scope: Vec<u64>,
-        name: BinOp,
-        count: usize,
-        tipo: Arc<Type>,
-    },
-
-    Assignment {
-        scope: Vec<u64>,
-        name: String,
-    },
-
-    Assert {
-        scope: Vec<u64>,
-        constr_index: usize,
     },
 
     DefineFunc {
@@ -99,11 +71,42 @@ pub enum Air {
         variant_name: String,
     },
 
-    Lam {
+    Fn {
+        scope: Vec<u64>,
+        params: Vec<String>,
+    },
+
+    Builtin {
+        scope: Vec<u64>,
+        func: DefaultFunction,
+        tipo: Arc<Type>,
+    },
+
+    // Operators
+    BinOp {
+        scope: Vec<u64>,
+        name: BinOp,
+        count: usize,
+        tipo: Arc<Type>,
+    },
+
+    UnOp {
+        scope: Vec<u64>,
+        op: UnOp,
+    },
+
+    // Assignment
+    Assert {
+        scope: Vec<u64>,
+        constr_index: usize,
+    },
+
+    Let {
         scope: Vec<u64>,
         name: String,
     },
 
+    // When
     When {
         scope: Vec<u64>,
         tipo: Arc<Type>,
@@ -153,18 +156,17 @@ pub enum Air {
         inverse: bool,
     },
 
-    Discard {
-        scope: Vec<u64>,
-    },
-
     Finally {
         scope: Vec<u64>,
     },
 
+    // If
     If {
         scope: Vec<u64>,
+        tipo: Arc<Type>,
     },
 
+    // Record Creation
     Record {
         scope: Vec<u64>,
         constr_index: usize,
@@ -172,6 +174,14 @@ pub enum Air {
         count: usize,
     },
 
+    RecordUpdate {
+        scope: Vec<u64>,
+        highest_index: usize,
+        indices: Vec<(usize, Arc<Type>)>,
+        tipo: Arc<Type>,
+    },
+
+    // Field Access
     RecordAccess {
         scope: Vec<u64>,
         record_index: u64,
@@ -184,10 +194,26 @@ pub enum Air {
         indices: Vec<(usize, String, Arc<Type>)>,
     },
 
-    Tuple {
+    // ListAccess
+    ListAccessor {
         scope: Vec<u64>,
         tipo: Arc<Type>,
-        count: usize,
+        names: Vec<String>,
+        tail: bool,
+    },
+
+    ListExpose {
+        scope: Vec<u64>,
+        tipo: Arc<Type>,
+        tail_head_names: Vec<(String, String)>,
+        tail: Option<(String, String)>,
+    },
+
+    // Tuple Access
+    TupleAccessor {
+        scope: Vec<u64>,
+        names: Vec<String>,
+        tipo: Arc<Type>,
     },
 
     TupleIndex {
@@ -196,6 +222,7 @@ pub enum Air {
         tuple_index: usize,
     },
 
+    // Misc.
     Todo {
         scope: Vec<u64>,
         label: Option<String>,
@@ -213,23 +240,6 @@ pub enum Air {
         text: Option<String>,
         tipo: Arc<Type>,
     },
-
-    RecordUpdate {
-        scope: Vec<u64>,
-        highest_index: usize,
-        indices: Vec<(usize, Arc<Type>)>,
-    },
-
-    UnOp {
-        scope: Vec<u64>,
-        op: UnOp,
-    },
-
-    TupleAccessor {
-        scope: Vec<u64>,
-        names: Vec<String>,
-        tipo: Arc<Type>,
-    },
 }
 
 impl Air {
@@ -239,47 +249,93 @@ impl Air {
             | Air::String { scope, .. }
             | Air::ByteArray { scope, .. }
             | Air::Bool { scope, .. }
-            | Air::Var { scope, .. }
             | Air::List { scope, .. }
-            | Air::ListAccessor { scope, .. }
-            | Air::ListExpose { scope, .. }
-            | Air::Fn { scope, .. }
+            | Air::Tuple { scope, .. }
+            | Air::Void { scope }
+            | Air::Var { scope, .. }
             | Air::Call { scope, .. }
+            | Air::DefineFunc { scope, .. }
+            | Air::Fn { scope, .. }
             | Air::Builtin { scope, .. }
             | Air::BinOp { scope, .. }
-            | Air::Assignment { scope, .. }
+            | Air::UnOp { scope, .. }
             | Air::Assert { scope, .. }
-            | Air::DefineFunc { scope, .. }
-            | Air::Lam { scope, .. }
+            | Air::Let { scope, .. }
             | Air::When { scope, .. }
             | Air::Clause { scope, .. }
             | Air::ListClause { scope, .. }
-            | Air::TupleClause { scope, .. }
             | Air::WrapClause { scope }
+            | Air::TupleClause { scope, .. }
             | Air::ClauseGuard { scope, .. }
             | Air::ListClauseGuard { scope, .. }
-            | Air::Discard { scope }
             | Air::Finally { scope }
             | Air::If { scope, .. }
             | Air::Record { scope, .. }
+            | Air::RecordUpdate { scope, .. }
             | Air::RecordAccess { scope, .. }
             | Air::FieldsExpose { scope, .. }
-            | Air::Tuple { scope, .. }
+            | Air::ListAccessor { scope, .. }
+            | Air::ListExpose { scope, .. }
+            | Air::TupleAccessor { scope, .. }
+            | Air::TupleIndex { scope, .. }
             | Air::Todo { scope, .. }
             | Air::ErrorTerm { scope, .. }
-            | Air::RecordUpdate { scope, .. }
-            | Air::UnOp { scope, .. }
-            | Air::Trace { scope, .. }
-            | Air::TupleAccessor { scope, .. }
-            | Air::TupleIndex { scope, .. } => scope.to_vec(),
+            | Air::Trace { scope, .. } => scope.clone(),
         }
     }
 
     pub fn tipo(&self) -> Option<Arc<Type>> {
         match self {
+            Air::Int { .. } => Some(
+                Type::App {
+                    public: true,
+                    module: String::new(),
+                    name: "Int".to_string(),
+                    args: vec![],
+                }
+                .into(),
+            ),
+            Air::String { .. } => Some(
+                Type::App {
+                    public: true,
+                    module: String::new(),
+                    name: "String".to_string(),
+                    args: vec![],
+                }
+                .into(),
+            ),
+            Air::ByteArray { .. } => Some(
+                Type::App {
+                    public: true,
+                    module: String::new(),
+                    name: "ByteArray".to_string(),
+                    args: vec![],
+                }
+                .into(),
+            ),
+            Air::Bool { .. } => Some(
+                Type::App {
+                    public: true,
+                    module: String::new(),
+                    name: "Bool".to_string(),
+                    args: vec![],
+                }
+                .into(),
+            ),
+            Air::Void { .. } => Some(
+                Type::App {
+                    public: true,
+                    module: String::new(),
+                    name: "Void".to_string(),
+                    args: vec![],
+                }
+                .into(),
+            ),
+            Air::Var { constructor, .. } => Some(constructor.tipo.clone()),
+
             Air::List { tipo, .. }
-            | Air::ListAccessor { tipo, .. }
-            | Air::ListExpose { tipo, .. }
+            | Air::Tuple { tipo, .. }
+            | Air::Call { tipo, .. }
             | Air::Builtin { tipo, .. }
             | Air::BinOp { tipo, .. }
             | Air::When { tipo, .. }
@@ -287,20 +343,47 @@ impl Air {
             | Air::ListClause { tipo, .. }
             | Air::TupleClause { tipo, .. }
             | Air::ClauseGuard { tipo, .. }
+            | Air::If { tipo, .. }
             | Air::ListClauseGuard { tipo, .. }
             | Air::Record { tipo, .. }
+            | Air::RecordUpdate { tipo, .. }
             | Air::RecordAccess { tipo, .. }
-            | Air::Tuple { tipo, .. }
+            | Air::ListAccessor { tipo, .. }
+            | Air::ListExpose { tipo, .. }
+            | Air::TupleAccessor { tipo, .. }
             | Air::TupleIndex { tipo, .. }
             | Air::Todo { tipo, .. }
             | Air::ErrorTerm { tipo, .. }
-            | Air::Trace { tipo, .. }
-            | Air::TupleAccessor { tipo, .. }
-            | Air::Var {
-                constructor: ValueConstructor { tipo, .. },
-                ..
-            } => Some(tipo.clone()),
-            _ => None,
+            | Air::Trace { tipo, .. } => Some(tipo.clone()),
+
+            Air::DefineFunc { .. }
+            | Air::Fn { .. }
+            | Air::Assert { .. }
+            | Air::Let { .. }
+            | Air::WrapClause { .. }
+            | Air::Finally { .. }
+            | Air::FieldsExpose { .. } => None,
+
+            Air::UnOp { op, .. } => match op {
+                UnOp::Not => Some(
+                    Type::App {
+                        public: true,
+                        module: String::new(),
+                        name: "Bool".to_string(),
+                        args: vec![],
+                    }
+                    .into(),
+                ),
+                UnOp::Negate => Some(
+                    Type::App {
+                        public: true,
+                        module: String::new(),
+                        name: "Int".to_string(),
+                        args: vec![],
+                    }
+                    .into(),
+                ),
+            },
         }
     }
 }

--- a/crates/aiken-lang/src/air.rs
+++ b/crates/aiken-lang/src/air.rs
@@ -96,12 +96,6 @@ pub enum Air {
     },
 
     // Assignment
-    Assert {
-        scope: Vec<u64>,
-        tipo: Arc<Type>,
-        value_is_data: bool,
-    },
-
     Let {
         scope: Vec<u64>,
         name: String,
@@ -110,14 +104,6 @@ pub enum Air {
     UnWrapData {
         scope: Vec<u64>,
         tipo: Arc<Type>,
-    },
-
-    ListAssert {
-        scope: Vec<u64>,
-        tipo: Arc<Type>,
-        names: Vec<String>,
-        tail: bool,
-        value_is_data: bool,
     },
 
     // When
@@ -275,8 +261,6 @@ impl Air {
             | Air::Builtin { scope, .. }
             | Air::BinOp { scope, .. }
             | Air::UnOp { scope, .. }
-            | Air::Assert { scope, .. }
-            | Air::ListAssert { scope, .. }
             | Air::Let { scope, .. }
             | Air::UnWrapData { scope, .. }
             | Air::When { scope, .. }
@@ -356,8 +340,6 @@ impl Air {
             | Air::Call { tipo, .. }
             | Air::Builtin { tipo, .. }
             | Air::BinOp { tipo, .. }
-            | Air::Assert { tipo, .. }
-            | Air::ListAssert { tipo, .. }
             | Air::UnWrapData { tipo, .. }
             | Air::When { tipo, .. }
             | Air::Clause { tipo, .. }

--- a/crates/aiken-lang/src/air.rs
+++ b/crates/aiken-lang/src/air.rs
@@ -204,8 +204,8 @@ pub enum Air {
 
     FieldsExpose {
         scope: Vec<u64>,
-        count: usize,
         indices: Vec<(usize, String, Arc<Type>)>,
+        check_last_item: bool,
     },
 
     // ListAccess
@@ -214,6 +214,7 @@ pub enum Air {
         tipo: Arc<Type>,
         names: Vec<String>,
         tail: bool,
+        check_last_item: bool,
     },
 
     ListExpose {
@@ -228,6 +229,7 @@ pub enum Air {
         scope: Vec<u64>,
         names: Vec<String>,
         tipo: Arc<Type>,
+        check_last_item: bool,
     },
 
     TupleIndex {

--- a/crates/aiken-lang/src/air.rs
+++ b/crates/aiken-lang/src/air.rs
@@ -334,7 +334,6 @@ impl Air {
                 .into(),
             ),
             Air::Var { constructor, .. } => Some(constructor.tipo.clone()),
-
             Air::List { tipo, .. }
             | Air::Tuple { tipo, .. }
             | Air::Call { tipo, .. }

--- a/crates/aiken-lang/src/air.rs
+++ b/crates/aiken-lang/src/air.rs
@@ -106,6 +106,11 @@ pub enum Air {
         tipo: Arc<Type>,
     },
 
+    AssertConstr {
+        scope: Vec<u64>,
+        constr_index: usize,
+    },
+
     // When
     When {
         scope: Vec<u64>,
@@ -263,6 +268,7 @@ impl Air {
             | Air::UnOp { scope, .. }
             | Air::Let { scope, .. }
             | Air::UnWrapData { scope, .. }
+            | Air::AssertConstr { scope, .. }
             | Air::When { scope, .. }
             | Air::Clause { scope, .. }
             | Air::ListClause { scope, .. }
@@ -362,6 +368,7 @@ impl Air {
             | Air::Fn { .. }
             | Air::Let { .. }
             | Air::WrapClause { .. }
+            | Air::AssertConstr { .. }
             | Air::Finally { .. }
             | Air::FieldsExpose { .. } => None,
 

--- a/crates/aiken-lang/src/builder.rs
+++ b/crates/aiken-lang/src/builder.rs
@@ -1673,3 +1673,5 @@ pub fn replace_opaque_type(t: &mut Arc<Type>, data_types: IndexMap<DataTypeKey, 
         }
     }
 }
+
+pub fn recursive_assert(tipo: &Type, assert_vec: &mut Vec<Air>) {}

--- a/crates/aiken-lang/src/tipo.rs
+++ b/crates/aiken-lang/src/tipo.rs
@@ -213,6 +213,7 @@ impl Type {
         match self {
             Self::Fn { args, .. } => Some(args.clone()),
             Self::App { args, .. } => Some(args.clone()),
+            Self::Var { tipo } => tipo.borrow().arg_types(),
             _ => None,
         }
     }
@@ -494,6 +495,13 @@ impl TypeVar {
         match self {
             TypeVar::Generic { id } => Some(*id),
             TypeVar::Link { tipo } => tipo.get_generic(),
+            _ => None,
+        }
+    }
+
+    pub fn arg_types(&self) -> Option<Vec<Arc<Type>>> {
+        match self {
+            Self::Link { tipo } => tipo.arg_types(),
             _ => None,
         }
     }

--- a/crates/aiken-lang/src/tipo.rs
+++ b/crates/aiken-lang/src/tipo.rs
@@ -173,6 +173,14 @@ impl Type {
         }
     }
 
+    pub fn is_data(&self) -> bool {
+        match self {
+            Self::App { module, name, .. } => "Data" == name && module.is_empty(),
+            Self::Var { tipo } => tipo.borrow().is_data(),
+            _ => false,
+        }
+    }
+
     pub fn is_generic(&self) -> bool {
         match self {
             Type::App { args, .. } => {
@@ -463,6 +471,13 @@ impl TypeVar {
     pub fn is_tuple(&self) -> bool {
         match self {
             Self::Link { tipo } => tipo.is_tuple(),
+            _ => false,
+        }
+    }
+
+    pub fn is_data(&self) -> bool {
+        match self {
+            Self::Link { tipo } => tipo.is_data(),
             _ => false,
         }
     }

--- a/crates/aiken-lang/src/tipo/error.rs
+++ b/crates/aiken-lang/src/tipo/error.rs
@@ -724,6 +724,15 @@ The best thing to do from here is to remove it."#))]
         location: Span,
         name: String,
     },
+
+    #[error("I discovered a type cast from Data without an annotation")]
+    #[diagnostic(code("illegal::type_cast"))]
+    #[diagnostic(help("Try adding an annotation...\n\n{}", format_suggestion(value)))]
+    CastDataNoAnn {
+        #[label]
+        location: Span,
+        value: UntypedExpr,
+    },
 }
 
 impl Error {

--- a/crates/aiken-lang/src/tipo/expr.rs
+++ b/crates/aiken-lang/src/tipo/expr.rs
@@ -807,8 +807,8 @@ impl<'a, 'b> ExprTyper<'a, 'b> {
         annotation: &Option<Annotation>,
         location: Span,
     ) -> Result<TypedExpr, Error> {
-        let value = self.in_new_scope(|value_typer| value_typer.infer(value))?;
-        let mut value_typ = value.tipo();
+        let typed_value = self.in_new_scope(|value_typer| value_typer.infer(value.clone()))?;
+        let mut value_typ = typed_value.tipo();
 
         // Check that any type annotation is accurate.
         let pattern = if let Some(ann) = annotation {
@@ -819,7 +819,7 @@ impl<'a, 'b> ExprTyper<'a, 'b> {
             self.unify(
                 ann_typ.clone(),
                 value_typ.clone(),
-                value.type_defining_location(),
+                typed_value.type_defining_location(),
             )?;
 
             value_typ = ann_typ.clone();
@@ -831,6 +831,24 @@ impl<'a, 'b> ExprTyper<'a, 'b> {
                 Some(ann_typ),
             )?
         } else {
+            if value_typ.is_data() {
+                return Err(Error::CastDataNoAnn {
+                    location,
+                    value: UntypedExpr::Assignment {
+                        location,
+                        value: value.into(),
+                        pattern,
+                        kind,
+                        annotation: Some(Annotation::Constructor {
+                            location: Span::empty(),
+                            module: None,
+                            name: "Type".to_string(),
+                            arguments: vec![],
+                        }),
+                    },
+                });
+            }
+
             // Ensure the pattern matches the type of the value
             PatternTyper::new(self.environment, &self.hydrator).unify(
                 pattern,
@@ -860,7 +878,7 @@ impl<'a, 'b> ExprTyper<'a, 'b> {
             tipo: value_typ,
             kind,
             pattern,
-            value: Box::new(value),
+            value: Box::new(typed_value),
         })
     }
 

--- a/crates/aiken-lang/src/uplc.rs
+++ b/crates/aiken-lang/src/uplc.rs
@@ -307,6 +307,10 @@ impl<'a> CodeGenerator<'a> {
                 // assuming one subject at the moment
                 let subject = subjects[0].clone();
 
+                if clauses.len() <= 1 {
+                    todo!("Single clause cases not implemented")
+                }
+
                 let clauses = if matches!(clauses[0].pattern[0], Pattern::List { .. }) {
                     rearrange_clauses(clauses.clone())
                 } else {

--- a/crates/uplc/src/ast/builder.rs
+++ b/crates/uplc/src/ast/builder.rs
@@ -5,6 +5,7 @@ use super::{Constant, Name, Term};
 pub const CONSTR_FIELDS_EXPOSER: &str = "__constr_fields_exposer";
 pub const CONSTR_INDEX_EXPOSER: &str = "__constr_index_exposer";
 pub const CONSTR_GET_FIELD: &str = "__constr_get_field";
+pub const ASSERT_ON_LIST: &str = "__assert_on_list";
 
 pub fn apply_wrap(function: Term<Name>, arg: Term<Name>) -> Term<Name> {
     Term::Apply {
@@ -28,6 +29,108 @@ pub fn final_wrapper(term: Term<Name>) -> Term<Name> {
             argument: Term::Delay(Term::Error.into()).into(),
         }
         .into(),
+    )
+}
+
+pub fn assert_on_list(term: Term<Name>) -> Term<Name> {
+    apply_wrap(
+        Term::Lambda {
+            parameter_name: Name {
+                text: ASSERT_ON_LIST.to_string(),
+                unique: 0.into(),
+            },
+            body: apply_wrap(
+                Term::Lambda {
+                    parameter_name: Name {
+                        text: ASSERT_ON_LIST.to_string(),
+                        unique: 0.into(),
+                    },
+                    body: term.into(),
+                },
+                apply_wrap(
+                    Term::Var(Name {
+                        text: ASSERT_ON_LIST.to_string(),
+                        unique: 0.into(),
+                    }),
+                    Term::Var(Name {
+                        text: ASSERT_ON_LIST.to_string(),
+                        unique: 0.into(),
+                    }),
+                ),
+            )
+            .into(),
+        },
+        Term::Lambda {
+            parameter_name: Name {
+                text: ASSERT_ON_LIST.to_string(),
+                unique: 0.into(),
+            },
+            body: Term::Lambda {
+                parameter_name: Name {
+                    text: "list_to_check".to_string(),
+                    unique: 0.into(),
+                },
+                body: Term::Lambda {
+                    parameter_name: Name {
+                        text: "check_with".to_string(),
+                        unique: 0.into(),
+                    },
+                    body: delayed_choose_list(
+                        Term::Var(Name {
+                            text: "list_to_check".to_string(),
+                            unique: 0.into(),
+                        }),
+                        Term::Constant(Constant::Unit),
+                        apply_wrap(
+                            apply_wrap(
+                                Term::Builtin(DefaultFunction::ChooseUnit).force_wrap(),
+                                apply_wrap(
+                                    Term::Var(Name {
+                                        text: "check_with".to_string(),
+                                        unique: 0.into(),
+                                    }),
+                                    apply_wrap(
+                                        Term::Builtin(DefaultFunction::HeadList).force_wrap(),
+                                        Term::Var(Name {
+                                            text: "list_to_check".to_string(),
+                                            unique: 0.into(),
+                                        }),
+                                    ),
+                                ),
+                            ),
+                            apply_wrap(
+                                apply_wrap(
+                                    apply_wrap(
+                                        Term::Var(Name {
+                                            text: ASSERT_ON_LIST.to_string(),
+                                            unique: 0.into(),
+                                        }),
+                                        Term::Var(Name {
+                                            text: ASSERT_ON_LIST.to_string(),
+                                            unique: 0.into(),
+                                        }),
+                                    ),
+                                    apply_wrap(
+                                        Term::Builtin(DefaultFunction::TailList).force_wrap(),
+                                        Term::Var(Name {
+                                            text: "list_to_check".to_string(),
+                                            unique: 0.into(),
+                                        }),
+                                    ),
+                                ),
+                                Term::Var(Name {
+                                    text: "check_with".to_string(),
+                                    unique: 0.into(),
+                                }),
+                            ),
+                        ),
+                    )
+                    .into(),
+                }
+                .into(),
+            }
+            .into(),
+        },
     )
 }
 

--- a/crates/uplc/src/machine.rs
+++ b/crates/uplc/src/machine.rs
@@ -343,7 +343,7 @@ impl Machine {
                     Err(Error::UnexpectedBuiltinTermArgument(t.as_ref().clone()))
                 }
             }
-            rest => Err(Error::NonFunctionalApplication(rest)),
+            rest => Err(Error::NonFunctionalApplication(rest, argument)),
         }
     }
 

--- a/crates/uplc/src/machine/error.rs
+++ b/crates/uplc/src/machine/error.rs
@@ -16,8 +16,8 @@ pub enum Error {
     EvaluationFailure,
     #[error("Attempted to instantiate a non-polymorphic term:\n\n{0:#?}")]
     NonPolymorphicInstantiation(Value),
-    #[error("Attempted to apply a non-function:\n\n{0:#?}")]
-    NonFunctionalApplication(Value),
+    #[error("Attempted to apply a non-function:\n\n{0:#?} to argument:\n\n{1:#?}")]
+    NonFunctionalApplication(Value, Value),
     #[error("Type mismatch expected '{0}' got '{1}'")]
     TypeMismatch(Type, Type),
     #[error("Type mismatch expected '(list a)' got '{0}'")]

--- a/examples/acceptance_tests/040/lib/tests.ak
+++ b/examples/acceptance_tests/040/lib/tests.ak
@@ -1,3 +1,9 @@
+pub type Door{
+  angle: Int,
+  locked: Bool
+}
+
+
 pub type Car {
   Honda { remote_connect: ByteArray, owner: ByteArray, wheels: Int }
   Ford {
@@ -5,18 +11,19 @@ pub type Car {
     owner: ByteArray,
     wheels: Int,
     truck_bed_limit: Int,
+    car_doors: List<Door>
   }
 }
 
 // test update_owner2_should_fail(){
-//   let initial_car: Data = Ford{remote_connect: #[], owner: #[], wheels: 4, truck_bed_limit: 10000}
+//   let initial_car: Data = Ford{remote_connect: #[], owner: #[], wheels: 4, truck_bed_limit: 10000, car_doors: []}
 //   assert Honda{ owner, ..}: Car = initial_car
 //   owner == #[]
 // }
 
 test update_owner1() {
   let initial_car: Data =
-    Ford { remote_connect: #[], owner: #[], wheels: 4, truck_bed_limit: 10000 }
+    Ford { remote_connect: #[], owner: #[], wheels: 4, truck_bed_limit: 10000, car_doors: [] }
   assert Ford { owner, .. }: Car = initial_car
   owner == #[]
 }

--- a/examples/acceptance_tests/040/lib/tests.ak
+++ b/examples/acceptance_tests/040/lib/tests.ak
@@ -10,13 +10,13 @@ pub type Car {
 
 // test update_owner2_should_fail(){
 //   let initial_car: Data = Ford{remote_connect: #[], owner: #[], wheels: 4, truck_bed_limit: 10000}
-//   assert Honda{ owner, ..} = initial_car
+//   assert Honda{ owner, ..}: Car = initial_car
 //   owner == #[]
 // }
 
 test update_owner1() {
   let initial_car: Data =
     Ford { remote_connect: #[], owner: #[], wheels: 4, truck_bed_limit: 10000 }
-  assert Ford { owner, .. } = initial_car
+  assert Ford { owner, .. }: Car = initial_car
   owner == #[]
 }


### PR DESCRIPTION
- Minor fix to head list in function list_access_to_uplc
- Assert is fleshed out to recursively check a type cast
- Clean up unused Air and categorically order Air
- Refactoring to reduce code reusage
- Safe guard against type casting without a left hand type annotation
- Found a great use case for choose_unit :P
- Added handling of single clause when for acceptance test 48