### PR TITLE
Upgrade Term::Constant to use BigInt

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2669,6 +2669,7 @@ dependencies = [
  "itertools",
  "k256",
  "num-bigint",
+ "num-traits",
  "pallas-addresses",
  "pallas-codec",
  "pallas-crypto",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2669,6 +2669,7 @@ dependencies = [
  "itertools",
  "k256",
  "num-bigint",
+ "num-integer",
  "num-traits",
  "pallas-addresses",
  "pallas-codec",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1381,6 +1381,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-bigint"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f93ab6289c7b344a8a9f60f88d80aa20032336fe78da341afc91c8a2341fc75f"
+dependencies = [
+ "autocfg",
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
 name = "num-integer"
 version = "0.1.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2657,6 +2668,7 @@ dependencies = [
  "indexmap",
  "itertools",
  "k256",
+ "num-bigint",
  "pallas-addresses",
  "pallas-codec",
  "pallas-crypto",

--- a/crates/aiken-lang/src/builder.rs
+++ b/crates/aiken-lang/src/builder.rs
@@ -8,8 +8,11 @@ use uplc::{
         Constant as UplcConstant, Name, Term, Type as UplcType,
     },
     builtins::DefaultFunction,
-    machine::runtime::{convert_constr_to_tag, ANY_TAG},
-    BigInt, Constr, KeyValuePairs, PlutusData,
+    machine::{
+        runtime::{convert_constr_to_tag, ANY_TAG},
+        to_pallas_bigint,
+    },
+    Constr, KeyValuePairs, PlutusData,
 };
 
 use crate::{
@@ -332,7 +335,7 @@ pub fn convert_data_to_type(term: Term<Name>, field_type: &Arc<Type>) -> Term<Na
         apply_wrap(
             apply_wrap(
                 DefaultFunction::EqualsInteger.into(),
-                Term::Constant(UplcConstant::Integer(1).into()),
+                Term::Constant(UplcConstant::Integer(1.into()).into()),
             ),
             apply_wrap(
                 Term::Builtin(DefaultFunction::FstPair)
@@ -998,9 +1001,7 @@ pub fn convert_constants_to_data(constants: Vec<Rc<UplcConstant>>) -> Vec<UplcCo
     let mut new_constants = vec![];
     for constant in constants {
         let constant = match constant.as_ref() {
-            UplcConstant::Integer(i) => {
-                UplcConstant::Data(PlutusData::BigInt(BigInt::Int((*i).try_into().unwrap())))
-            }
+            UplcConstant::Integer(i) => UplcConstant::Data(PlutusData::BigInt(to_pallas_bigint(i))),
             UplcConstant::ByteString(b) => {
                 UplcConstant::Data(PlutusData::BoundedBytes(b.clone().try_into().unwrap()))
             }

--- a/crates/aiken-lang/src/uplc.rs
+++ b/crates/aiken-lang/src/uplc.rs
@@ -4417,7 +4417,7 @@ impl<'a> CodeGenerator<'a> {
                     apply_wrap(
                         apply_wrap(
                             DefaultFunction::EqualsInteger.into(),
-                            Term::Constant(UplcConstant::Integer(constr_index as i128).into()),
+                            Term::Constant(UplcConstant::Integer(constr_index.into()).into()),
                         ),
                         constr_index_exposer(constr),
                     ),
@@ -4975,7 +4975,7 @@ impl<'a> CodeGenerator<'a> {
                 term = apply_wrap(
                     apply_wrap(
                         DefaultFunction::ConstrData.into(),
-                        Term::Constant(UplcConstant::Integer(constr_index as i128).into()),
+                        Term::Constant(UplcConstant::Integer(constr_index.into()).into()),
                     ),
                     term,
                 );
@@ -5234,7 +5234,7 @@ impl<'a> CodeGenerator<'a> {
                 term = apply_wrap(
                     apply_wrap(
                         Term::Builtin(DefaultFunction::ConstrData),
-                        Term::Constant(UplcConstant::Integer(0).into()),
+                        Term::Constant(UplcConstant::Integer(0.into()).into()),
                     ),
                     term,
                 );
@@ -5342,7 +5342,7 @@ impl<'a> CodeGenerator<'a> {
                     UnOp::Negate => apply_wrap(
                         apply_wrap(
                             DefaultFunction::SubtractInteger.into(),
-                            Term::Constant(UplcConstant::Integer(0).into()),
+                            Term::Constant(UplcConstant::Integer(0.into()).into()),
                         ),
                         value,
                     ),
@@ -5391,7 +5391,7 @@ impl<'a> CodeGenerator<'a> {
                                 ),
                                 term,
                             ),
-                            Term::Constant(UplcConstant::Integer(tuple_index as i128).into()),
+                            Term::Constant(UplcConstant::Integer(tuple_index.into()).into()),
                         ),
                         &tipo.get_inner_types()[tuple_index],
                     );

--- a/crates/uplc/Cargo.toml
+++ b/crates/uplc/Cargo.toml
@@ -33,6 +33,7 @@ itertools = "0.10.5"
 indexmap = "1.9.2"
 secp256k1 = { version = "0.26.0", optional = true }
 k256 = { version = "0.12.0", optional = true }
+num-bigint = "0.4.3"
 
 [dev-dependencies]
 hex = "0.4.3"

--- a/crates/uplc/Cargo.toml
+++ b/crates/uplc/Cargo.toml
@@ -35,6 +35,7 @@ secp256k1 = { version = "0.26.0", optional = true }
 k256 = { version = "0.12.0", optional = true }
 num-bigint = "0.4.3"
 num-traits = "0.2.15"
+num-integer = "0.1.45"
 
 [dev-dependencies]
 hex = "0.4.3"

--- a/crates/uplc/Cargo.toml
+++ b/crates/uplc/Cargo.toml
@@ -34,6 +34,7 @@ indexmap = "1.9.2"
 secp256k1 = { version = "0.26.0", optional = true }
 k256 = { version = "0.12.0", optional = true }
 num-bigint = "0.4.3"
+num-traits = "0.2.15"
 
 [dev-dependencies]
 hex = "0.4.3"

--- a/crates/uplc/src/ast.rs
+++ b/crates/uplc/src/ast.rs
@@ -4,6 +4,7 @@ use std::{
     rc::Rc,
 };
 
+use num_bigint::BigInt;
 use serde::{
     self,
     de::{self, Deserialize, Deserializer, MapAccess, Visitor},
@@ -228,7 +229,7 @@ where
 #[derive(Debug, Clone, PartialEq)]
 pub enum Constant {
     // tag: 0
-    Integer(i128),
+    Integer(BigInt),
     // tag: 1
     ByteString(Vec<u8>),
     // tag: 2

--- a/crates/uplc/src/machine.rs
+++ b/crates/uplc/src/machine.rs
@@ -730,3 +730,33 @@ impl From<&Constant> for Type {
         }
     }
 }
+
+#[cfg(test)]
+mod test {
+    use crate::{
+        ast::{Constant, NamedDeBruijn, Program, Term},
+        builtins::DefaultFunction,
+        machine::Error,
+    };
+
+    use super::cost_model::ExBudget;
+
+    #[test]
+    fn add_big_ints() {
+        let program: Program<NamedDeBruijn> = Program {
+            version: (0, 0, 0),
+            term: Term::Apply {
+                function: Term::Apply {
+                    function: Term::Builtin(DefaultFunction::AddInteger).into(),
+                    argument: Term::Constant(Constant::Integer(i128::MAX).into()).into(),
+                }
+                .into(),
+                argument: Term::Constant(Constant::Integer(i128::MAX).into()).into(),
+            },
+        };
+
+        let (eval_result, _, _) = program.eval(ExBudget::default());
+
+        assert!(!matches!(eval_result, Err(Error::OverflowError)));
+    }
+}

--- a/crates/uplc/src/machine.rs
+++ b/crates/uplc/src/machine.rs
@@ -1,3 +1,4 @@
+use num_traits::sign::Signed;
 use std::{collections::VecDeque, ops::Deref, rc::Rc};
 
 use crate::{
@@ -545,10 +546,10 @@ impl Value {
         match self {
             Value::Con(c) => match c.as_ref() {
                 Constant::Integer(i) => {
-                    if *i == 0 {
+                    if *i == 0.into() {
                         1
                     } else {
-                        ((i.abs() as f64).log2().floor() as i64 / 64) + 1
+                        (i.abs().log2().floor() as i64 / 64) + 1
                     }
                 }
                 Constant::ByteString(b) => {
@@ -748,10 +749,10 @@ mod test {
             term: Term::Apply {
                 function: Term::Apply {
                     function: Term::Builtin(DefaultFunction::AddInteger).into(),
-                    argument: Term::Constant(Constant::Integer(i128::MAX).into()).into(),
+                    argument: Term::Constant(Constant::Integer(i128::MAX.into()).into()).into(),
                 }
                 .into(),
-                argument: Term::Constant(Constant::Integer(i128::MAX).into()).into(),
+                argument: Term::Constant(Constant::Integer(i128::MAX.into()).into()).into(),
             },
         };
 

--- a/crates/uplc/src/machine/error.rs
+++ b/crates/uplc/src/machine/error.rs
@@ -1,5 +1,7 @@
 use std::string::FromUtf8Error;
 
+use num_bigint::BigInt;
+
 use crate::ast::{NamedDeBruijn, Term, Type};
 
 use super::{ExBudget, Value};
@@ -37,9 +39,9 @@ pub enum Error {
     #[error("Decoding utf8")]
     Utf8(#[from] FromUtf8Error),
     #[error("Out of Bounds\n\nindex: {}\nbytestring: {}\npossible: 0 - {}", .0, hex::encode(.1), .1.len() - 1)]
-    ByteStringOutOfBounds(i128, Vec<u8>),
+    ByteStringOutOfBounds(BigInt, Vec<u8>),
     #[error("Divide By Zero\n\n{0} / {1}")]
-    DivideByZero(i128, i128),
+    DivideByZero(BigInt, BigInt),
     #[error("Ed25519S PublicKey should be 32 bytes but it was {0}")]
     UnexpectedEd25519PublicKeyLength(usize),
     #[error("Ed25519S Signature should be 64 bytes but it was {0}")]

--- a/crates/uplc/src/parser.rs
+++ b/crates/uplc/src/parser.rs
@@ -159,7 +159,7 @@ peg::parser! {
           = n:$("-"* ['0'..='9']+) {? n.parse().or(Err("isize")) }
 
         rule big_number() -> BigInt
-          = n:$("-"* ['0'..='9']+) {? (if n.starts_with("-") { BigInt::parse_bytes(&n.as_bytes()[1..], 10).map(|i| i.neg()) } else { BigInt::parse_bytes(n.as_bytes(), 10) }).ok_or("BigInt") }
+          = n:$("-"* ['0'..='9']+) {? (if n.starts_with('-') { BigInt::parse_bytes(&n.as_bytes()[1..], 10).map(|i| i.neg()) } else { BigInt::parse_bytes(n.as_bytes(), 10) }).ok_or("BigInt") }
 
         rule boolean() -> bool
           = b:$("True" / "False") { b == "True" }
@@ -258,6 +258,8 @@ peg::parser! {
 
 #[cfg(test)]
 mod test {
+    use num_bigint::BigInt;
+
     use crate::ast::{Constant, Name, Program, Term, Type, Unique};
     use crate::builtins::DefaultFunction;
     use std::rc::Rc;
@@ -554,7 +556,10 @@ mod test {
                         argument: Rc::new(Term::Constant(Constant::ByteString(vec![0x00]).into()))
                     }),
                     argument: Rc::new(Term::Constant(
-                        Constant::Integer(9223372036854775808.into()).into()
+                        Constant::Integer(
+                            BigInt::parse_bytes("9223372036854775808".as_bytes(), 10).unwrap()
+                        )
+                        .into()
                     )),
                 }
             }

--- a/crates/uplc/src/parser.rs
+++ b/crates/uplc/src/parser.rs
@@ -1,4 +1,4 @@
-use std::{rc::Rc, str::FromStr};
+use std::{ops::Neg, rc::Rc, str::FromStr};
 
 use crate::{
     ast::{Constant, Name, Program, Term, Type},
@@ -6,6 +6,7 @@ use crate::{
 };
 
 use interner::Interner;
+use num_bigint::BigInt;
 use pallas_primitives::{alonzo::PlutusData, Fragment};
 use peg::{error::ParseError, str::LineCol};
 
@@ -157,8 +158,8 @@ peg::parser! {
         rule number() -> isize
           = n:$("-"* ['0'..='9']+) {? n.parse().or(Err("isize")) }
 
-        rule big_number() -> i128
-          = n:$("-"* ['0'..='9']+) {? n.parse().or(Err("i128")) }
+        rule big_number() -> BigInt
+          = n:$("-"* ['0'..='9']+) {? (if n.starts_with("-") { BigInt::parse_bytes(&n.as_bytes()[1..], 10).map(|i| i.neg()) } else { BigInt::parse_bytes(n.as_bytes(), 10) }).ok_or("BigInt") }
 
         rule boolean() -> bool
           = b:$("True" / "False") { b == "True" }
@@ -277,7 +278,7 @@ mod test {
                         parameter_name: x.clone().into(),
                         body: Rc::new(Term::Var(x.into())),
                     }),
-                    argument: Rc::new(Term::Constant(Constant::Integer(0).into()))
+                    argument: Rc::new(Term::Constant(Constant::Integer(0.into()).into()))
                 }
             }
         )
@@ -344,7 +345,7 @@ mod test {
             super::program(uplc).unwrap(),
             Program::<Name> {
                 version: (11, 22, 33),
-                term: Term::Constant(Constant::Integer(11).into()),
+                term: Term::Constant(Constant::Integer(11.into()).into()),
             }
         );
     }
@@ -492,7 +493,7 @@ mod test {
                 term: Term::Apply {
                     function: Rc::new(Term::Apply {
                         function: Rc::new(Term::Builtin(DefaultFunction::ConsByteString)),
-                        argument: Rc::new(Term::Constant(Constant::Integer(256).into())),
+                        argument: Rc::new(Term::Constant(Constant::Integer(256.into()).into())),
                     }),
                     argument: Rc::new(Term::Constant(Constant::ByteString(vec![]).into()))
                 }
@@ -511,9 +512,9 @@ mod test {
                     function: Rc::new(Term::Apply {
                         function: Rc::new(Term::Apply {
                             function: Rc::new(Term::Builtin(DefaultFunction::SliceByteString)),
-                            argument: Rc::new(Term::Constant(Constant::Integer(1).into())),
+                            argument: Rc::new(Term::Constant(Constant::Integer(1.into()).into())),
                         }),
-                        argument: Rc::new(Term::Constant(Constant::Integer(2).into())),
+                        argument: Rc::new(Term::Constant(Constant::Integer(2.into()).into())),
                     }),
                     argument: Rc::new(Term::Constant(
                         Constant::ByteString(vec![0x00, 0xFF, 0xAA]).into()
@@ -553,7 +554,7 @@ mod test {
                         argument: Rc::new(Term::Constant(Constant::ByteString(vec![0x00]).into()))
                     }),
                     argument: Rc::new(Term::Constant(
-                        Constant::Integer(9223372036854775808).into()
+                        Constant::Integer(9223372036854775808.into()).into()
                     )),
                 }
             }
@@ -704,9 +705,12 @@ mod test {
                         vec![
                             Constant::ProtoList(
                                 Type::Integer,
-                                vec![Constant::Integer(14), Constant::Integer(42)]
+                                vec![Constant::Integer(14.into()), Constant::Integer(42.into())]
                             ),
-                            Constant::ProtoList(Type::Integer, vec![Constant::Integer(1337)])
+                            Constant::ProtoList(
+                                Type::Integer,
+                                vec![Constant::Integer(1337.into())]
+                            )
                         ]
                     )
                     .into()
@@ -733,7 +737,7 @@ mod test {
                 term: Term::Constant(
                     Constant::ProtoList(
                         Type::Integer,
-                        vec![Constant::Integer(14), Constant::Integer(42)],
+                        vec![Constant::Integer(14.into()), Constant::Integer(42.into())],
                     )
                     .into()
                 )
@@ -776,7 +780,7 @@ mod test {
                         Constant::ProtoPair(
                             Type::Integer,
                             Type::ByteString,
-                            Constant::Integer(14).into(),
+                            Constant::Integer(14.into()).into(),
                             Constant::ByteString(vec![0x42]).into(),
                         )
                         .into()
@@ -801,7 +805,7 @@ mod test {
                         Constant::String(String::from("foo")).into(),
                         Constant::ProtoList(
                             Type::Integer,
-                            vec![Constant::Integer(14), Constant::Integer(42)],
+                            vec![Constant::Integer(14.into()), Constant::Integer(42.into())],
                         )
                         .into()
                     )
@@ -828,8 +832,8 @@ mod test {
                     Constant::ProtoPair(
                         Type::Integer,
                         Type::Integer,
-                        Constant::Integer(14).into(),
-                        Constant::Integer(42).into()
+                        Constant::Integer(14.into()).into(),
+                        Constant::Integer(42.into()).into()
                     )
                     .into()
                 )
@@ -859,9 +863,9 @@ mod test {
                 term: Term::Apply {
                     function: Rc::new(Term::Apply {
                         function: Rc::new(Term::Builtin(default_function)),
-                        argument: Rc::new(Term::Constant(Constant::Integer(x).into())),
+                        argument: Rc::new(Term::Constant(Constant::Integer(x.into()).into())),
                     }),
-                    argument: Rc::new(Term::Constant(Constant::Integer(y).into()))
+                    argument: Rc::new(Term::Constant(Constant::Integer(y.into()).into()))
                 }
             }
         )

--- a/crates/uplc/src/program_builder/constant.rs
+++ b/crates/uplc/src/program_builder/constant.rs
@@ -3,7 +3,7 @@ use crate::program_builder::WithTerm;
 
 pub trait WithConstant: WithTerm {
     fn with_int(self, int: i128) -> Self::Next {
-        let term = Term::Constant(Constant::Integer(int).into());
+        let term = Term::Constant(Constant::Integer(int.into()).into());
         self.next(term)
     }
 


### PR DESCRIPTION
closes #355

We decided to go with [num-bigint](https://docs.rs/num-bigint/latest/num_bigint/struct.BigInt.html#impl-From%3Ci128%3E).

We started by replacing `Constant::Integer(i128)` with `Constant::Integer(BigInt)`.

This resulted in a need for a new way to get the `integer_log2` of `Constant::Integer` in `machine::Value::to_ex_mem`.

We've added some tests to the bottom of the `machine` module.

## UPLC Parser

It was pretty easy/simple to go from a string to bytes to `BigInt` when parsing.

## Flat

For the flat decoding/encoding is seemed appropriate to just cast `BigInt` to and from `i128` which made things very simple.

It seemed unlikely that people will have hardcoded constant larger than that, which is really the only situation where you'd find yourself decoding/encoding a `Constant::Integer`