### PR TITLE
Patterns improvements

### DIFF
--- a/crates/aiken-lang/src/ast.rs
+++ b/crates/aiken-lang/src/ast.rs
@@ -717,11 +717,6 @@ pub enum Pattern<Constructor, Type> {
         value: String,
     },
 
-    String {
-        location: Span,
-        value: String,
-    },
-
     /// The creation of a variable.
     /// e.g. `assert [this_is_a_var, .._] = x`
     Var {
@@ -776,7 +771,6 @@ impl<A, B> Pattern<A, B> {
             | Pattern::Var { location, .. }
             | Pattern::List { location, .. }
             | Pattern::Discard { location, .. }
-            | Pattern::String { location, .. }
             | Pattern::Tuple { location, .. }
             // | Pattern::Concatenate { location, .. }
             | Pattern::Constructor { location, .. } => *location,

--- a/crates/aiken-lang/src/format.rs
+++ b/crates/aiken-lang/src/format.rs
@@ -1454,8 +1454,6 @@ impl<'comments> Formatter<'comments> {
         let doc = match pattern {
             Pattern::Int { value, .. } => value.to_doc(),
 
-            Pattern::String { value, .. } => self.string(value),
-
             Pattern::Var { name, .. } => name.to_doc(),
 
             Pattern::Assign { name, pattern, .. } => {

--- a/crates/aiken-lang/src/parser.rs
+++ b/crates/aiken-lang/src/parser.rs
@@ -1689,12 +1689,6 @@ pub fn pattern_parser() -> impl Parser<Token, ast::UntypedPattern, Error = Parse
                     location: span,
                 }
             }),
-            select! {Token::String {value} => value}.map_with_span(|value, span| {
-                ast::UntypedPattern::String {
-                    location: span,
-                    value,
-                }
-            }),
             select! {Token::Int {value} => value}.map_with_span(|value, span| {
                 ast::UntypedPattern::Int {
                     location: span,

--- a/crates/aiken-lang/src/tests/check.rs
+++ b/crates/aiken-lang/src/tests/check.rs
@@ -1,0 +1,128 @@
+use crate::{
+    ast::{ModuleKind, TypedModule, UntypedModule},
+    builtins, parser,
+    tipo::error::{Error, Warning},
+    IdGenerator,
+};
+use std::collections::HashMap;
+
+fn parse(source_code: &str) -> UntypedModule {
+    let kind = ModuleKind::Lib;
+    let (ast, _) = parser::module(source_code, kind).expect("Failed to parse module");
+    ast
+}
+
+fn check(ast: UntypedModule) -> Result<TypedModule, (Vec<Warning>, Error)> {
+    let kind = ModuleKind::Lib;
+
+    let id_gen = IdGenerator::new();
+
+    let mut warnings = vec![];
+
+    let mut module_types = HashMap::new();
+    module_types.insert("aiken".to_string(), builtins::prelude(&id_gen));
+    module_types.insert("aiken/builtin".to_string(), builtins::plutus(&id_gen));
+
+    let result = ast.infer(&id_gen, kind, "test/project", &module_types, &mut warnings);
+
+    result.map_err(|e| (warnings, e))
+}
+
+#[test]
+fn list_pattern_1() {
+    let source_code = r#"
+        test foo() {
+          let xs = [1, 2, 3]
+          let [x] = xs
+          x == 1
+        }
+    "#;
+    assert!(matches!(
+        check(parse(source_code)),
+        Err((_, Error::NotExhaustivePatternMatch { .. }))
+    ))
+}
+
+#[test]
+fn list_pattern_2() {
+    let source_code = r#"
+        test foo() {
+          let xs = [1, 2, 3]
+          let x = when xs is {
+            [x] -> x
+          }
+          x == 1
+        }
+    "#;
+    assert!(matches!(
+        check(parse(source_code)),
+        Err((_, Error::NotExhaustivePatternMatch { .. }))
+    ))
+}
+
+#[test]
+fn list_pattern_3() {
+    let source_code = r#"
+        test foo() {
+          let xs = [1, 2, 3]
+          let x = when xs is {
+            [x] -> x
+            [x, ..] -> x
+          }
+          x == 1
+        }
+    "#;
+    assert!(matches!(
+        check(parse(source_code)),
+        Err((_, Error::NotExhaustivePatternMatch { .. }))
+    ))
+}
+
+#[test]
+fn list_pattern_4() {
+    let source_code = r#"
+        test foo() {
+          let xs = [1, 2, 3]
+          let x = when xs is {
+            [] -> 1
+            [x] -> x
+            [x, ..] if x > 10 -> x
+          }
+          x == 1
+        }
+    "#;
+    assert!(matches!(
+        check(parse(source_code)),
+        Err((_, Error::NotExhaustivePatternMatch { .. }))
+    ))
+}
+
+#[test]
+fn list_pattern_5() {
+    let source_code = r#"
+        test foo() {
+          let xs = [1, 2, 3]
+          let x = when xs is {
+            [] -> 1
+            [_, ..] -> 1
+          }
+          x == 1
+        }
+    "#;
+    assert!(check(parse(source_code)).is_ok())
+}
+
+#[test]
+fn list_pattern_6() {
+    let source_code = r#"
+        test foo() {
+          let xs = [1, 2, 3]
+          let x = when xs is {
+            [x, ..] -> 1
+            _ -> 1
+          }
+          x == 1
+        }
+    "#;
+    assert!(check(parse(source_code)).is_ok())
+}

--- a/crates/aiken-lang/src/tests/mod.rs
+++ b/crates/aiken-lang/src/tests/mod.rs
@@ -1,3 +1,4 @@
+mod check;
 mod format;
 mod lexer;
 mod parser;

--- a/crates/aiken-lang/src/tipo/error.rs
+++ b/crates/aiken-lang/src/tipo/error.rs
@@ -424,7 +424,7 @@ In this particular instance, the following cases are unmatched:
             .iter()
             .map(|s| format!("─▶ {s}"))
             .collect::<Vec<_>>()
-            .join("")
+            .join("\n")
     ))]
     NotExhaustivePatternMatch {
         #[label("{}", if *is_let { "use when/is" } else { "non-exhaustive" })]
@@ -1247,5 +1247,5 @@ fn format_suggestion(sample: &UntypedExpr) -> String {
             }
         })
         .collect::<Vec<_>>()
-        .join("")
+        .join("\n")
 }

--- a/crates/aiken-lang/src/tipo/pattern.rs
+++ b/crates/aiken-lang/src/tipo/pattern.rs
@@ -16,7 +16,7 @@ use super::{
 };
 use crate::{
     ast::{CallArg, Pattern, Span, TypedPattern, UntypedMultiPattern, UntypedPattern},
-    builtins::{int, list, string, tuple},
+    builtins::{int, list, tuple},
 };
 
 pub struct PatternTyper<'a, 'b> {
@@ -284,12 +284,6 @@ impl<'a, 'b> PatternTyper<'a, 'b> {
                 self.environment.unify(tipo, int(), location, false)?;
 
                 Ok(Pattern::Int { location, value })
-            }
-
-            Pattern::String { location, value } => {
-                self.environment.unify(tipo, string(), location, false)?;
-
-                Ok(Pattern::String { location, value })
             }
 
             Pattern::List {

--- a/crates/aiken-lang/src/uplc.rs
+++ b/crates/aiken-lang/src/uplc.rs
@@ -1534,7 +1534,7 @@ impl<'a> CodeGenerator<'a> {
                 Some(item_name)
             }
             Pattern::Assign { .. } => todo!("Nested assign is not yet done"),
-            Pattern::Int { .. } => unimplemented!(),
+            Pattern::Int { .. } => todo!("Nested pattern-match on integers isn't implemented yet. Use when clause-guard as an alternative, or break down the pattern."),
         }
     }
 

--- a/crates/aiken-lang/src/uplc.rs
+++ b/crates/aiken-lang/src/uplc.rs
@@ -871,7 +871,6 @@ impl<'a> CodeGenerator<'a> {
 
                 pattern_vec.append(values);
             }
-            Pattern::String { .. } => todo!("String matching in whens not yet implemented"),
             Pattern::Var { name, .. } => {
                 pattern_vec.push(Air::Void {
                     scope: scope.clone(),
@@ -1060,7 +1059,6 @@ impl<'a> CodeGenerator<'a> {
     ) {
         match pattern {
             Pattern::Int { .. } => unreachable!(),
-            Pattern::String { .. } => unreachable!(),
             Pattern::Var { .. } => unreachable!(),
             Pattern::Assign { .. } => todo!("Nested assign not yet implemented"),
             Pattern::Discard { .. } => {
@@ -1537,7 +1535,6 @@ impl<'a> CodeGenerator<'a> {
             }
             Pattern::Assign { .. } => todo!("Nested assign is not yet done"),
             Pattern::Int { .. } => unimplemented!(),
-            Pattern::String { .. } => unimplemented!(),
         }
     }
 
@@ -1569,7 +1566,7 @@ impl<'a> CodeGenerator<'a> {
             )
         }
         match pattern {
-            Pattern::Int { .. } | Pattern::String { .. } => unreachable!(),
+            Pattern::Int { .. } => unreachable!(),
             Pattern::Var { name, .. } => {
                 pattern_vec.push(Air::Let {
                     name: name.clone(),
@@ -1690,7 +1687,6 @@ impl<'a> CodeGenerator<'a> {
     ) {
         match pattern {
             Pattern::Int { .. } => todo!(),
-            Pattern::String { .. } => todo!(),
             Pattern::Var { .. } => todo!(),
             Pattern::Assign { .. } => todo!(),
             Pattern::Discard { .. } => todo!(),
@@ -1736,7 +1732,6 @@ impl<'a> CodeGenerator<'a> {
                             );
                         }
                         Pattern::Int { .. } => todo!(),
-                        Pattern::String { .. } => todo!(),
                         Pattern::Assign { .. } => todo!(),
                         Pattern::Discard { .. } => {
                             names.push("_".to_string());
@@ -1904,7 +1899,6 @@ impl<'a> CodeGenerator<'a> {
     ) {
         match pattern {
             Pattern::Int { .. } => unreachable!(),
-            Pattern::String { .. } => unreachable!(),
             Pattern::Var { name, .. } => {
                 pattern_vec.append(value_vec);
 
@@ -2651,7 +2645,6 @@ impl<'a> CodeGenerator<'a> {
                     (false, tuple_name)
                 }
                 Pattern::Int { .. } => todo!(),
-                Pattern::String { .. } => todo!(),
                 Pattern::Assign { .. } => todo!(),
             };
 


### PR DESCRIPTION
- :round_pushpin: **Basic exhaustivness check on list patterns**
    Before that commit, the type-checker would allow unsafe list patterns
  such as:

  ```
  let [x] = xs

  when xs is {
    [x] -> ...
    [x, ..] ->  ...
  }
  ```

  This is quite unsafe and can lead to confusing situations. Now at
  least the compiler warns about this. It isn't perfect though,
  especially in the presence of clause guards. But that's a start.

- :round_pushpin: **Add missing newlines to 'join' in error messages.**
  
- :round_pushpin: **Add type-checker sanity tests for list patterns.**
  
- :round_pushpin: **Remove patterns on 'String'**
    There's arguably no use case ever for that in the context of on-chain
  Plutus. Strings are really just meant to be used for tracing. They
  aren't meant to be manipulated as heavily as in classic programming
  languages.

- :round_pushpin: **Add slightly more informative note for list pattern on int.**
  