### PR TITLE
remove check assignment

### DIFF
--- a/crates/aiken-lang/src/ast.rs
+++ b/crates/aiken-lang/src/ast.rs
@@ -769,7 +769,6 @@ impl<A, B> Pattern<A, B> {
 pub enum AssignmentKind {
     Let,
     Assert,
-    Check,
 }
 
 pub type MultiPattern<PatternConstructor, Type> = Vec<Pattern<PatternConstructor, Type>>;

--- a/crates/aiken-lang/src/format.rs
+++ b/crates/aiken-lang/src/format.rs
@@ -607,7 +607,6 @@ impl<'comments> Formatter<'comments> {
         let keyword = match kind {
             Some(AssignmentKind::Let) => "let ",
             Some(AssignmentKind::Assert) => "assert ",
-            Some(AssignmentKind::Check) => "check ",
             None => "try ",
         };
 

--- a/crates/aiken-lang/src/parser.rs
+++ b/crates/aiken-lang/src/parser.rs
@@ -1043,21 +1043,6 @@ pub fn expr_parser(
                 },
             );
 
-        let check_parser = just(Token::Check)
-            .ignore_then(pattern_parser())
-            .then(just(Token::Colon).ignore_then(type_parser()).or_not())
-            .then_ignore(just(Token::Equal))
-            .then(r.clone())
-            .map_with_span(
-                |((pattern, annotation), value), span| expr::UntypedExpr::Assignment {
-                    location: span,
-                    value: Box::new(value),
-                    pattern,
-                    kind: ast::AssignmentKind::Check,
-                    annotation,
-                },
-            );
-
         let if_parser = just(Token::If)
             .ignore_then(r.clone().then(block_parser.clone()).map_with_span(
                 |(condition, body), span| ast::IfBranch {
@@ -1109,7 +1094,6 @@ pub fn expr_parser(
             when_parser,
             let_parser,
             assert_parser,
-            check_parser,
             if_parser,
         ));
 

--- a/crates/aiken-lang/src/parser/token.rs
+++ b/crates/aiken-lang/src/parser/token.rs
@@ -61,7 +61,6 @@ pub enum Token {
     // Keywords (alphabetically):
     As,
     Assert,
-    Check,
     Const,
     Fn,
     If,
@@ -142,7 +141,6 @@ impl fmt::Display for Token {
             Token::NewLine => "NEWLINE",
             Token::As => "as",
             Token::Assert => "assert",
-            Token::Check => "check",
             Token::When => "when",
             Token::Is => "is",
             Token::Const => "const",

--- a/crates/aiken-lang/src/tipo/infer.rs
+++ b/crates/aiken-lang/src/tipo/infer.rs
@@ -513,7 +513,6 @@ fn str_to_keyword(word: &str) -> Option<Token> {
     match word {
         "as" => Some(Token::As),
         "assert" => Some(Token::Assert),
-        "check" => Some(Token::Check),
         "when" => Some(Token::When),
         "const" => Some(Token::Const),
         "fn" => Some(Token::Fn),


### PR DESCRIPTION
There was some discussion a little while back and we realized that having `check` just makes things in regards to assignment confusing. We also decided that `assert` might as well also do the extra things `check` was going to to anyways.

assert now have the following behaviour:

1. if asserting and casting on `Data` then the structure is recursively checked
2. if it's not a type cast then it only checks the constr index