### PR TITLE
Add missing carets when dumping builtin list

### DIFF
--- a/crates/uplc/src/pretty.rs
+++ b/crates/uplc/src/pretty.rs
@@ -195,7 +195,9 @@ impl Constant {
                 .append(RcDoc::text(if *b { "True" } else { "False" })),
             Constant::ProtoList(r#type, items) => RcDoc::text("list")
                 .append(RcDoc::line_())
+                .append(RcDoc::text("<"))
                 .append(r#type.to_doc())
+                .append(RcDoc::text(">"))
                 .append(RcDoc::line())
                 .append(RcDoc::text("["))
                 .append(RcDoc::intersperse(


### PR DESCRIPTION
This attempts to fix #328 but beware, is 100% untested.