### PR TITLE
Trace rework and unification

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -31,15 +31,6 @@ dependencies = [
 
 [[package]]
 name = "ahash"
-version = "0.3.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8fd72866655d1904d6b0997d0b07ba561047d070fbe29de039031c641b61217"
-dependencies = [
- "const-random",
-]
-
-[[package]]
-name = "ahash"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fcb51a0695d8f838b1ee009b3fbf66bda078cd64590202a864a8f3e8c4315c47"
@@ -390,11 +381,12 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "chumsky"
-version = "0.8.0"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d02796e4586c6c41aeb68eae9bfb4558a522c35f1430c14b40136c3706e09e4"
+checksum = "c4d619fba796986dd538d82660b76e0b9756c6e19b2e4d4559ba5a57f9f00810"
 dependencies = [
- "ahash 0.3.8",
+ "hashbrown",
+ "stacker",
 ]
 
 [[package]]
@@ -450,28 +442,6 @@ name = "const-oid"
 version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cec318a675afcb6a1ea1d4340e2d377e56e47c266f28043ceccbf4412ddfdd3b"
-
-[[package]]
-name = "const-random"
-version = "0.1.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "368a7a772ead6ce7e1de82bfb04c485f3db8ec744f72925af5735e29a22cc18e"
-dependencies = [
- "const-random-macro",
- "proc-macro-hack",
-]
-
-[[package]]
-name = "const-random-macro"
-version = "0.1.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d7d6ab3c3a2282db210df5f02c4dab6e0a7057af0fb7ebd4070f30fe05c0ddb"
-dependencies = [
- "getrandom",
- "once_cell",
- "proc-macro-hack",
- "tiny-keccak",
-]
 
 [[package]]
 name = "constant_time_eq"
@@ -555,12 +525,6 @@ checksum = "4fb766fa798726286dbbb842f174001dab8abc7b627a1dd86e0b7222a95d929f"
 dependencies = [
  "cfg-if",
 ]
-
-[[package]]
-name = "crunchy"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a81dae078cea95a014a339291cec439d2f232ebe854a9d672b796c6afafa9b7"
 
 [[package]]
 name = "crypto-bigint"
@@ -955,7 +919,7 @@ version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 dependencies = [
- "ahash 0.7.6",
+ "ahash",
 ]
 
 [[package]]
@@ -1801,12 +1765,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "proc-macro-hack"
-version = "0.5.20+deprecated"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc375e1527247fe1a97d8b7156678dfe7c1af2fc075c9a4db3690ecd2a148068"
-
-[[package]]
 name = "proc-macro2"
 version = "1.0.49"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1833,6 +1791,15 @@ dependencies = [
  "regex-syntax",
  "rusty-fork",
  "tempfile",
+]
+
+[[package]]
+name = "psm"
+version = "0.1.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5787f7cda34e3033a72192c018bc5883100330f362ef279a8cbccfce8bb4e874"
+dependencies = [
+ "cc",
 ]
 
 [[package]]
@@ -2276,6 +2243,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "stacker"
+version = "0.1.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c886bd4480155fd3ef527d45e9ac8dd7118a898a46530b7b94c3e21866259fce"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "libc",
+ "psm",
+ "winapi",
+]
+
+[[package]]
 name = "static_assertions"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2460,15 +2440,6 @@ name = "time-core"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2e153e1f1acaef8acc537e68b44906d2db6436e2b35ac2c6b42640fff91f00fd"
-
-[[package]]
-name = "tiny-keccak"
-version = "2.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c9d3793400a45f954c52e73d068316d76b6f4e36977e3fcebb13a2721e80237"
-dependencies = [
- "crunchy",
-]
 
 [[package]]
 name = "tinyvec"

--- a/crates/aiken-lang/Cargo.toml
+++ b/crates/aiken-lang/Cargo.toml
@@ -11,7 +11,7 @@ authors = ["Lucas Rosa <x@rvcas.dev>", "Kasey White <kwhitemsg@gmail.com>"]
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-chumsky = "0.8.0"
+chumsky = "0.9.0"
 hex = "0.4.3"
 indexmap = "1.9.1"
 indoc = "1.0.7"

--- a/crates/aiken-lang/src/air.rs
+++ b/crates/aiken-lang/src/air.rs
@@ -249,7 +249,6 @@ pub enum Air {
 
     Trace {
         scope: Vec<u64>,
-        text: Option<String>,
         tipo: Arc<Type>,
     },
 }

--- a/crates/aiken-lang/src/air.rs
+++ b/crates/aiken-lang/src/air.rs
@@ -244,7 +244,6 @@ pub enum Air {
     ErrorTerm {
         scope: Vec<u64>,
         tipo: Arc<Type>,
-        label: Option<String>,
     },
 
     Trace {

--- a/crates/aiken-lang/src/air.rs
+++ b/crates/aiken-lang/src/air.rs
@@ -235,12 +235,6 @@ pub enum Air {
     },
 
     // Misc.
-    Todo {
-        scope: Vec<u64>,
-        label: Option<String>,
-        tipo: Arc<Type>,
-    },
-
     ErrorTerm {
         scope: Vec<u64>,
         tipo: Arc<Type>,
@@ -290,7 +284,6 @@ impl Air {
             | Air::ListExpose { scope, .. }
             | Air::TupleAccessor { scope, .. }
             | Air::TupleIndex { scope, .. }
-            | Air::Todo { scope, .. }
             | Air::ErrorTerm { scope, .. }
             | Air::Trace { scope, .. } => scope.clone(),
         }
@@ -373,7 +366,6 @@ impl Air {
             | Air::ListExpose { tipo, .. }
             | Air::TupleAccessor { tipo, .. }
             | Air::TupleIndex { tipo, .. }
-            | Air::Todo { tipo, .. }
             | Air::ErrorTerm { tipo, .. }
             | Air::Trace { tipo, .. } => Some(tipo.clone()),
 

--- a/crates/aiken-lang/src/ast.rs
+++ b/crates/aiken-lang/src/ast.rs
@@ -995,9 +995,10 @@ pub struct RecordUpdateSpread {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub enum TodoKind {
-    Keyword,
-    EmptyFunction,
+pub enum TraceKind {
+    Trace,
+    Todo,
+    Error,
 }
 
 #[derive(Copy, Clone, PartialEq, Eq)]

--- a/crates/aiken-lang/src/builder.rs
+++ b/crates/aiken-lang/src/builder.rs
@@ -1685,12 +1685,12 @@ pub fn monomorphize(
                     needs_variant = true;
                 }
             }
-            Air::Trace { scope, text, tipo } => {
+            Air::Trace { scope, tipo } => {
                 if tipo.is_generic() {
                     let mut tipo = tipo.clone();
                     find_generics_to_replace(&mut tipo, &generic_types);
 
-                    new_air[index] = Air::Trace { scope, tipo, text };
+                    new_air[index] = Air::Trace { scope, tipo };
                     needs_variant = true;
                 }
             }

--- a/crates/aiken-lang/src/builder.rs
+++ b/crates/aiken-lang/src/builder.rs
@@ -1678,15 +1678,6 @@ pub fn monomorphize(
                     needs_variant = true;
                 }
             }
-            Air::Todo { scope, label, tipo } => {
-                if tipo.is_generic() {
-                    let mut tipo = tipo.clone();
-                    find_generics_to_replace(&mut tipo, &generic_types);
-
-                    new_air[index] = Air::Todo { scope, tipo, label };
-                    needs_variant = true;
-                }
-            }
             Air::ErrorTerm { scope, tipo } => {
                 if tipo.is_generic() {
                     let mut tipo = tipo.clone();

--- a/crates/aiken-lang/src/expr.rs
+++ b/crates/aiken-lang/src/expr.rs
@@ -96,7 +96,7 @@ pub enum TypedExpr {
         location: Span,
         tipo: Arc<Type>,
         then: Box<Self>,
-        text: Option<String>,
+        text: Box<Self>,
     },
 
     When {
@@ -389,7 +389,7 @@ pub enum UntypedExpr {
     Trace {
         location: Span,
         then: Box<Self>,
-        text: Option<String>,
+        text: Box<Self>,
     },
 
     When {

--- a/crates/aiken-lang/src/expr.rs
+++ b/crates/aiken-lang/src/expr.rs
@@ -5,7 +5,8 @@ use vec1::Vec1;
 use crate::{
     ast::{
         Annotation, Arg, AssignmentKind, BinOp, CallArg, Clause, DefinitionLocation, IfBranch,
-        Pattern, RecordUpdateSpread, Span, TypedRecordUpdateArg, UnOp, UntypedRecordUpdateArg,
+        Pattern, RecordUpdateSpread, Span, TraceKind, TypedRecordUpdateArg, UnOp,
+        UntypedRecordUpdateArg,
     },
     builtins::void,
     tipo::{ModuleValueConstructor, PatternConstructor, Type, ValueConstructor},
@@ -375,6 +376,7 @@ pub enum UntypedExpr {
     },
 
     Trace {
+        kind: TraceKind,
         location: Span,
         then: Box<Self>,
         text: Box<Self>,
@@ -435,6 +437,7 @@ impl UntypedExpr {
     pub fn todo(location: Span, reason: Option<Self>) -> Self {
         UntypedExpr::Trace {
             location,
+            kind: TraceKind::Todo,
             then: Box::new(UntypedExpr::ErrorTerm { location }),
             text: Box::new(reason.unwrap_or_else(|| UntypedExpr::String {
                 location,

--- a/crates/aiken-lang/src/expr.rs
+++ b/crates/aiken-lang/src/expr.rs
@@ -152,7 +152,6 @@ pub enum TypedExpr {
     ErrorTerm {
         location: Span,
         tipo: Arc<Type>,
-        label: Option<String>,
     },
 
     RecordUpdate {
@@ -429,7 +428,6 @@ pub enum UntypedExpr {
 
     ErrorTerm {
         location: Span,
-        label: Option<String>,
     },
 
     RecordUpdate {

--- a/crates/aiken-lang/src/expr.rs
+++ b/crates/aiken-lang/src/expr.rs
@@ -446,6 +446,18 @@ impl UntypedExpr {
         }
     }
 
+    pub fn error(location: Span, reason: Option<Self>) -> Self {
+        UntypedExpr::Trace {
+            location,
+            kind: TraceKind::Error,
+            then: Box::new(UntypedExpr::ErrorTerm { location }),
+            text: Box::new(reason.unwrap_or_else(|| UntypedExpr::String {
+                location,
+                value: DEFAULT_ERROR_STR.to_string(),
+            })),
+        }
+    }
+
     pub fn append_in_sequence(self, next: Self) -> Self {
         let location = Span {
             start: self.location().start,

--- a/crates/aiken-lang/src/expr.rs
+++ b/crates/aiken-lang/src/expr.rs
@@ -5,8 +5,7 @@ use vec1::Vec1;
 use crate::{
     ast::{
         Annotation, Arg, AssignmentKind, BinOp, CallArg, Clause, DefinitionLocation, IfBranch,
-        Pattern, RecordUpdateSpread, Span, TodoKind, TypedRecordUpdateArg, UnOp,
-        UntypedRecordUpdateArg,
+        Pattern, RecordUpdateSpread, Span, TypedRecordUpdateArg, UnOp, UntypedRecordUpdateArg,
     },
     builtins::void,
     tipo::{ModuleValueConstructor, PatternConstructor, Type, ValueConstructor},
@@ -143,12 +142,6 @@ pub enum TypedExpr {
         tuple: Box<Self>,
     },
 
-    Todo {
-        location: Span,
-        label: Option<String>,
-        tipo: Arc<Type>,
-    },
-
     ErrorTerm {
         location: Span,
         tipo: Arc<Type>,
@@ -176,7 +169,6 @@ impl TypedExpr {
             Self::Trace { then, .. } => then.tipo(),
             Self::Fn { tipo, .. }
             | Self::Int { tipo, .. }
-            | Self::Todo { tipo, .. }
             | Self::ErrorTerm { tipo, .. }
             | Self::When { tipo, .. }
             | Self::List { tipo, .. }
@@ -222,7 +214,6 @@ impl TypedExpr {
             | TypedExpr::List { .. }
             | TypedExpr::Call { .. }
             | TypedExpr::When { .. }
-            | TypedExpr::Todo { .. }
             | TypedExpr::ErrorTerm { .. }
             | TypedExpr::BinOp { .. }
             | TypedExpr::Tuple { .. }
@@ -261,7 +252,6 @@ impl TypedExpr {
             | Self::Int { location, .. }
             | Self::Var { location, .. }
             | Self::Trace { location, .. }
-            | Self::Todo { location, .. }
             | Self::ErrorTerm { location, .. }
             | Self::When { location, .. }
             | Self::Call { location, .. }
@@ -297,7 +287,6 @@ impl TypedExpr {
             | Self::Int { location, .. }
             | Self::Trace { location, .. }
             | Self::Var { location, .. }
-            | Self::Todo { location, .. }
             | Self::ErrorTerm { location, .. }
             | Self::When { location, .. }
             | Self::Call { location, .. }
@@ -420,12 +409,6 @@ pub enum UntypedExpr {
         tuple: Box<Self>,
     },
 
-    Todo {
-        kind: TodoKind,
-        location: Span,
-        label: Option<String>,
-    },
-
     ErrorTerm {
         location: Span,
     },
@@ -444,7 +427,22 @@ pub enum UntypedExpr {
     },
 }
 
+pub const DEFAULT_TODO_STR: &str = "aiken::todo";
+
+pub const DEFAULT_ERROR_STR: &str = "aiken::error";
+
 impl UntypedExpr {
+    pub fn todo(location: Span, reason: Option<Self>) -> Self {
+        UntypedExpr::Trace {
+            location,
+            then: Box::new(UntypedExpr::ErrorTerm { location }),
+            text: Box::new(reason.unwrap_or_else(|| UntypedExpr::String {
+                location,
+                value: DEFAULT_TODO_STR.to_string(),
+            })),
+        }
+    }
+
     pub fn append_in_sequence(self, next: Self) -> Self {
         let location = Span {
             start: self.location().start,
@@ -500,7 +498,6 @@ impl UntypedExpr {
             Self::Fn { location, .. }
             | Self::Var { location, .. }
             | Self::Int { location, .. }
-            | Self::Todo { location, .. }
             | Self::ErrorTerm { location, .. }
             | Self::When { location, .. }
             | Self::Call { location, .. }

--- a/crates/aiken-lang/src/format.rs
+++ b/crates/aiken-lang/src/format.rs
@@ -743,9 +743,7 @@ impl<'comments> Formatter<'comments> {
                     .append(suffix)
             }
 
-            UntypedExpr::ErrorTerm { label: None, .. } => "error".to_doc(),
-
-            UntypedExpr::ErrorTerm { label: Some(l), .. } => docvec!["error(\"", l, "\")"],
+            UntypedExpr::ErrorTerm { .. } => "error".to_doc(),
         };
 
         commented(document, comments)

--- a/crates/aiken-lang/src/format.rs
+++ b/crates/aiken-lang/src/format.rs
@@ -705,22 +705,10 @@ impl<'comments> Formatter<'comments> {
                 ..
             } => self.assignment(pattern, value, None, Some(*kind), annotation),
 
-            UntypedExpr::Trace {
-                text: None, then, ..
-            } => "trace"
+            UntypedExpr::Trace { text, then, .. } => "trace"
                 .to_doc()
-                .append(if self.pop_empty_lines(then.start_byte_index()) {
-                    lines(2)
-                } else {
-                    line()
-                })
-                .append(self.expr(then)),
-
-            UntypedExpr::Trace {
-                text: Some(l),
-                then,
-                ..
-            } => docvec!["trace(\"", l, "\")"]
+                .append(wrap_args([(self.wrap_expr(text), false)]))
+                .group()
                 .append(if self.pop_empty_lines(then.start_byte_index()) {
                     lines(2)
                 } else {

--- a/crates/aiken-lang/src/format.rs
+++ b/crates/aiken-lang/src/format.rs
@@ -654,9 +654,6 @@ impl<'comments> Formatter<'comments> {
                 final_else,
                 ..
             } => self.if_expr(branches, final_else),
-            UntypedExpr::Todo { label: None, .. } => "todo".to_doc(),
-
-            UntypedExpr::Todo { label: Some(l), .. } => docvec!["todo(\"", l, "\")"],
 
             UntypedExpr::PipeLine { expressions, .. } => self.pipeline(expressions),
 

--- a/crates/aiken-lang/src/parser.rs
+++ b/crates/aiken-lang/src/parser.rs
@@ -592,15 +592,14 @@ pub fn expr_seq_parser() -> impl Parser<Token, expr::UntypedExpr, Error = ParseE
         choice((
             just(Token::Trace)
                 .ignore_then(
-                    select! {Token::String {value} => value}
-                        .delimited_by(just(Token::LeftParen), just(Token::RightParen))
-                        .or_not(),
+                    expr_parser(r.clone())
+                        .delimited_by(just(Token::LeftParen), just(Token::RightParen)),
                 )
                 .then(r.clone())
                 .map_with_span(|(text, then_), span| expr::UntypedExpr::Trace {
                     location: span,
                     then: Box::new(then_),
-                    text,
+                    text: Box::new(text),
                 }),
             expr_parser(r.clone())
                 .then(r.repeated())

--- a/crates/aiken-lang/src/tests/check.rs
+++ b/crates/aiken-lang/src/tests/check.rs
@@ -126,3 +126,35 @@ fn list_pattern_6() {
     "#;
     assert!(check(parse(source_code)).is_ok())
 }
+
+#[test]
+fn trace_strings() {
+    let source_code = r#"
+        fn bar() {
+            "BAR"
+        }
+
+        test foo() {
+            let msg1 = "FOO"
+            trace("INLINE")
+            trace(msg1)
+            trace(bar())
+            True
+        }
+    "#;
+    assert!(check(parse(source_code)).is_ok())
+}
+
+#[test]
+fn trace_non_strings() {
+    let source_code = r#"
+        test foo() {
+            trace(14 + 42)
+            True
+        }
+    "#;
+    assert!(matches!(
+        check(parse(source_code)),
+        Err((_, Error::CouldNotUnify { .. }))
+    ))
+}

--- a/crates/aiken-lang/src/tests/format.rs
+++ b/crates/aiken-lang/src/tests/format.rs
@@ -320,7 +320,7 @@ fn test_nested_function_calls() {
             ,
             when output.datum is {
               InlineDatum(_) -> True
-              _ -> error("expected inline datum")
+              _ -> error "expected inline datum"
             },
           ]
           |> list.and
@@ -339,7 +339,7 @@ fn test_nested_function_calls() {
             ),
             when output.datum is {
               InlineDatum(_) -> True
-              _ -> error("expected inline datum")
+              _ -> error "expected inline datum"
             },
           ]
           |> list.and
@@ -347,4 +347,35 @@ fn test_nested_function_calls() {
     "#};
 
     assert_fmt(src, expected);
+}
+
+#[test]
+fn format_trace_todo_error() {
+    let src = indoc! {r#"
+        fn foo_1() {
+          todo
+        }
+
+        fn foo_2() {
+          todo "my custom message"
+        }
+
+        fn foo_3() {
+          when x is {
+            Foo -> True
+            _ -> error
+          }
+        }
+
+        fn foo_4() {
+          if 14 == 42 {
+            error "I don't think so"
+          } else {
+            trace "been there"
+            True
+          }
+        }
+    "#};
+
+    assert_fmt(src, src);
 }

--- a/crates/aiken-lang/src/tests/parser.rs
+++ b/crates/aiken-lang/src/tests/parser.rs
@@ -309,6 +309,7 @@ fn empty_function() {
         vec![ast::UntypedDefinition::Fn(Function {
             arguments: vec![],
             body: expr::UntypedExpr::Trace {
+                kind: ast::TraceKind::Todo,
                 location: Span::new((), 0..15),
                 text: Box::new(expr::UntypedExpr::String {
                     value: "aiken::todo".to_string(),
@@ -1787,6 +1788,7 @@ fn function_def() {
             doc: None,
             arguments: vec![],
             body: expr::UntypedExpr::Trace {
+                kind: ast::TraceKind::Todo,
                 location: Span::new((), 0..11),
                 text: Box::new(expr::UntypedExpr::String {
                     value: "aiken::todo".to_string(),
@@ -2630,12 +2632,16 @@ fn trace_expressions() {
                         annotation: None,
                     },
                     expr::UntypedExpr::Trace {
+                        kind: ast::TraceKind::Trace,
                         location: Span::new((), 32..128),
                         then: Box::new(expr::UntypedExpr::Trace {
+                            kind: ast::TraceKind::Trace,
                             location: Span::new((), 49..128),
                             then: Box::new(expr::UntypedExpr::Trace {
+                                kind: ast::TraceKind::Trace,
                                 location: Span::new((), 62..128),
                                 then: Box::new(expr::UntypedExpr::Trace {
+                                    kind: ast::TraceKind::Trace,
                                     location: Span::new((), 97..128),
                                     then: Box::new(expr::UntypedExpr::Var {
                                         location: Span::new((), 124..128),
@@ -2735,6 +2741,7 @@ fn parse_keyword_error() {
             ast::Definition::Fn(Function {
                 arguments: vec![],
                 body: expr::UntypedExpr::Trace {
+                    kind: ast::TraceKind::Error,
                     location: Span::new((), 13..36),
                     then: Box::new(expr::UntypedExpr::ErrorTerm {
                         location: Span::new((), 13..36),
@@ -2789,6 +2796,7 @@ fn parse_keyword_error() {
                             alternative_patterns: vec![],
                             guard: None,
                             then: expr::UntypedExpr::Trace {
+                                kind: ast::TraceKind::Error,
                                 location: Span::new((), 100..105),
                                 then: Box::new(expr::UntypedExpr::ErrorTerm {
                                     location: Span::new((), 100..105),
@@ -2833,6 +2841,7 @@ fn parse_keyword_todo() {
             ast::Definition::Fn(Function {
                 arguments: vec![],
                 body: expr::UntypedExpr::Trace {
+                    kind: ast::TraceKind::Todo,
                     location: Span::new((), 13..35),
                     then: Box::new(expr::UntypedExpr::ErrorTerm {
                         location: Span::new((), 13..35),
@@ -2887,6 +2896,7 @@ fn parse_keyword_todo() {
                             alternative_patterns: vec![],
                             guard: None,
                             then: expr::UntypedExpr::Trace {
+                                kind: ast::TraceKind::Todo,
                                 location: Span::new((), 99..103),
                                 then: Box::new(expr::UntypedExpr::ErrorTerm {
                                     location: Span::new((), 99..103),

--- a/crates/aiken-lang/src/tests/parser.rs
+++ b/crates/aiken-lang/src/tests/parser.rs
@@ -308,10 +308,15 @@ fn empty_function() {
         code,
         vec![ast::UntypedDefinition::Fn(Function {
             arguments: vec![],
-            body: expr::UntypedExpr::Todo {
-                kind: ast::TodoKind::EmptyFunction,
+            body: expr::UntypedExpr::Trace {
                 location: Span::new((), 0..15),
-                label: None,
+                text: Box::new(expr::UntypedExpr::String {
+                    value: "aiken::todo".to_string(),
+                    location: Span::new((), 0..15),
+                }),
+                then: Box::new(expr::UntypedExpr::ErrorTerm {
+                    location: Span::new((), 0..15),
+                }),
             },
             doc: None,
             location: Span::new((), 0..12),
@@ -1781,10 +1786,15 @@ fn function_def() {
         vec![ast::UntypedDefinition::Fn(Function {
             doc: None,
             arguments: vec![],
-            body: expr::UntypedExpr::Todo {
-                kind: ast::TodoKind::EmptyFunction,
+            body: expr::UntypedExpr::Trace {
                 location: Span::new((), 0..11),
-                label: None,
+                text: Box::new(expr::UntypedExpr::String {
+                    value: "aiken::todo".to_string(),
+                    location: Span::new((), 0..11),
+                }),
+                then: Box::new(expr::UntypedExpr::ErrorTerm {
+                    location: Span::new((), 0..11),
+                }),
             },
             location: Span::new((), 0..8),
             name: "foo".to_string(),
@@ -2710,7 +2720,6 @@ fn parse_keyword_error() {
     let code = indoc! {r#"
           fn foo() {
             error "not implemented"
-            Void
           }
 
           fn bar() {
@@ -2726,18 +2735,9 @@ fn parse_keyword_error() {
             ast::Definition::Fn(Function {
                 arguments: vec![],
                 body: expr::UntypedExpr::Trace {
-                    location: Span::new((), 13..43),
-                    then: Box::new(expr::UntypedExpr::Sequence {
-                        location: Span::new((), 13..43),
-                        expressions: vec![
-                            expr::UntypedExpr::ErrorTerm {
-                                location: Span::new((), 13..43),
-                            },
-                            expr::UntypedExpr::Var {
-                                location: Span::new((), 39..43),
-                                name: "Void".to_string(),
-                            },
-                        ],
+                    location: Span::new((), 13..36),
+                    then: Box::new(expr::UntypedExpr::ErrorTerm {
+                        location: Span::new((), 13..36),
                     }),
                     text: Box::new(expr::UntypedExpr::String {
                         location: Span::new((), 19..36),
@@ -2750,22 +2750,22 @@ fn parse_keyword_error() {
                 public: false,
                 return_annotation: None,
                 return_type: (),
-                end_position: 44,
+                end_position: 37,
             }),
             ast::Definition::Fn(Function {
                 arguments: vec![],
                 body: expr::UntypedExpr::When {
-                    location: Span::new((), 60..116),
+                    location: Span::new((), 53..109),
                     subjects: vec![expr::UntypedExpr::Var {
-                        location: Span::new((), 65..66),
+                        location: Span::new((), 58..59),
                         name: "x".to_string(),
                     }],
                     clauses: vec![
                         ast::Clause {
-                            location: Span::new((), 78..95),
+                            location: Span::new((), 71..88),
                             pattern: vec![ast::Pattern::Constructor {
                                 is_record: false,
-                                location: Span::new((), 78..87),
+                                location: Span::new((), 71..80),
                                 name: "Something".to_string(),
                                 arguments: vec![],
                                 module: None,
@@ -2776,25 +2776,25 @@ fn parse_keyword_error() {
                             alternative_patterns: vec![],
                             guard: None,
                             then: expr::UntypedExpr::Var {
-                                location: Span::new((), 91..95),
+                                location: Span::new((), 84..88),
                                 name: "Void".to_string(),
                             },
                         },
                         ast::Clause {
-                            location: Span::new((), 102..112),
+                            location: Span::new((), 95..105),
                             pattern: vec![ast::Pattern::Discard {
                                 name: "_".to_string(),
-                                location: Span::new((), 102..103),
+                                location: Span::new((), 95..96),
                             }],
                             alternative_patterns: vec![],
                             guard: None,
                             then: expr::UntypedExpr::Trace {
-                                location: Span::new((), 107..112),
+                                location: Span::new((), 100..105),
                                 then: Box::new(expr::UntypedExpr::ErrorTerm {
-                                    location: Span::new((), 107..112),
+                                    location: Span::new((), 100..105),
                                 }),
                                 text: Box::new(expr::UntypedExpr::String {
-                                    location: Span::new((), 107..112),
+                                    location: Span::new((), 100..105),
                                     value: "aiken::error".to_string(),
                                 }),
                             },
@@ -2802,12 +2802,110 @@ fn parse_keyword_error() {
                     ],
                 },
                 doc: None,
-                location: Span::new((), 47..55),
+                location: Span::new((), 40..48),
                 name: "bar".to_string(),
                 public: false,
                 return_annotation: None,
                 return_type: (),
-                end_position: 117,
+                end_position: 110,
+            }),
+        ],
+    )
+}
+
+#[test]
+fn parse_keyword_todo() {
+    let code = indoc! {r#"
+          fn foo() {
+            todo "not implemented"
+          }
+
+          fn bar() {
+            when x is {
+                Something -> Void
+                _ -> todo
+            }
+          }
+        "#};
+    assert_definitions(
+        code,
+        vec![
+            ast::Definition::Fn(Function {
+                arguments: vec![],
+                body: expr::UntypedExpr::Trace {
+                    location: Span::new((), 13..35),
+                    then: Box::new(expr::UntypedExpr::ErrorTerm {
+                        location: Span::new((), 13..35),
+                    }),
+                    text: Box::new(expr::UntypedExpr::String {
+                        location: Span::new((), 18..35),
+                        value: "not implemented".to_string(),
+                    }),
+                },
+                doc: None,
+                location: Span::new((), 0..8),
+                name: "foo".to_string(),
+                public: false,
+                return_annotation: None,
+                return_type: (),
+                end_position: 36,
+            }),
+            ast::Definition::Fn(Function {
+                arguments: vec![],
+                body: expr::UntypedExpr::When {
+                    location: Span::new((), 52..107),
+                    subjects: vec![expr::UntypedExpr::Var {
+                        location: Span::new((), 57..58),
+                        name: "x".to_string(),
+                    }],
+                    clauses: vec![
+                        ast::Clause {
+                            location: Span::new((), 70..87),
+                            pattern: vec![ast::Pattern::Constructor {
+                                is_record: false,
+                                location: Span::new((), 70..79),
+                                name: "Something".to_string(),
+                                arguments: vec![],
+                                module: None,
+                                constructor: (),
+                                with_spread: false,
+                                tipo: (),
+                            }],
+                            alternative_patterns: vec![],
+                            guard: None,
+                            then: expr::UntypedExpr::Var {
+                                location: Span::new((), 83..87),
+                                name: "Void".to_string(),
+                            },
+                        },
+                        ast::Clause {
+                            location: Span::new((), 94..103),
+                            pattern: vec![ast::Pattern::Discard {
+                                name: "_".to_string(),
+                                location: Span::new((), 94..95),
+                            }],
+                            alternative_patterns: vec![],
+                            guard: None,
+                            then: expr::UntypedExpr::Trace {
+                                location: Span::new((), 99..103),
+                                then: Box::new(expr::UntypedExpr::ErrorTerm {
+                                    location: Span::new((), 99..103),
+                                }),
+                                text: Box::new(expr::UntypedExpr::String {
+                                    location: Span::new((), 99..103),
+                                    value: "aiken::todo".to_string(),
+                                }),
+                            },
+                        },
+                    ],
+                },
+                doc: None,
+                location: Span::new((), 39..47),
+                name: "bar".to_string(),
+                public: false,
+                return_annotation: None,
+                return_type: (),
+                end_position: 108,
             }),
         ],
     )

--- a/crates/aiken-lang/src/tests/parser.rs
+++ b/crates/aiken-lang/src/tests/parser.rs
@@ -2586,3 +2586,121 @@ fn scope_logical_expression() {
         })],
     )
 }
+
+#[test]
+fn trace_expressions() {
+    let code = indoc! {r#"
+          fn foo() {
+            let msg1 = "FOO"
+            trace "INLINE"
+            trace msg1
+            trace string.concat(msg1, "BAR")
+            trace ( 14 + 42 * 1337 )
+            Void
+          }
+        "#};
+    assert_definitions(
+        code,
+        vec![ast::Definition::Fn(Function {
+            arguments: vec![],
+            body: expr::UntypedExpr::Sequence {
+                location: Span::new((), 13..128),
+                expressions: vec![
+                    expr::UntypedExpr::Assignment {
+                        location: Span::new((), 13..29),
+                        value: Box::new(expr::UntypedExpr::String {
+                            location: Span::new((), 24..29),
+                            value: "FOO".to_string(),
+                        }),
+                        pattern: ast::Pattern::Var {
+                            location: Span::new((), 17..21),
+                            name: "msg1".to_string(),
+                        },
+                        kind: ast::AssignmentKind::Let,
+                        annotation: None,
+                    },
+                    expr::UntypedExpr::Trace {
+                        location: Span::new((), 32..128),
+                        then: Box::new(expr::UntypedExpr::Trace {
+                            location: Span::new((), 49..128),
+                            then: Box::new(expr::UntypedExpr::Trace {
+                                location: Span::new((), 62..128),
+                                then: Box::new(expr::UntypedExpr::Trace {
+                                    location: Span::new((), 97..128),
+                                    then: Box::new(expr::UntypedExpr::Var {
+                                        location: Span::new((), 124..128),
+                                        name: "Void".to_string(),
+                                    }),
+                                    text: Box::new(expr::UntypedExpr::BinOp {
+                                        location: Span::new((), 105..119),
+                                        name: ast::BinOp::AddInt,
+                                        left: Box::new(expr::UntypedExpr::Int {
+                                            location: Span::new((), 105..107),
+                                            value: "14".to_string(),
+                                        }),
+                                        right: Box::new(expr::UntypedExpr::BinOp {
+                                            location: Span::new((), 110..119),
+                                            name: ast::BinOp::MultInt,
+                                            left: Box::new(expr::UntypedExpr::Int {
+                                                location: Span::new((), 110..112),
+                                                value: "42".to_string(),
+                                            }),
+                                            right: Box::new(expr::UntypedExpr::Int {
+                                                location: Span::new((), 115..119),
+                                                value: "1337".to_string(),
+                                            }),
+                                        }),
+                                    }),
+                                }),
+                                text: Box::new(expr::UntypedExpr::Call {
+                                    arguments: vec![
+                                        ast::CallArg {
+                                            label: None,
+                                            location: Span::new((), 82..86),
+                                            value: expr::UntypedExpr::Var {
+                                                location: Span::new((), 82..86),
+                                                name: "msg1".to_string(),
+                                            },
+                                        },
+                                        ast::CallArg {
+                                            label: None,
+                                            location: Span::new((), 88..93),
+                                            value: expr::UntypedExpr::String {
+                                                location: Span::new((), 88..93),
+                                                value: "BAR".to_string(),
+                                            },
+                                        },
+                                    ],
+                                    fun: Box::new(expr::UntypedExpr::FieldAccess {
+                                        location: Span::new((), 68..81),
+                                        label: "concat".to_string(),
+                                        container: Box::new(expr::UntypedExpr::Var {
+                                            location: Span::new((), 68..74),
+                                            name: "string".to_string(),
+                                        }),
+                                    }),
+                                    location: Span::new((), 68..94),
+                                }),
+                            }),
+                            text: Box::new(expr::UntypedExpr::Var {
+                                location: Span::new((), 55..59),
+                                name: "msg1".to_string(),
+                            }),
+                        }),
+                        text: Box::new(expr::UntypedExpr::String {
+                            location: Span::new((), 38..46),
+                            value: "INLINE".to_string(),
+                        }),
+                    },
+                ],
+            },
+            doc: None,
+            location: Span::new((), 0..8),
+            name: "foo".to_string(),
+            public: false,
+            return_annotation: None,
+            return_type: (),
+            end_position: 129,
+        })],
+    )
+}

--- a/crates/aiken-lang/src/tests/parser.rs
+++ b/crates/aiken-lang/src/tests/parser.rs
@@ -2704,3 +2704,111 @@ fn trace_expressions() {
         })],
     )
 }
+
+#[test]
+fn parse_keyword_error() {
+    let code = indoc! {r#"
+          fn foo() {
+            error "not implemented"
+            Void
+          }
+
+          fn bar() {
+            when x is {
+                Something -> Void
+                _ -> error
+            }
+          }
+        "#};
+    assert_definitions(
+        code,
+        vec![
+            ast::Definition::Fn(Function {
+                arguments: vec![],
+                body: expr::UntypedExpr::Trace {
+                    location: Span::new((), 13..43),
+                    then: Box::new(expr::UntypedExpr::Sequence {
+                        location: Span::new((), 13..43),
+                        expressions: vec![
+                            expr::UntypedExpr::ErrorTerm {
+                                location: Span::new((), 13..43),
+                            },
+                            expr::UntypedExpr::Var {
+                                location: Span::new((), 39..43),
+                                name: "Void".to_string(),
+                            },
+                        ],
+                    }),
+                    text: Box::new(expr::UntypedExpr::String {
+                        location: Span::new((), 19..36),
+                        value: "not implemented".to_string(),
+                    }),
+                },
+                doc: None,
+                location: Span::new((), 0..8),
+                name: "foo".to_string(),
+                public: false,
+                return_annotation: None,
+                return_type: (),
+                end_position: 44,
+            }),
+            ast::Definition::Fn(Function {
+                arguments: vec![],
+                body: expr::UntypedExpr::When {
+                    location: Span::new((), 60..116),
+                    subjects: vec![expr::UntypedExpr::Var {
+                        location: Span::new((), 65..66),
+                        name: "x".to_string(),
+                    }],
+                    clauses: vec![
+                        ast::Clause {
+                            location: Span::new((), 78..95),
+                            pattern: vec![ast::Pattern::Constructor {
+                                is_record: false,
+                                location: Span::new((), 78..87),
+                                name: "Something".to_string(),
+                                arguments: vec![],
+                                module: None,
+                                constructor: (),
+                                with_spread: false,
+                                tipo: (),
+                            }],
+                            alternative_patterns: vec![],
+                            guard: None,
+                            then: expr::UntypedExpr::Var {
+                                location: Span::new((), 91..95),
+                                name: "Void".to_string(),
+                            },
+                        },
+                        ast::Clause {
+                            location: Span::new((), 102..112),
+                            pattern: vec![ast::Pattern::Discard {
+                                name: "_".to_string(),
+                                location: Span::new((), 102..103),
+                            }],
+                            alternative_patterns: vec![],
+                            guard: None,
+                            then: expr::UntypedExpr::Trace {
+                                location: Span::new((), 107..112),
+                                then: Box::new(expr::UntypedExpr::ErrorTerm {
+                                    location: Span::new((), 107..112),
+                                }),
+                                text: Box::new(expr::UntypedExpr::String {
+                                    location: Span::new((), 107..112),
+                                    value: "aiken::error".to_string(),
+                                }),
+                            },
+                        },
+                    ],
+                },
+                doc: None,
+                location: Span::new((), 47..55),
+                name: "bar".to_string(),
+                public: false,
+                return_annotation: None,
+                return_type: (),
+                end_position: 117,
+            }),
+        ],
+    )
+}

--- a/crates/aiken-lang/src/tests/parser.rs
+++ b/crates/aiken-lang/src/tests/parser.rs
@@ -2830,8 +2830,9 @@ fn parse_keyword_todo() {
 
           fn bar() {
             when x is {
-                Something -> Void
-                _ -> todo
+                Foo -> todo
+                Bar -> True
+                _ -> False
             }
           }
         "#};
@@ -2862,18 +2863,44 @@ fn parse_keyword_todo() {
             ast::Definition::Fn(Function {
                 arguments: vec![],
                 body: expr::UntypedExpr::When {
-                    location: Span::new((), 52..107),
+                    location: Span::new((), 52..120),
                     subjects: vec![expr::UntypedExpr::Var {
                         location: Span::new((), 57..58),
                         name: "x".to_string(),
                     }],
                     clauses: vec![
                         ast::Clause {
-                            location: Span::new((), 70..87),
+                            location: Span::new((), 70..81),
                             pattern: vec![ast::Pattern::Constructor {
                                 is_record: false,
-                                location: Span::new((), 70..79),
-                                name: "Something".to_string(),
+                                location: Span::new((), 70..73),
+                                name: "Foo".to_string(),
+                                arguments: vec![],
+                                module: None,
+                                constructor: (),
+                                with_spread: false,
+                                tipo: (),
+                            }],
+                            alternative_patterns: vec![],
+                            guard: None,
+                            then: expr::UntypedExpr::Trace {
+                                kind: ast::TraceKind::Todo,
+                                location: Span::new((), 77..81),
+                                then: Box::new(expr::UntypedExpr::ErrorTerm {
+                                    location: Span::new((), 77..81),
+                                }),
+                                text: Box::new(expr::UntypedExpr::String {
+                                    location: Span::new((), 77..81),
+                                    value: "aiken::todo".to_string(),
+                                }),
+                            },
+                        },
+                        ast::Clause {
+                            location: Span::new((), 88..99),
+                            pattern: vec![ast::Pattern::Constructor {
+                                is_record: false,
+                                location: Span::new((), 88..91),
+                                name: "Bar".to_string(),
                                 arguments: vec![],
                                 module: None,
                                 constructor: (),
@@ -2883,28 +2910,21 @@ fn parse_keyword_todo() {
                             alternative_patterns: vec![],
                             guard: None,
                             then: expr::UntypedExpr::Var {
-                                location: Span::new((), 83..87),
-                                name: "Void".to_string(),
+                                location: Span::new((), 95..99),
+                                name: "True".to_string(),
                             },
                         },
                         ast::Clause {
-                            location: Span::new((), 94..103),
+                            location: Span::new((), 106..116),
                             pattern: vec![ast::Pattern::Discard {
                                 name: "_".to_string(),
-                                location: Span::new((), 94..95),
+                                location: Span::new((), 106..107),
                             }],
                             alternative_patterns: vec![],
                             guard: None,
-                            then: expr::UntypedExpr::Trace {
-                                kind: ast::TraceKind::Todo,
-                                location: Span::new((), 99..103),
-                                then: Box::new(expr::UntypedExpr::ErrorTerm {
-                                    location: Span::new((), 99..103),
-                                }),
-                                text: Box::new(expr::UntypedExpr::String {
-                                    location: Span::new((), 99..103),
-                                    value: "aiken::todo".to_string(),
-                                }),
+                            then: expr::UntypedExpr::Var {
+                                location: Span::new((), 111..116),
+                                name: "False".to_string(),
                             },
                         },
                     ],
@@ -2915,7 +2935,7 @@ fn parse_keyword_todo() {
                 public: false,
                 return_annotation: None,
                 return_type: (),
-                end_position: 108,
+                end_position: 121,
             }),
         ],
     )

--- a/crates/aiken-lang/src/tipo/error.rs
+++ b/crates/aiken-lang/src/tipo/error.rs
@@ -1,6 +1,6 @@
 use super::Type;
 use crate::{
-    ast::{Annotation, BinOp, CallArg, Span, TodoKind, UntypedPattern},
+    ast::{Annotation, BinOp, CallArg, Span, UntypedPattern},
     expr::{self, UntypedExpr},
     format::Formatter,
     levenshtein,
@@ -1118,7 +1118,6 @@ pub enum Warning {
     #[diagnostic(help("You probably want to replace that one with real code... eventually."))]
     #[diagnostic(code("todo"))]
     Todo {
-        kind: TodoKind,
         #[label]
         location: Span,
         tipo: Arc<Type>,

--- a/crates/aiken-lang/src/tipo/expr.rs
+++ b/crates/aiken-lang/src/tipo/expr.rs
@@ -5,7 +5,7 @@ use vec1::Vec1;
 use crate::{
     ast::{
         Annotation, Arg, ArgName, AssignmentKind, BinOp, CallArg, Clause, ClauseGuard, Constant,
-        RecordUpdateSpread, Span, TypedArg, TypedCallArg, TypedClause, TypedClauseGuard,
+        RecordUpdateSpread, Span, TraceKind, TypedArg, TypedCallArg, TypedClause, TypedClauseGuard,
         TypedConstant, TypedIfBranch, TypedMultiPattern, TypedRecordUpdateArg, UnOp, UntypedArg,
         UntypedClause, UntypedClauseGuard, UntypedConstant, UntypedIfBranch, UntypedMultiPattern,
         UntypedPattern, UntypedRecordUpdateArg,
@@ -299,7 +299,8 @@ impl<'a, 'b> ExprTyper<'a, 'b> {
                 location,
                 then,
                 text,
-            } => self.infer_trace(*then, location, *text),
+                kind,
+            } => self.infer_trace(kind, *then, location, *text),
 
             UntypedExpr::When {
                 location,
@@ -1855,6 +1856,7 @@ impl<'a, 'b> ExprTyper<'a, 'b> {
 
     fn infer_trace(
         &mut self,
+        kind: TraceKind,
         then: UntypedExpr,
         location: Span,
         text: UntypedExpr,
@@ -1865,12 +1867,12 @@ impl<'a, 'b> ExprTyper<'a, 'b> {
         let then = self.infer(then)?;
         let tipo = then.tipo();
 
-        // TODO: reinstate once we can distinguish traces
-        //
-        // self.environment.warnings.push(Warning::Todo {
-        //     location,
-        //     tipo: tipo.clone(),
-        // })
+        if let TraceKind::Todo = kind {
+            self.environment.warnings.push(Warning::Todo {
+                location,
+                tipo: tipo.clone(),
+            })
+        }
 
         Ok(TypedExpr::Trace {
             location,

--- a/crates/aiken-lang/src/tipo/expr.rs
+++ b/crates/aiken-lang/src/tipo/expr.rs
@@ -256,9 +256,7 @@ impl<'a, 'b> ExprTyper<'a, 'b> {
                 ..
             } => Ok(self.infer_todo(location, kind, label)),
 
-            UntypedExpr::ErrorTerm { location, label } => {
-                Ok(self.infer_error_term(location, label))
-            }
+            UntypedExpr::ErrorTerm { location } => Ok(self.infer_error_term(location)),
 
             UntypedExpr::Var { location, name, .. } => self.infer_var(name, location),
 
@@ -1873,14 +1871,10 @@ impl<'a, 'b> ExprTyper<'a, 'b> {
         }
     }
 
-    fn infer_error_term(&mut self, location: Span, label: Option<String>) -> TypedExpr {
+    fn infer_error_term(&mut self, location: Span) -> TypedExpr {
         let tipo = self.new_unbound_var();
 
-        TypedExpr::ErrorTerm {
-            location,
-            tipo,
-            label,
-        }
+        TypedExpr::ErrorTerm { location, tipo }
     }
 
     fn infer_trace(

--- a/crates/aiken-lang/src/tipo/expr.rs
+++ b/crates/aiken-lang/src/tipo/expr.rs
@@ -309,7 +309,7 @@ impl<'a, 'b> ExprTyper<'a, 'b> {
                 location,
                 then,
                 text,
-            } => self.infer_trace(*then, location, text),
+            } => self.infer_trace(*then, location, *text),
 
             UntypedExpr::When {
                 location,
@@ -1887,17 +1887,19 @@ impl<'a, 'b> ExprTyper<'a, 'b> {
         &mut self,
         then: UntypedExpr,
         location: Span,
-        text: Option<String>,
+        text: UntypedExpr,
     ) -> Result<TypedExpr, Error> {
-        let then = self.infer(then)?;
+        let text = self.infer(text)?;
+        self.unify(text.tipo(), string(), text.location(), false)?;
 
+        let then = self.infer(then)?;
         let tipo = then.tipo();
 
         Ok(TypedExpr::Trace {
             location,
             tipo,
             then: Box::new(then),
-            text,
+            text: Box::new(text),
         })
     }
 

--- a/crates/aiken-lang/src/uplc.rs
+++ b/crates/aiken-lang/src/uplc.rs
@@ -587,13 +587,6 @@ impl<'a> CodeGenerator<'a> {
                     constants_ir(literal, ir_stack, scope);
                 }
             },
-            TypedExpr::Todo { label, tipo, .. } => {
-                ir_stack.push(Air::Todo {
-                    scope,
-                    label: label.clone(),
-                    tipo: tipo.clone(),
-                });
-            }
             TypedExpr::RecordUpdate {
                 spread, args, tipo, ..
             } => {
@@ -3494,16 +3487,6 @@ impl<'a> CodeGenerator<'a> {
                         tuple_index,
                     };
                 }
-                Air::Todo { tipo, scope, label } => {
-                    let mut replaced_type = tipo.clone();
-                    replace_opaque_type(&mut replaced_type, self.data_types.clone());
-
-                    ir_stack[index] = Air::Todo {
-                        scope,
-                        label,
-                        tipo: replaced_type,
-                    };
-                }
                 Air::ErrorTerm { tipo, scope } => {
                     let mut replaced_type = tipo.clone();
                     replace_opaque_type(&mut replaced_type, self.data_types.clone());
@@ -5285,23 +5268,6 @@ impl<'a> CodeGenerator<'a> {
                     }
                     arg_stack.push(term);
                 }
-            }
-            Air::Todo { label, .. } => {
-                let term = apply_wrap(
-                    apply_wrap(
-                        Term::Builtin(DefaultFunction::Trace).force_wrap(),
-                        Term::Constant(
-                            UplcConstant::String(
-                                label.unwrap_or_else(|| "aiken::todo".to_string()),
-                            )
-                            .into(),
-                        ),
-                    ),
-                    Term::Delay(Term::Error.into()),
-                )
-                .force_wrap();
-
-                arg_stack.push(term);
             }
             Air::RecordUpdate {
                 highest_index,

--- a/examples/acceptance_tests/032/lib/tests.ak
+++ b/examples/acceptance_tests/032/lib/tests.ak
@@ -1,9 +1,19 @@
+use aiken/builtin
+
+fn concat(left: String, right: String) -> String {
+  builtin.append_bytearray(
+    builtin.encode_utf8(left),
+    builtin.encode_utf8(right),
+  )
+  |> builtin.decode_utf8
+}
+
 fn is_negative(i: Int) -> Bool {
   if i < 0 {
     trace("is negative")
     True
   } else {
-    trace("is non-negative")
+    trace(concat("is", concat(" ", "non-negative")))
     False
   }
 }

--- a/examples/acceptance_tests/032/lib/tests.ak
+++ b/examples/acceptance_tests/032/lib/tests.ak
@@ -10,10 +10,10 @@ fn concat(left: String, right: String) -> String {
 
 fn is_negative(i: Int) -> Bool {
   if i < 0 {
-    trace("is negative")
+    trace "is negative"
     True
   } else {
-    trace(concat("is", concat(" ", "non-negative")))
+    trace concat("is", concat(" ", "non-negative"))
     False
   }
 }


### PR DESCRIPTION
- :round_pushpin: **Allow to trace expressions (and not only string literals)**
    This however enforces that the argument unifies to a `String`. So this
  is more flexible than the previous form, but does fundamentally the
  same thing.

  Fixes #378.

- :round_pushpin: **Lift 'error' up one level in the parser and remove its label.**
    We now parse errors as a combination of a trace plus and error term. This is a baby step in order to simplify the code generation down the line and the internal representation of todo / errors.

- :round_pushpin: **Remove 'Todo' from the AST & AIR**
    Todo is fundamentally just a trace and an error. The only reason we kept it as a separate element in the AST is for the formatter to work out whether it should format something back to a todo or something else.

  However, this introduces redundancy in the code internally and makes the AIR more complicated than it needs to be. Both todo and errors can actually be represented as trace + errors, and we only need to record their preferred shape when parsing so that we can format them back to what's expected.

- :round_pushpin: **Preserve trace, error & todo formatting.**
  