### PR TITLE
Change how expect works on lists and constructors

### DIFF
--- a/examples/acceptance_tests/040/lib/tests.ak
+++ b/examples/acceptance_tests/040/lib/tests.ak
@@ -55,3 +55,11 @@ test expect_list2() {
   expect [a, ..d] = initial_car
   a == 5 && d == [6, 7]
 }
+
+
+
+test expect_list3() {
+  let initial_car = builtin.list_data([builtin.i_data(5), builtin.i_data(6), builtin.i_data(7)])
+  expect [a, ..d]: List<Int> = initial_car
+  a == 5 && d == [6, 7]
+}

--- a/examples/acceptance_tests/040/lib/tests.ak
+++ b/examples/acceptance_tests/040/lib/tests.ak
@@ -16,7 +16,7 @@ pub type Car {
   }
 }
 
-test update_owner1() {
+test expect_ford1() {
   let initial_car =
     builtin.constr_data(
       1,
@@ -30,4 +30,28 @@ test update_owner1() {
     )
   expect Ford { owner, wheels, truck_bed_limit, .. }: Car = initial_car
   owner == #"" && wheels == 4 && truck_bed_limit == 10000
+}
+
+
+test expect_ford2() {
+  let initial_car = Ford {remote_connect: #"", owner: #[34,34,34,34,34],  wheels: 6, truck_bed_limit: 15000, car_doors: []}
+  expect Ford { owner, wheels, remote_connect, .. } = initial_car
+  owner == #[34,34,34,34,34] && wheels == 6 && remote_connect == #""
+}
+
+
+
+
+test expect_list1() {
+  let initial_car = [5,6,7]
+  expect [a,b,c] = initial_car
+  a == 5 && b == 6 && c == 7 
+}
+
+
+
+test expect_list2() {
+  let initial_car = [5,6,7]
+  expect [a, ..d] = initial_car
+  a == 5 && d == [6, 7]
 }


### PR DESCRIPTION
Add more coverage to acceptance test 40 on expect
Lists with expect check for exact items in list patterns with no tail.
Constructors with expect check for contructor index in a constructor pattern