### PR TITLE
Handle recursive type definitions in blueprint

### DIFF
--- a/crates/aiken-project/src/blueprint/definitions.rs
+++ b/crates/aiken-project/src/blueprint/definitions.rs
@@ -1,0 +1,183 @@
+use aiken_lang::tipo::{Type, TypeVar};
+use serde::{
+    self,
+    ser::{Serialize, SerializeStruct, Serializer},
+};
+use std::{
+    collections::{BTreeMap, HashMap},
+    fmt::{self, Display},
+    ops::Deref,
+    sync::Arc,
+};
+
+// ---------- Definitions
+
+/// A map of definitions meant to be optionally registered and looked up.
+#[derive(Debug, PartialEq, Eq, Clone, Default, serde::Serialize, serde::Deserialize)]
+pub struct Definitions<T> {
+    #[serde(flatten, default)]
+    inner: BTreeMap<String, Option<T>>,
+}
+
+impl<T> Definitions<T> {
+    /// Constructs a new empty definitions set.
+    pub fn new() -> Self {
+        Definitions {
+            inner: BTreeMap::new(),
+        }
+    }
+
+    /// True when there's no known definitions.
+    pub fn is_empty(&self) -> bool {
+        self.inner.is_empty()
+    }
+
+    /// Retrieve a definition, if it exists.
+    pub fn lookup(&self, reference: &Reference) -> Option<&T> {
+        self.inner
+            .get(reference.as_key())
+            .map(|v| v
+              .as_ref()
+              .expect("All registered definitions are 'Some'. 'None' state is only transient during registration")
+            )
+    }
+
+    /// Merge two set of definitions together. Prioritize callee.
+    pub fn merge(&mut self, other: &mut Definitions<T>) {
+        self.inner.append(&mut other.inner);
+    }
+
+    /// Erase a known definition. Does nothing if the reference is unknown.
+    pub fn remove(&mut self, reference: &Reference) {
+        self.inner.remove(reference.as_key());
+    }
+
+    /// Register a new definition only if it doesn't exist. This uses a strategy of
+    /// mark-and-insert such that recursive definitions are only built once.
+    pub fn register<F, E>(
+        &mut self,
+        type_info: &Type,
+        type_parameters: &HashMap<u64, Arc<Type>>,
+        build_schema: F,
+    ) -> Result<Reference, E>
+    where
+        F: FnOnce(&mut Self) -> Result<T, E>,
+    {
+        let reference = Reference::from_type(type_info, type_parameters);
+        let key = reference.as_key();
+
+        if !self.inner.contains_key(key) {
+            self.inner.insert(key.to_string(), None);
+            let schema = build_schema(self)?;
+            self.inner.insert(key.to_string(), Some(schema));
+        }
+
+        Ok(reference)
+    }
+}
+
+// ---------- Reference
+
+/// A URI pointer to an underlying data-type.
+#[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Clone, Default)]
+pub struct Reference {
+    inner: String,
+}
+
+impl Reference {
+    /// Create a (possibly unsound) Reference from a string. This isn't the preferred way to create
+    /// a reference. One should use: `into()` on a 'Type' instead.
+    pub fn new(path: &str) -> Reference {
+        Reference {
+            inner: path.to_string(),
+        }
+    }
+
+    /// Turn a reference into a key suitable for lookup.
+    fn as_key(&self) -> &str {
+        self.inner.as_str()
+    }
+
+    /// Turn a reference into a valid JSON pointer. Note that the JSON pointer specification
+    /// indicates that '/' must be escaped as '~1' in pointer addresses (as they are otherwise
+    /// treated as path delimiter in pointers paths).
+    fn as_json_pointer(&self) -> String {
+        format!("#/definitions/{}", self.as_key().replace('/', "~1"))
+    }
+}
+
+impl Display for Reference {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        f.write_str(&self.inner)
+    }
+}
+
+impl Reference {
+    pub fn from_type(type_info: &Type, type_parameters: &HashMap<u64, Arc<Type>>) -> Self {
+        match type_info {
+            Type::App {
+                module, name, args, ..
+            } => {
+                let args: Self = Self::from_types(args, type_parameters);
+                Self {
+                    inner: if module.is_empty() {
+                        format!("{name}{args}")
+                    } else {
+                        format!("{module}/{name}{args}")
+                    },
+                }
+            }
+
+            Type::Tuple { elems } => Self {
+                inner: format!(
+                    "Tuple{elems}",
+                    elems = Self::from_types(elems, type_parameters)
+                ),
+            },
+
+            // NOTE:
+            //
+            // Implementations below are only there for completeness. In practice, we should never
+            // end up creating references for 'Var' or 'Fn' in the context of blueprints.
+            Type::Var { tipo } => match tipo.borrow().deref() {
+                TypeVar::Link { tipo } => Self::from_type(tipo.as_ref(), type_parameters),
+                TypeVar::Generic { id } | TypeVar::Unbound { id } => {
+                    let tipo = type_parameters.get(id).unwrap();
+                    Self::from_type(tipo, type_parameters)
+                }
+            },
+
+            Type::Fn { args, ret } => Self {
+                inner: format!(
+                    "Fn{args}_{ret}",
+                    args = Self::from_types(args, type_parameters),
+                    ret = Self::from_type(ret, type_parameters)
+                ),
+            },
+        }
+    }
+
+    fn from_types(args: &Vec<Arc<Type>>, type_parameters: &HashMap<u64, Arc<Type>>) -> Self {
+        if args.is_empty() {
+            Reference::new("")
+        } else {
+            Reference {
+                inner: format!(
+                    "${}",
+                    args.iter()
+                        .map(|s| Self::from_type(s.as_ref(), type_parameters).inner)
+                        .collect::<Vec<_>>()
+                        .join("_")
+                ),
+            }
+        }
+    }
+}
+
+impl Serialize for Reference {
+    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        let mut s = serializer.serialize_struct("$ref", 1)?;
+        s.serialize_field("$ref", &self.as_json_pointer())?;
+        s.end()
+    }
+}

--- a/crates/aiken-project/src/blueprint/mod.rs
+++ b/crates/aiken-project/src/blueprint/mod.rs
@@ -109,7 +109,7 @@ where
     }
 }
 
-impl Display for Blueprint<Schema> {
+impl<T: serde::Serialize + Default> Display for Blueprint<T> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         let s = serde_json::to_string_pretty(self).map_err(|_| fmt::Error)?;
         f.write_str(&s)

--- a/crates/aiken-project/src/blueprint/schema.rs
+++ b/crates/aiken-project/src/blueprint/schema.rs
@@ -57,7 +57,7 @@ pub enum Items<T> {
 #[derive(Debug, PartialEq, Eq, Clone)]
 pub struct Constructor {
     pub index: usize,
-    pub fields: Vec<Reference>,
+    pub fields: Vec<Annotated<Reference>>,
 }
 
 impl<T> From<T> for Annotated<T> {
@@ -191,7 +191,7 @@ impl Annotated<Schema> {
                                         description: Some("An optional value.".to_string()),
                                         annotated: Constructor {
                                             index: 0,
-                                            fields: vec![generic],
+                                            fields: vec![generic.into()],
                                         },
                                     },
                                     Annotated {
@@ -367,7 +367,11 @@ impl Data {
                     return Ok(schema.into_data(&field.tipo)?.annotated);
                 }
 
-                fields.push(reference);
+                fields.push(Annotated {
+                    title: field.label.clone(),
+                    description: field.doc.clone().map(|s| s.trim().to_string()),
+                    annotated: reference,
+                });
             }
 
             let variant = Annotated {
@@ -750,12 +754,12 @@ pub mod test {
         let schema = Schema::Data(Data::AnyOf(vec![
             Constructor {
                 index: 0,
-                fields: vec![Reference::new("Int")],
+                fields: vec![Reference::new("Int").into()],
             }
             .into(),
             Constructor {
                 index: 1,
-                fields: vec![Reference::new("Bytes")],
+                fields: vec![Reference::new("Bytes").into()],
             }
             .into(),
         ]));

--- a/crates/aiken-project/src/blueprint/schema.rs
+++ b/crates/aiken-project/src/blueprint/schema.rs
@@ -334,9 +334,10 @@ impl Data {
     }
 }
 
+// Needed because of Blueprint's default, but actually never used.
 impl Default for Schema {
     fn default() -> Self {
-        Schema::Unit
+        Schema::Data(Data::Opaque)
     }
 }
 

--- a/crates/aiken-project/src/blueprint/validator.rs
+++ b/crates/aiken-project/src/blueprint/validator.rs
@@ -1,4 +1,5 @@
 use super::{
+    definitions::{Definitions, Reference},
     error::Error,
     schema::{Annotated, Schema},
 };
@@ -6,30 +7,30 @@ use crate::module::{CheckedModule, CheckedModules};
 use aiken_lang::{ast::TypedValidator, uplc::CodeGenerator};
 use miette::NamedSource;
 use serde;
-use std::{
-    collections::HashMap,
-    fmt::{self, Display},
-};
 use uplc::ast::{DeBruijn, Program, Term};
 
 #[derive(Debug, PartialEq, Clone, serde::Serialize, serde::Deserialize)]
-pub struct Validator<T> {
+pub struct Validator<R, S> {
     pub title: String,
 
     #[serde(skip_serializing_if = "Option::is_none")]
     pub description: Option<String>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub datum: Option<Argument<T>>,
+    pub datum: Option<Argument<R>>,
 
-    pub redeemer: Argument<T>,
+    pub redeemer: Argument<R>,
 
     #[serde(skip_serializing_if = "Vec::is_empty")]
     #[serde(default)]
-    pub parameters: Vec<Argument<T>>,
+    pub parameters: Vec<Argument<R>>,
 
     #[serde(flatten)]
     pub program: Program<DeBruijn>,
+
+    #[serde(skip_serializing_if = "Definitions::is_empty")]
+    #[serde(default)]
+    pub definitions: Definitions<S>,
 }
 
 #[derive(Debug, PartialEq, Eq, Clone, serde::Serialize, serde::Deserialize)]
@@ -37,43 +38,16 @@ pub struct Argument<T> {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub title: Option<String>,
 
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub description: Option<String>,
-
     pub schema: T,
 }
 
-impl Display for Validator<Schema> {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        let s = serde_json::to_string_pretty(self).map_err(|_| fmt::Error)?;
-        f.write_str(&s)
-    }
-}
-
-impl Display for Argument<Schema> {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        let s = serde_json::to_string_pretty(self).map_err(|_| fmt::Error)?;
-        f.write_str(&s)
-    }
-}
-
-impl<T> From<Annotated<T>> for Argument<T> {
-    fn from(annotated: Annotated<T>) -> Self {
-        Argument {
-            title: annotated.title,
-            description: annotated.description,
-            schema: annotated.annotated,
-        }
-    }
-}
-
-impl Validator<Schema> {
+impl Validator<Reference, Annotated<Schema>> {
     pub fn from_checked_module(
         modules: &CheckedModules,
         generator: &mut CodeGenerator,
         module: &CheckedModule,
         def: &TypedValidator,
-    ) -> Result<Validator<Schema>, Error> {
+    ) -> Result<Validator<Reference, Annotated<Schema>>, Error> {
         let mut args = def.fun.arguments.iter().rev();
         let (_, redeemer, datum) = (args.next(), args.next().unwrap(), args.next());
 
@@ -82,6 +56,8 @@ impl Validator<Schema> {
         arguments.extend(def.params.clone());
         arguments.extend(def.fun.arguments.clone());
 
+        let mut definitions = Definitions::new();
+
         Ok(Validator {
             title: format!("{}.{}", &module.name, &def.fun.name),
             description: None,
@@ -89,28 +65,24 @@ impl Validator<Schema> {
                 .params
                 .iter()
                 .map(|param| {
-                    let annotation =
-                        Annotated::from_type(modules.into(), &param.tipo, &HashMap::new()).map_err(
-                            |error| Error::Schema {
-                                error,
-                                location: param.location,
-                                source_code: NamedSource::new(
-                                    module.input_path.display().to_string(),
-                                    module.code.clone(),
-                                ),
-                            },
-                        );
-                    annotation.map(|mut annotation| {
-                        annotation.title = annotation
-                            .title
-                            .or_else(|| Some(param.arg_name.get_label()));
-                        annotation.into()
-                    })
+                    Annotated::from_type(modules.into(), &param.tipo, &mut definitions)
+                        .map(|schema| Argument {
+                            title: Some(param.arg_name.get_label()),
+                            schema,
+                        })
+                        .map_err(|error| Error::Schema {
+                            error,
+                            location: param.location,
+                            source_code: NamedSource::new(
+                                module.input_path.display().to_string(),
+                                module.code.clone(),
+                            ),
+                        })
                 })
                 .collect::<Result<_, _>>()?,
             datum: datum
                 .map(|datum| {
-                    Annotated::from_type(modules.into(), &datum.tipo, &HashMap::new()).map_err(
+                    Annotated::from_type(modules.into(), &datum.tipo, &mut definitions).map_err(
                         |error| Error::Schema {
                             error,
                             location: datum.location,
@@ -122,8 +94,11 @@ impl Validator<Schema> {
                     )
                 })
                 .transpose()?
-                .map(|annotated| annotated.into()),
-            redeemer: Annotated::from_type(modules.into(), &redeemer.tipo, &HashMap::new())
+                .map(|schema| Argument {
+                    title: datum.map(|datum| datum.arg_name.get_label()),
+                    schema,
+                }),
+            redeemer: Annotated::from_type(modules.into(), &redeemer.tipo, &mut definitions)
                 .map_err(|error| Error::Schema {
                     error,
                     location: redeemer.location,
@@ -131,19 +106,24 @@ impl Validator<Schema> {
                         module.input_path.display().to_string(),
                         module.code.clone(),
                     ),
-                })?
-                .into(),
+                })
+                .map(|schema| Argument {
+                    title: Some(redeemer.arg_name.get_label()),
+                    schema,
+                })?,
             program: generator
                 .generate(&def.fun.body, &arguments, true)
                 .try_into()
                 .unwrap(),
+            definitions,
         })
     }
 }
 
-impl<T> Validator<T>
+impl<R, S> Validator<R, S>
 where
-    T: Clone,
+    S: Clone,
+    R: Clone,
 {
     pub fn apply(self, arg: &Term<DeBruijn>) -> Result<Self, Error> {
         match self.parameters.split_first() {
@@ -289,7 +269,7 @@ mod test {
     }
 
     #[test]
-    fn validator_mint_basic() {
+    fn mint_basic() {
         assert_validator(
             r#"
             validator mint {
@@ -300,19 +280,26 @@ mod test {
             "#,
             json!({
               "title": "test_module.mint",
-              "hash": "afddc16c18e7d8de379fb9aad39b3d1b5afd27603e5ebac818432a72",
               "redeemer": {
-                "title": "Data",
-                "description": "Any Plutus data.",
-                "schema": {}
+                "title": "redeemer",
+                "schema": {
+                  "$ref": "#/definitions/Data"
+                }
               },
-              "compiledCode": "583b010000323232323232322253330054a22930b180080091129998030010a4c26600a6002600e0046660060066010004002ae695cdaab9f5742ae881"
+              "compiledCode": "583b010000323232323232322253330054a22930b180080091129998030010a4c26600a6002600e0046660060066010004002ae695cdaab9f5742ae881",
+              "hash": "afddc16c18e7d8de379fb9aad39b3d1b5afd27603e5ebac818432a72",
+              "definitions": {
+                "Data": {
+                  "title": "Data",
+                  "description": "Any Plutus data."
+                }
+              }
             }),
         );
     }
 
     #[test]
-    fn validator_mint_parameterized() {
+    fn mint_parameterized() {
         assert_validator(
             r#"
             validator mint(utxo_ref: Int) {
@@ -323,25 +310,37 @@ mod test {
             "#,
             json!({
               "title": "test_module.mint",
-              "hash": "a82df717fd39f5b273c4eb89ae5252e11cc272ac59d815419bf2e4c3",
-              "parameters": [{
-                "title": "utxo_ref",
+              "redeemer": {
+                "title": "redeemer",
                 "schema": {
+                  "$ref": "#/definitions/Data"
+                }
+              },
+              "parameters": [
+                {
+                  "title": "utxo_ref",
+                  "schema": {
+                    "$ref": "#/definitions/Int"
+                  }
+                }
+              ],
+              "compiledCode": "5840010000323232323232322322253330074a22930b1bad0013001001222533300600214984cc014c004c01c008ccc00c00cc0200080055cd2b9b5573eae855d101",
+              "hash": "a82df717fd39f5b273c4eb89ae5252e11cc272ac59d815419bf2e4c3",
+              "definitions": {
+                "Data": {
+                  "title": "Data",
+                  "description": "Any Plutus data."
+                },
+                "Int": {
                   "dataType": "integer"
                 }
-              }],
-              "redeemer": {
-                "title": "Data",
-                "description": "Any Plutus data.",
-                "schema": {}
-              },
-              "compiledCode": "5840010000323232323232322322253330074a22930b1bad0013001001222533300600214984cc014c004c01c008ccc00c00cc0200080055cd2b9b5573eae855d101"
+              }
             }),
         );
     }
 
     #[test]
-    fn validator_spend() {
+    fn simplified_hydra() {
         assert_validator(
             r#"
             /// On-chain state
@@ -374,62 +373,60 @@ mod test {
                 Abort
             }
 
-            validator spend {
+            validator simplified_hydra {
               fn(datum: State, redeemer: Input, ctx: Data) {
                 True
               }
             }
             "#,
             json!({
-              "title": "test_module.spend",
-              "hash": "e37db487fbd58c45d059bcbf5cd6b1604d3bec16cf888f1395a4ebc4",
+              "title": "test_module.simplified_hydra",
               "datum": {
-                "title": "State",
-                "description": "On-chain state",
+                "title": "datum",
                 "schema": {
+                  "$ref": "#/definitions/test_module~1State"
+                }
+              },
+              "redeemer": {
+                "title": "redeemer",
+                "schema": {
+                  "$ref": "#/definitions/test_module~1Input"
+                }
+              },
+              "compiledCode": "583b0100003232323232323222253330064a22930b180080091129998030010a4c26600a6002600e0046660060066010004002ae695cdaab9f5742ae89",
+              "hash": "e37db487fbd58c45d059bcbf5cd6b1604d3bec16cf888f1395a4ebc4",
+              "definitions": {
+                "ByteArray": {
+                  "dataType": "bytes"
+                },
+                "Int": {
+                  "dataType": "integer"
+                },
+                "List$ByteArray": {
+                  "dataType": "list",
+                  "items": {
+                    "$ref": "#/definitions/ByteArray"
+                  }
+                },
+                "test_module/ContestationPeriod": {
+                  "title": "ContestationPeriod",
+                  "description": "Whatever",
                   "anyOf": [
                     {
-                      "title": "State",
+                      "title": "ContestationPeriod",
+                      "description": "A positive, non-zero number of seconds.",
                       "dataType": "constructor",
                       "index": 0,
                       "fields": [
                         {
-                          "title": "contestationPeriod",
-                          "description": "The contestation period as a number of seconds",
-                          "anyOf": [
-                            {
-                              "title": "ContestationPeriod",
-                              "description": "A positive, non-zero number of seconds.",
-                              "dataType": "constructor",
-                              "index": 0,
-                              "fields": [
-                                {
-                                  "dataType": "integer"
-                                }
-                              ]
-                            }
-                          ]
-                        },
-                        {
-                          "title": "parties",
-                          "description": "List of public key hashes of all participants",
-                          "dataType": "list",
-                          "items": {
-                            "dataType": "bytes"
-                          }
-                        },
-                        {
-                          "title": "utxoHash",
-                          "dataType": "bytes"
+                          "$ref": "#/definitions/Int"
                         }
                       ]
                     }
                   ]
-                }
-              },
-              "redeemer": {
-                "title": "Input",
-                "schema": {
+                },
+                "test_module/Input": {
+                  "title": "Input",
                   "anyOf": [
                     {
                       "title": "CollectCom",
@@ -451,88 +448,101 @@ mod test {
                       "fields": []
                     }
                   ]
+                },
+                "test_module/State": {
+                  "title": "State",
+                  "description": "On-chain state",
+                  "anyOf": [
+                    {
+                      "title": "State",
+                      "dataType": "constructor",
+                      "index": 0,
+                      "fields": [
+                        {
+                          "$ref": "#/definitions/test_module~1ContestationPeriod"
+                        },
+                        {
+                          "$ref": "#/definitions/List$ByteArray"
+                        },
+                        {
+                          "$ref": "#/definitions/ByteArray"
+                        }
+                      ]
+                    }
+                  ]
                 }
-              },
-              "compiledCode": "583b0100003232323232323222253330064a22930b180080091129998030010a4c26600a6002600e0046660060066010004002ae695cdaab9f5742ae89"
+              }
             }),
         );
     }
 
     #[test]
-    fn validator_spend_2tuple() {
+    fn tuples() {
         assert_validator(
             r#"
-            validator spend {
-              fn(datum: (Int, ByteArray), redeemer: String, ctx: Void) {
+            validator tuples {
+              fn(datum: (Int, ByteArray), redeemer: (Int, Int, Int), ctx: Void) {
                 True
               }
             }
             "#,
             json!({
-              "title": "test_module.spend",
-              "hash": "3c6766e7a36df2aa13c0e9e6e071317ed39d05f405771c4f1a81c6cc",
+              "title": "test_module.tuples",
               "datum": {
-                "title": "Tuple",
+                "title": "datum",
                 "schema": {
-                  "dataType": "list",
-                  "items": [
-                    { "dataType": "integer" },
-                    { "dataType": "bytes" }
-                  ]
+                  "$ref": "#/definitions/Tuple$Int_ByteArray"
                 }
               },
               "redeemer": {
+                "title": "redeemer",
                 "schema": {
-                  "dataType": "#string"
+                  "$ref": "#/definitions/Tuple$Int_Int_Int"
                 }
               },
-              "compiledCode": "585501000032323232323232232232253330084a22930b1b99375c002646466ec0c024008c024004c024004dd6000980080091129998030010a4c26600a6002600e0046660060066010004002ae695cdaab9f5742ae881"
-            }),
-        )
-    }
-
-    #[test]
-    fn validator_spend_tuples() {
-        assert_validator(
-            r#"
-            validator spend {
-              fn(datum: (Int, Int, Int), redeemer: Data, ctx: Void) {
-                True
-              }
-            }
-            "#,
-            json!({
-              "title": "test_module.spend",
-              "hash": "f335ce0436fd7df56e727a66ada7298534a27b98f887bc3b7947ee48",
-              "datum": {
-                "title": "Tuple",
-                "schema": {
+              "compiledCode": "585301000032323232323232232232253330084a22930b1bac0013232337606012004601200260120026eb0004c0040048894ccc0180085261330053001300700233300300330080020015734ae6d55cfaba157441",
+              "hash": "500b9b576c11ad73dee3b9d5202496a7df78e8de4097c57f0acfcc3a",
+              "definitions": {
+                "ByteArray": {
+                  "dataType": "bytes"
+                },
+                "Int": {
+                  "dataType": "integer"
+                },
+                "Tuple$Int_ByteArray": {
+                  "title": "Tuple",
                   "dataType": "list",
                   "items": [
                     {
-                      "dataType": "integer"
+                      "$ref": "#/definitions/Int"
                     },
                     {
-                      "dataType": "integer"
+                      "$ref": "#/definitions/ByteArray"
+                    }
+                  ]
+                },
+                "Tuple$Int_Int_Int": {
+                  "title": "Tuple",
+                  "dataType": "list",
+                  "items": [
+                    {
+                      "$ref": "#/definitions/Int"
                     },
                     {
-                      "dataType": "integer"
+                      "$ref": "#/definitions/Int"
+                    },
+                    {
+                      "$ref": "#/definitions/Int"
                     }
                   ]
                 }
-              },
-              "redeemer": {
-                "title": "Data",
-                "description": "Any Plutus data.",
-                "schema": {}
-              },
-              "compiledCode": "5840010000323232323232322322253330074a22930b1bac0013001001222533300600214984cc014c004c01c008ccc00c00cc0200080055cd2b9b5573eae855d101"
+              }
             }),
         )
     }
 
     #[test]
-    fn validator_generics() {
+    fn generics() {
         assert_validator(
             r#"
             type Either<left, right> {
@@ -545,69 +555,82 @@ mod test {
                 Infinite
             }
 
-            validator withdraw {
+            validator generics {
               fn(redeemer: Either<ByteArray, Interval<Int>>, ctx: Void) {
                 True
               }
             }
             "#,
-            json!(
-                {
-                  "title": "test_module.withdraw",
-                  "hash": "afddc16c18e7d8de379fb9aad39b3d1b5afd27603e5ebac818432a72",
-                  "redeemer": {
-                    "title": "Either",
-                    "schema": {
-                      "anyOf": [
+            json!({
+              "title": "test_module.generics",
+              "redeemer": {
+                "title": "redeemer",
+                "schema": {
+                  "$ref": "#/definitions/test_module~1Either$ByteArray_test_module~1Interval$Int"
+                }
+              },
+              "compiledCode": "583b010000323232323232322253330054a22930b180080091129998030010a4c26600a6002600e0046660060066010004002ae695cdaab9f5742ae881",
+              "hash": "afddc16c18e7d8de379fb9aad39b3d1b5afd27603e5ebac818432a72",
+              "definitions": {
+                "ByteArray": {
+                  "dataType": "bytes"
+                },
+                "Int": {
+                  "dataType": "integer"
+                },
+                "test_module/Either$ByteArray_test_module/Interval$Int": {
+                  "title": "Either",
+                  "anyOf": [
+                    {
+                      "title": "Left",
+                      "dataType": "constructor",
+                      "index": 0,
+                      "fields": [
                         {
-                          "title": "Left",
-                          "dataType": "constructor",
-                          "index": 0,
-                          "fields": [
-                            {
-                              "dataType": "bytes"
-                            }
-                          ]
-                        },
+                          "$ref": "#/definitions/ByteArray"
+                        }
+                      ]
+                    },
+                    {
+                      "title": "Right",
+                      "dataType": "constructor",
+                      "index": 1,
+                      "fields": [
                         {
-                          "title": "Right",
-                          "dataType": "constructor",
-                          "index": 1,
-                          "fields": [
-                            {
-                              "title": "Interval",
-                              "anyOf": [
-                                {
-                                  "title": "Finite",
-                                  "dataType": "constructor",
-                                  "index": 0,
-                                  "fields": [
-                                    {
-                                      "dataType": "integer"
-                                    }
-                                  ]
-                                },
-                                {
-                                  "title": "Infinite",
-                                  "dataType": "constructor",
-                                  "index": 1,
-                                  "fields": []
-                                }
-                              ]
-                            }
-                          ]
+                          "$ref": "#/definitions/test_module~1Interval$Int"
                         }
                       ]
                     }
-                  },
-                  "compiledCode": "583b010000323232323232322253330054a22930b180080091129998030010a4c26600a6002600e0046660060066010004002ae695cdaab9f5742ae881"
+                  ]
+                },
+                "test_module/Interval$Int": {
+                  "title": "Interval",
+                  "anyOf": [
+                    {
+                      "title": "Finite",
+                      "dataType": "constructor",
+                      "index": 0,
+                      "fields": [
+                        {
+                          "$ref": "#/definitions/Int"
+                        }
+                      ]
+                    },
+                    {
+                      "title": "Infinite",
+                      "dataType": "constructor",
+                      "index": 1,
+                      "fields": []
+                    }
+                  ]
                 }
-            ),
+              }
+            }),
         )
     }
 
     #[test]
-    fn validator_phantom_types() {
+    fn list_2_tuples_as_map() {
         assert_validator(
             r#"
             type Dict<key, value> {
@@ -616,48 +639,60 @@ mod test {
 
             type UUID { UUID }
 
-            validator mint {
+            validator list_2_tuples_as_map {
               fn(redeemer: Dict<UUID, Int>, ctx: Void) {
                 True
               }
             }
             "#,
-            json!(
-                {
-                  "title": "test_module.mint",
-                  "hash": "afddc16c18e7d8de379fb9aad39b3d1b5afd27603e5ebac818432a72",
-                  "redeemer": {
-                    "title": "Dict",
-                    "schema": {
-                      "anyOf": [
+            json!({
+              "title": "test_module.list_2_tuples_as_map",
+              "redeemer": {
+                "title": "redeemer",
+                "schema": {
+                  "$ref": "#/definitions/test_module~1Dict$test_module~1UUID_Int"
+                }
+              },
+              "compiledCode": "583b010000323232323232322253330054a22930b180080091129998030010a4c26600a6002600e0046660060066010004002ae695cdaab9f5742ae881",
+              "hash": "afddc16c18e7d8de379fb9aad39b3d1b5afd27603e5ebac818432a72",
+              "definitions": {
+                "ByteArray": {
+                  "dataType": "bytes"
+                },
+                "Int": {
+                  "dataType": "integer"
+                },
+                "List$Tuple$ByteArray_Int": {
+                  "dataType": "map",
+                  "keys": {
+                    "$ref": "#/definitions/ByteArray"
+                  },
+                  "values": {
+                    "$ref": "#/definitions/Int"
+                  }
+                },
+                "test_module/Dict$test_module/UUID_Int": {
+                  "title": "Dict",
+                  "anyOf": [
+                    {
+                      "title": "Dict",
+                      "dataType": "constructor",
+                      "index": 0,
+                      "fields": [
                         {
-                          "title": "Dict",
-                          "dataType": "constructor",
-                          "index": 0,
-                          "fields": [
-                            {
-                              "title": "inner",
-                              "dataType": "map",
-                              "keys": {
-                                "dataType": "bytes"
-                              },
-                              "values": {
-                                "dataType": "integer"
-                              }
-                            }
-                          ]
+                          "$ref": "#/definitions/List$Tuple$ByteArray_Int"
                         }
                       ]
                     }
-                  },
-                  "compiledCode": "583b010000323232323232322253330054a22930b180080091129998030010a4c26600a6002600e0046660060066010004002ae695cdaab9f5742ae881"
+                  ]
                 }
-            ),
+              }
+            }),
         );
     }
 
     #[test]
-    fn validator_opaque_types() {
+    fn opaque_singleton_variants() {
         assert_validator(
             r#"
             pub opaque type Dict<key, value> {
@@ -666,84 +701,185 @@ mod test {
 
             type UUID { UUID }
 
-            validator mint {
+            validator opaque_singleton_variants {
               fn(redeemer: Dict<UUID, Int>, ctx: Void) {
                 True
               }
             }
             "#,
-            json!(
-                {
-                  "title": "test_module.mint",
-                  "hash": "afddc16c18e7d8de379fb9aad39b3d1b5afd27603e5ebac818432a72",
-                  "redeemer": {
-                    "title": "Dict",
-                    "schema": {
-                      "dataType": "map",
-                      "keys": {
-                        "dataType": "bytes"
-                      },
-                      "values": {
-                        "dataType": "integer"
-                      }
-                    }
-                  },
-                  "compiledCode": "583b010000323232323232322253330054a22930b180080091129998030010a4c26600a6002600e0046660060066010004002ae695cdaab9f5742ae881"
+            json!({
+              "title": "test_module.opaque_singleton_variants",
+              "redeemer": {
+                "title": "redeemer",
+                "schema": {
+                  "$ref": "#/definitions/test_module~1Dict$test_module~1UUID_Int"
                 }
-            ),
+              },
+              "compiledCode": "583b010000323232323232322253330054a22930b180080091129998030010a4c26600a6002600e0046660060066010004002ae695cdaab9f5742ae881",
+              "hash": "afddc16c18e7d8de379fb9aad39b3d1b5afd27603e5ebac818432a72",
+              "definitions": {
+                "ByteArray": {
+                  "dataType": "bytes"
+                },
+                "Int": {
+                  "dataType": "integer"
+                },
+                "test_module/Dict$test_module/UUID_Int": {
+                  "title": "Dict",
+                  "dataType": "map",
+                  "keys": {
+                    "$ref": "#/definitions/ByteArray"
+                  },
+                  "values": {
+                    "$ref": "#/definitions/Int"
+                  }
+                }
+              }
+            }),
         );
     }
 
     #[test]
-    fn exported_data() {
+    fn nested_data() {
         assert_validator(
             r#"
             pub type Foo {
                 foo: Data
             }
 
-            validator spend {
+            validator nested_data {
               fn(datum: Foo, redeemer: Int, ctx: Void) {
                 True
               }
             }
             "#,
-            json!(
-                {
-                  "title": "test_module.spend",
-                  "hash": "a3dbab684d90d19e6bab3a0b00a7290ff59fe637d14428859bf74376",
-                  "datum": {
-                    "title": "Foo",
-                    "schema": {
-                        "anyOf": [{
-                            "title": "Foo",
-                            "index": 0,
-                            "fields": [{
-                                "title": "foo",
-                                "description": "Any Plutus data.",
-                            }],
-                            "dataType": "constructor",
-                        }]
-                    },
-                  },
-                  "redeemer": {
-                    "schema": {
-                      "dataType": "integer",
-                    }
-                  },
-                  "compiledCode": "5840010000323232323232322232253330074a22930b1bad0013001001222533300600214984cc014c004c01c008ccc00c00cc0200080055cd2b9b5573eae855d101"
+            json!({
+              "title": "test_module.nested_data",
+              "datum": {
+                "title": "datum",
+                "schema": {
+                  "$ref": "#/definitions/test_module~1Foo"
                 }
-            ),
+              },
+              "redeemer": {
+                "title": "redeemer",
+                "schema": {
+                  "$ref": "#/definitions/Int"
+                }
+              },
+              "compiledCode": "5840010000323232323232322232253330074a22930b1bad0013001001222533300600214984cc014c004c01c008ccc00c00cc0200080055cd2b9b5573eae855d101",
+              "hash": "a3dbab684d90d19e6bab3a0b00a7290ff59fe637d14428859bf74376",
+              "definitions": {
+                "Data": {
+                  "title": "Data",
+                  "description": "Any Plutus data."
+                },
+                "Int": {
+                  "dataType": "integer"
+                },
+                "test_module/Foo": {
+                  "title": "Foo",
+                  "anyOf": [
+                    {
+                      "title": "Foo",
+                      "dataType": "constructor",
+                      "index": 0,
+                      "fields": [
+                        {
+                          "$ref": "#/definitions/Data"
+                        }
+                      ]
+                    }
+                  ]
+                }
+              }
+            }),
         );
     }
 
     #[test]
-    fn recursive_type() {
+    fn recursive_types() {
+        assert_validator(
+            r#"
+            pub type Expr {
+              Val(Int)
+              Sum(Expr, Expr)
+              Mul(Expr, Expr)
+            }
+
+            validator recursive_types {
+              fn(redeemer: Expr, ctx: Void) {
+                True
+              }
+            }
+            "#,
+            json!({
+              "title": "test_module.recursive_types",
+              "redeemer": {
+                "title": "redeemer",
+                "schema": {
+                  "$ref": "#/definitions/test_module~1Expr"
+                }
+              },
+              "compiledCode": "583b010000323232323232322253330054a22930b180080091129998030010a4c26600a6002600e0046660060066010004002ae695cdaab9f5742ae881",
+              "hash": "afddc16c18e7d8de379fb9aad39b3d1b5afd27603e5ebac818432a72",
+              "definitions": {
+                "Int": {
+                  "dataType": "integer"
+                },
+                "test_module/Expr": {
+                  "title": "Expr",
+                  "anyOf": [
+                    {
+                      "title": "Val",
+                      "dataType": "constructor",
+                      "index": 0,
+                      "fields": [
+                        {
+                          "$ref": "#/definitions/Int"
+                        }
+                      ]
+                    },
+                    {
+                      "title": "Sum",
+                      "dataType": "constructor",
+                      "index": 1,
+                      "fields": [
+                        {
+                          "$ref": "#/definitions/test_module~1Expr"
+                        },
+                        {
+                          "$ref": "#/definitions/test_module~1Expr"
+                        }
+                      ]
+                    },
+                    {
+                      "title": "Mul",
+                      "dataType": "constructor",
+                      "index": 2,
+                      "fields": [
+                        {
+                          "$ref": "#/definitions/test_module~1Expr"
+                        },
+                        {
+                          "$ref": "#/definitions/test_module~1Expr"
+                        }
+                      ]
+                    }
+                  ]
+                }
+              }
+            }),
+        )
+    }
+
+    #[test]
+    fn recursive_generic_types() {
         assert_validator(
             r#"
             pub type LinkedList<a> {
-              Nil
               Cons(a, LinkedList<a>)
+              Nil
             }
 
             pub type Foo {
@@ -756,43 +892,147 @@ mod test {
                 }
             }
 
-            validator spend {
+            validator recursive_generic_types {
               fn(datum: Foo, redeemer: LinkedList<Int>, ctx: Void) {
                 True
               }
             }
             "#,
             json!({
-                "redeemer": {
-                  "schema": {
-                    "$ref": "#/$defs/LinkedList_Int"
+              "title": "test_module.recursive_generic_types",
+              "datum": {
+                "title": "datum",
+                "schema": {
+                  "$ref": "#/definitions/test_module~1Foo"
+                }
+              },
+              "redeemer": {
+                "title": "redeemer",
+                "schema": {
+                  "$ref": "#/definitions/test_module~1LinkedList$Int"
+                }
+              },
+              "compiledCode": "583b0100003232323232323222253330064a22930b180080091129998030010a4c26600a6002600e0046660060066010004002ae695cdaab9f5742ae89",
+              "hash": "e37db487fbd58c45d059bcbf5cd6b1604d3bec16cf888f1395a4ebc4",
+              "definitions": {
+                "Bool": {
+                  "title": "Bool",
+                  "anyOf": [
+                    {
+                      "title": "False",
+                      "dataType": "constructor",
+                      "index": 0,
+                      "fields": []
+                    },
+                    {
+                      "title": "True",
+                      "dataType": "constructor",
+                      "index": 1,
+                      "fields": []
+                    }
+                  ]
+                },
+                "ByteArray": {
+                  "dataType": "bytes"
+                },
+                "Int": {
+                  "dataType": "integer"
+                },
+                "List$test_module/LinkedList$Int": {
+                  "dataType": "list",
+                  "items": {
+                    "$ref": "#/definitions/test_module~1LinkedList$Int"
                   }
                 },
-                "$defs": {
-                  "LinkedList_Int": {
-                    "anyOf": [
-                      {
-                        "title": "Nil",
-                        "dataType": "constructor",
-                        "index": 0,
-                        "fields": []
-                      },
-                      {
-                        "title": "Cons",
-                        "dataType": "constructor",
-                        "index": 1,
-                        "fields": [
-                          {
-                            "dataType": "integer"
-                          },
-                          {
-                            "$ref": "#/$defs/LinkedList_Int"
-                          },
-                        ]
-                      }
-                    ],
-                  },
+                "Tuple$ByteArray_List$test_module/LinkedList$Int": {
+                  "title": "Tuple",
+                  "dataType": "list",
+                  "items": [
+                    {
+                      "$ref": "#/definitions/ByteArray"
+                    },
+                    {
+                      "$ref": "#/definitions/List$test_module~1LinkedList$Int"
+                    }
+                  ]
+                },
+                "test_module/Foo": {
+                  "title": "Foo",
+                  "anyOf": [
+                    {
+                      "title": "Foo",
+                      "dataType": "constructor",
+                      "index": 0,
+                      "fields": [
+                        {
+                          "$ref": "#/definitions/test_module~1LinkedList$Bool"
+                        }
+                      ]
+                    },
+                    {
+                      "title": "Bar",
+                      "dataType": "constructor",
+                      "index": 1,
+                      "fields": [
+                        {
+                          "$ref": "#/definitions/Int"
+                        },
+                        {
+                          "$ref": "#/definitions/Tuple$ByteArray_List$test_module~1LinkedList$Int"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                "test_module/LinkedList$Bool": {
+                  "title": "LinkedList",
+                  "anyOf": [
+                    {
+                      "title": "Cons",
+                      "dataType": "constructor",
+                      "index": 0,
+                      "fields": [
+                        {
+                          "$ref": "#/definitions/Bool"
+                        },
+                        {
+                          "$ref": "#/definitions/test_module~1LinkedList$Bool"
+                        }
+                      ]
+                    },
+                    {
+                      "title": "Nil",
+                      "dataType": "constructor",
+                      "index": 1,
+                      "fields": []
+                    }
+                  ]
+                },
+                "test_module/LinkedList$Int": {
+                  "title": "LinkedList",
+                  "anyOf": [
+                    {
+                      "title": "Cons",
+                      "dataType": "constructor",
+                      "index": 0,
+                      "fields": [
+                        {
+                          "$ref": "#/definitions/Int"
+                        },
+                        {
+                          "$ref": "#/definitions/test_module~1LinkedList$Int"
+                        }
+                      ]
+                    },
+                    {
+                      "title": "Nil",
+                      "dataType": "constructor",
+                      "index": 1,
+                      "fields": []
+                    }
+                  ]
                 }
+              }
             }),
         )
     }

--- a/crates/aiken-project/src/blueprint/validator.rs
+++ b/crates/aiken-project/src/blueprint/validator.rs
@@ -459,12 +459,17 @@ mod test {
                       "index": 0,
                       "fields": [
                         {
+                          "title": "contestationPeriod",
+                          "description": "The contestation period as a number of seconds",
                           "$ref": "#/definitions/test_module~1ContestationPeriod"
                         },
                         {
+                          "title": "parties",
+                          "description": "List of public key hashes of all participants",
                           "$ref": "#/definitions/List$ByteArray"
                         },
                         {
+                          "title": "utxoHash",
                           "$ref": "#/definitions/ByteArray"
                         }
                       ]
@@ -680,6 +685,7 @@ mod test {
                       "index": 0,
                       "fields": [
                         {
+                          "title": "inner",
                           "$ref": "#/definitions/List$Tuple$ByteArray_Int"
                         }
                       ]
@@ -786,6 +792,7 @@ mod test {
                       "index": 0,
                       "fields": [
                         {
+                          "title": "foo",
                           "$ref": "#/definitions/Data"
                         }
                       ]
@@ -965,6 +972,7 @@ mod test {
                       "index": 0,
                       "fields": [
                         {
+                          "title": "foo",
                           "$ref": "#/definitions/test_module~1LinkedList$Bool"
                         }
                       ]
@@ -975,9 +983,11 @@ mod test {
                       "index": 1,
                       "fields": [
                         {
+                          "title": "bar",
                           "$ref": "#/definitions/Int"
                         },
                         {
+                          "title": "baz",
                           "$ref": "#/definitions/Tuple$ByteArray_List$test_module~1LinkedList$Int"
                         }
                       ]

--- a/crates/aiken-project/src/lib.rs
+++ b/crates/aiken-project/src/lib.rs
@@ -12,7 +12,11 @@ pub mod pretty;
 pub mod script;
 pub mod telemetry;
 
-use crate::blueprint::{schema::Schema, Blueprint};
+use crate::blueprint::{
+    definitions::Reference,
+    schema::{Annotated, Schema},
+    Blueprint,
+};
 use aiken_lang::{
     ast::{Definition, Function, ModuleKind, Tracing, TypedDataType, TypedFunction},
     builder::{DataTypeKey, FunctionAccessKey},
@@ -214,7 +218,10 @@ where
         self.compile(options)
     }
 
-    pub fn dump_uplc(&self, blueprint: &Blueprint<Schema>) -> Result<(), Error> {
+    pub fn dump_uplc(
+        &self,
+        blueprint: &Blueprint<Reference, Annotated<Schema>>,
+    ) -> Result<(), Error> {
         let dir = self.root.join("artifacts");
 
         self.event_listener
@@ -355,7 +362,7 @@ where
         // Read blueprint
         let blueprint = File::open(self.blueprint_path())
             .map_err(|_| blueprint::error::Error::InvalidOrMissingFile)?;
-        let blueprint: Blueprint<serde_json::Value> =
+        let blueprint: Blueprint<serde_json::Value, serde_json::Value> =
             serde_json::from_reader(BufReader::new(blueprint))?;
 
         // Calculate the address
@@ -379,11 +386,11 @@ where
         &self,
         title: Option<&String>,
         param: &Term<DeBruijn>,
-    ) -> Result<Blueprint<serde_json::Value>, Error> {
+    ) -> Result<Blueprint<serde_json::Value, serde_json::Value>, Error> {
         // Read blueprint
         let blueprint = File::open(self.blueprint_path())
             .map_err(|_| blueprint::error::Error::InvalidOrMissingFile)?;
-        let mut blueprint: Blueprint<serde_json::Value> =
+        let mut blueprint: Blueprint<serde_json::Value, serde_json::Value> =
             serde_json::from_reader(BufReader::new(blueprint))?;
 
         // Apply parameters

--- a/crates/aiken/src/cmd/blueprint/convert.rs
+++ b/crates/aiken/src/cmd/blueprint/convert.rs
@@ -65,7 +65,7 @@ pub fn exec(
         .map_err(|_| BlueprintError::InvalidOrMissingFile)
         .into_diagnostic()?;
 
-    let blueprint: Blueprint<serde_json::Value> =
+    let blueprint: Blueprint<serde_json::Value, serde_json::Value> =
         serde_json::from_reader(BufReader::new(blueprint)).into_diagnostic()?;
 
     // Perform the conversion

--- a/examples/acceptance_tests/036/plutus.json
+++ b/examples/acceptance_tests/036/plutus.json
@@ -74,9 +74,11 @@
           "index": 0,
           "fields": [
             {
+              "title": "transaction_id",
               "$ref": "#/definitions/aiken~1transaction~1TransactionId"
             },
             {
+              "title": "output_index",
               "$ref": "#/definitions/Int"
             }
           ]
@@ -93,6 +95,7 @@
           "index": 0,
           "fields": [
             {
+              "title": "hash",
               "$ref": "#/definitions/ByteArray"
             }
           ]

--- a/examples/acceptance_tests/036/plutus.json
+++ b/examples/acceptance_tests/036/plutus.json
@@ -8,14 +8,16 @@
     {
       "title": "spend.spend",
       "datum": {
-        "title": "Data",
-        "description": "Any Plutus data.",
-        "schema": {}
+        "title": "_datum",
+        "schema": {
+          "$ref": "#/definitions/Data"
+        }
       },
       "redeemer": {
-        "title": "Data",
-        "description": "Any Plutus data.",
-        "schema": {}
+        "title": "_redeemer",
+        "schema": {
+          "$ref": "#/definitions/Data"
+        }
       },
       "compiledCode": "59015f010000323232323232323232322225333006323232323233001003232323322323232323330140014a0944004c94ccc05c0045288a5000133223233223253330173370e00290010801099190009bab301e00130110033018375400400297adef6c6033223300800200100200100100237566601260140049001001a441050000000000003001001222533301300213374a900125eb804c8c8c8c94ccc04ccdc7802800899ba548000cc060dd300125eb804ccc01c01c00c014dd7180a0019bab3014002301700330150023001001222533301000214a026464a66601c600600429444ccc01401400400cc05000cc048008dd6198009801198009801001a400090021119199800800a4000006444666601866e1c0100080488ccc010010cdc0001a40046028002002460146ea8004526163001001222533300800214984cc014c004c028008ccc00c00cc02c0080055cd2b9b5573aaae7955cfaba05742ae89",
       "hash": "3f46b921ead33594e1da4afa1f1ba31807c0d8deca029f96fe9fe394"
@@ -23,58 +25,79 @@
     {
       "title": "spend.mint",
       "redeemer": {
-        "title": "Unit",
-        "description": "The nullary constructor.",
+        "title": "_redeemer",
         "schema": {
-          "anyOf": [
-            {
-              "dataType": "constructor",
-              "index": 0,
-              "fields": []
-            }
-          ]
+          "$ref": "#/definitions/Void"
         }
       },
       "parameters": [
         {
-          "title": "OutputReference",
-          "description": "An `OutputReference` is a unique reference to an output on-chain. The `output_index`\n corresponds to the position in the output list of the transaction (identified by its id)\n that produced that output",
+          "title": "output_reference",
           "schema": {
-            "anyOf": [
-              {
-                "title": "OutputReference",
-                "dataType": "constructor",
-                "index": 0,
-                "fields": [
-                  {
-                    "title": "transaction_id",
-                    "description": "A unique transaction identifier, as the hash of a transaction body. Note that the transaction id\n isn't a direct hash of the `Transaction` as visible on-chain. Rather, they correspond to hash\n digests of transaction body as they are serialized on the network.",
-                    "anyOf": [
-                      {
-                        "title": "TransactionId",
-                        "dataType": "constructor",
-                        "index": 0,
-                        "fields": [
-                          {
-                            "title": "hash",
-                            "dataType": "bytes"
-                          }
-                        ]
-                      }
-                    ]
-                  },
-                  {
-                    "title": "output_index",
-                    "dataType": "integer"
-                  }
-                ]
-              }
-            ]
+            "$ref": "#/definitions/aiken~1transaction~1OutputReference"
           }
         }
       ],
       "compiledCode": "58e301000032323232323232323232222533300632323232533300a3370e0029000099251300400214a060166ea8004c8c8cc004dd6198019802198019802002a40009000119baf33004300500148000020c0040048894ccc03c0084cdd2a400497ae013232533300d300300213374a90001980900125eb804ccc01401400400cc04c00cc04400888c8ccc0040052000003222333300c3370e008004024466600800866e0000d200230140010012300a37540022930b180080091129998040010a4c26600a600260140046660060066016004002ae695cdaab9d5573caae7d5d02ba157441",
       "hash": "5a5aef5525783c007ee817dd5869ee67000ae5fd730815af7d87ec97"
     }
-  ]
+  ],
+  "definitions": {
+    "ByteArray": {
+      "dataType": "bytes"
+    },
+    "Data": {
+      "title": "Data",
+      "description": "Any Plutus data."
+    },
+    "Int": {
+      "dataType": "integer"
+    },
+    "Void": {
+      "title": "Unit",
+      "description": "The nullary constructor.",
+      "anyOf": [
+        {
+          "dataType": "constructor",
+          "index": 0,
+          "fields": []
+        }
+      ]
+    },
+    "aiken/transaction/OutputReference": {
+      "title": "OutputReference",
+      "description": "An `OutputReference` is a unique reference to an output on-chain. The `output_index`\n corresponds to the position in the output list of the transaction (identified by its id)\n that produced that output",
+      "anyOf": [
+        {
+          "title": "OutputReference",
+          "dataType": "constructor",
+          "index": 0,
+          "fields": [
+            {
+              "$ref": "#/definitions/aiken~1transaction~1TransactionId"
+            },
+            {
+              "$ref": "#/definitions/Int"
+            }
+          ]
+        }
+      ]
+    },
+    "aiken/transaction/TransactionId": {
+      "title": "TransactionId",
+      "description": "A unique transaction identifier, as the hash of a transaction body. Note that the transaction id\n isn't a direct hash of the `Transaction` as visible on-chain. Rather, they correspond to hash\n digests of transaction body as they are serialized on the network.",
+      "anyOf": [
+        {
+          "title": "TransactionId",
+          "dataType": "constructor",
+          "index": 0,
+          "fields": [
+            {
+              "$ref": "#/definitions/ByteArray"
+            }
+          ]
+        }
+      ]
+    }
+  }
 }

--- a/examples/acceptance_tests/047/plutus.json
+++ b/examples/acceptance_tests/047/plutus.json
@@ -8,33 +8,32 @@
     {
       "title": "foo.spend",
       "datum": {
-        "title": "Unit",
-        "description": "The nullary constructor.",
+        "title": "_datum",
         "schema": {
-          "anyOf": [
-            {
-              "dataType": "constructor",
-              "index": 0,
-              "fields": []
-            }
-          ]
+          "$ref": "#/definitions/Void"
         }
       },
       "redeemer": {
-        "title": "Unit",
-        "description": "The nullary constructor.",
+        "title": "_redeemer",
         "schema": {
-          "anyOf": [
-            {
-              "dataType": "constructor",
-              "index": 0,
-              "fields": []
-            }
-          ]
+          "$ref": "#/definitions/Void"
         }
       },
       "compiledCode": "583b0100003232323232323222253330064a22930b180080091129998030010a4c26600a6002600e0046660060066010004002ae695cdaab9f5742ae89",
       "hash": "e37db487fbd58c45d059bcbf5cd6b1604d3bec16cf888f1395a4ebc4"
     }
-  ]
+  ],
+  "definitions": {
+    "Void": {
+      "title": "Unit",
+      "description": "The nullary constructor.",
+      "anyOf": [
+        {
+          "dataType": "constructor",
+          "index": 0,
+          "fields": []
+        }
+      ]
+    }
+  }
 }

--- a/examples/acceptance_tests/048/plutus.json
+++ b/examples/acceptance_tests/048/plutus.json
@@ -8,17 +8,25 @@
     {
       "title": "foo.spend",
       "datum": {
-        "title": "Data",
-        "description": "Any Plutus data.",
-        "schema": {}
+        "title": "a",
+        "schema": {
+          "$ref": "#/definitions/Data"
+        }
       },
       "redeemer": {
-        "title": "Data",
-        "description": "Any Plutus data.",
-        "schema": {}
+        "title": "b",
+        "schema": {
+          "$ref": "#/definitions/Data"
+        }
       },
       "compiledCode": "586001000032323232323232323222253330063370e6464640046eb4c02c008dd69804800a5ef6c6010104000101010048020526163001001222533300800214984cc014c004c024008ccc00c00cc0280080055cd2b9b5573aaae7955cfaba157441",
       "hash": "7ecbfc3ae91c4d5ba3799b4d283e385d457c860cd22034d825379ae2"
     }
-  ]
+  ],
+  "definitions": {
+    "Data": {
+      "title": "Data",
+      "description": "Any Plutus data."
+    }
+  }
 }

--- a/examples/acceptance_tests/071/plutus.json
+++ b/examples/acceptance_tests/071/plutus.json
@@ -39,9 +39,11 @@
           "index": 0,
           "fields": [
             {
+              "title": "policy_id",
               "$ref": "#/definitions/ByteArray"
             },
             {
+              "title": "asset_name",
               "$ref": "#/definitions/ByteArray"
             }
           ]
@@ -57,9 +59,11 @@
           "index": 0,
           "fields": [
             {
+              "title": "input_cs",
               "$ref": "#/definitions/spend~1CurrencySymbol"
             },
             {
+              "title": "input_amount",
               "$ref": "#/definitions/Int"
             }
           ]
@@ -75,12 +79,15 @@
           "index": 0,
           "fields": [
             {
+              "title": "currency_symbol",
               "$ref": "#/definitions/spend~1CurrencySymbol"
             },
             {
+              "title": "balance",
               "$ref": "#/definitions/Int"
             },
             {
+              "title": "lent_out",
               "$ref": "#/definitions/Int"
             }
           ]
@@ -96,9 +103,11 @@
           "index": 0,
           "fields": [
             {
+              "title": "input_cs",
               "$ref": "#/definitions/spend~1CurrencySymbol"
             },
             {
+              "title": "input_amount",
               "$ref": "#/definitions/Int"
             }
           ]
@@ -114,6 +123,7 @@
           "index": 0,
           "fields": [
             {
+              "title": "action",
               "$ref": "#/definitions/spend~1PoolRedeemerType"
             }
           ]

--- a/examples/acceptance_tests/071/plutus.json
+++ b/examples/acceptance_tests/071/plutus.json
@@ -8,164 +8,152 @@
     {
       "title": "spend.pool_contract",
       "datum": {
-        "title": "PoolDatum",
+        "title": "datum",
         "schema": {
-          "anyOf": [
-            {
-              "title": "PoolDatum",
-              "dataType": "constructor",
-              "index": 0,
-              "fields": [
-                {
-                  "title": "currency_symbol",
-                  "anyOf": [
-                    {
-                      "title": "CurrencySymbol",
-                      "dataType": "constructor",
-                      "index": 0,
-                      "fields": [
-                        {
-                          "title": "policy_id",
-                          "dataType": "bytes"
-                        },
-                        {
-                          "title": "asset_name",
-                          "dataType": "bytes"
-                        }
-                      ]
-                    }
-                  ]
-                },
-                {
-                  "title": "balance",
-                  "dataType": "integer"
-                },
-                {
-                  "title": "lent_out",
-                  "dataType": "integer"
-                }
-              ]
-            }
-          ]
+          "$ref": "#/definitions/spend~1PoolDatum"
         }
       },
       "redeemer": {
-        "title": "PoolRedeemer",
+        "title": "redeemer",
         "schema": {
-          "anyOf": [
-            {
-              "title": "PoolRedeemer",
-              "dataType": "constructor",
-              "index": 0,
-              "fields": [
-                {
-                  "title": "action",
-                  "anyOf": [
-                    {
-                      "title": "PoolWithdraw",
-                      "dataType": "constructor",
-                      "index": 0,
-                      "fields": [
-                        {
-                          "dataType": "integer"
-                        }
-                      ]
-                    },
-                    {
-                      "title": "PoolDeposit",
-                      "dataType": "constructor",
-                      "index": 1,
-                      "fields": [
-                        {
-                          "title": "PoolDepositRedeemer",
-                          "anyOf": [
-                            {
-                              "title": "PoolDepositRedeemer",
-                              "dataType": "constructor",
-                              "index": 0,
-                              "fields": [
-                                {
-                                  "title": "input_cs",
-                                  "anyOf": [
-                                    {
-                                      "title": "CurrencySymbol",
-                                      "dataType": "constructor",
-                                      "index": 0,
-                                      "fields": [
-                                        {
-                                          "title": "policy_id",
-                                          "dataType": "bytes"
-                                        },
-                                        {
-                                          "title": "asset_name",
-                                          "dataType": "bytes"
-                                        }
-                                      ]
-                                    }
-                                  ]
-                                },
-                                {
-                                  "title": "input_amount",
-                                  "dataType": "integer"
-                                }
-                              ]
-                            }
-                          ]
-                        }
-                      ]
-                    },
-                    {
-                      "title": "PoolBorrow",
-                      "dataType": "constructor",
-                      "index": 2,
-                      "fields": [
-                        {
-                          "title": "PoolBorrowRedeemer",
-                          "anyOf": [
-                            {
-                              "title": "PoolBorrowRedeemer",
-                              "dataType": "constructor",
-                              "index": 0,
-                              "fields": [
-                                {
-                                  "title": "input_cs",
-                                  "anyOf": [
-                                    {
-                                      "title": "CurrencySymbol",
-                                      "dataType": "constructor",
-                                      "index": 0,
-                                      "fields": [
-                                        {
-                                          "title": "policy_id",
-                                          "dataType": "bytes"
-                                        },
-                                        {
-                                          "title": "asset_name",
-                                          "dataType": "bytes"
-                                        }
-                                      ]
-                                    }
-                                  ]
-                                },
-                                {
-                                  "title": "input_amount",
-                                  "dataType": "integer"
-                                }
-                              ]
-                            }
-                          ]
-                        }
-                      ]
-                    }
-                  ]
-                }
-              ]
-            }
-          ]
+          "$ref": "#/definitions/spend~1PoolRedeemer"
         }
       },
       "compiledCode": "59030501000032323232323232323232322225333006323232323232323232533300f3370e002900009925130090021533300f3370e0029001099191919299980999b87001480084c8c8cccc8888c8c8c8c8c9289812000980b19299980e99b8748000c080dd500088008a9980fa492a4578706563746564206f6e20696e636f727265637420636f6e7374727563746f722076617269616e742e0016330120070033022001301432533301b3370e9000180f1baa0011001153301d49012a4578706563746564206f6e20696e636f727265637420636f6e7374727563746f722076617269616e742e00163300f005001300d48901ff00010001012005301b001300d00214a0602a6ea8004cc028c02c03120023017001300900213232323253330133370e0029001099191999911119191919192513024001301632533301d3370e900018101baa0011001153301f49012a4578706563746564206f6e20696e636f727265637420636f6e7374727563746f722076617269616e742e0016330120070033022001301432533301b3370e9000180f1baa0011001153301d49012a4578706563746564206f6e20696e636f727265637420636f6e7374727563746f722076617269616e742e00163300f005001300d48901ff00010001012005301b001300d00214a0602a6ea8004cc028c02c031200230170013009002301137540026600c600e0129000119ba548000cc04ccdd2a4004660266ea40052f5c06602666e9520024bd7025eb8088cc010dd6198031803998031803801240009002119baf3300730080014800000888cc00cdd6198029803198029803001240009000119baf3300630073300630070014800920000023001001222533301000213374a900125eb804c8c94ccc034c00c0084cdd2a40006602600497ae013330050050010033014003301200222323330010014800000c888cccc030cdc3802001009919980200219b8000348008c0540040048c02cdd50008a4c2c6002002444a666012004293099802980098058011998018019806001000ab9a5736ae7155ceaab9e5573eae815d0aba201",
       "hash": "b79dffa847f2b9a55cb6cee2bd6057251f45e6a252587c7f6f3545d0"
     }
-  ]
+  ],
+  "definitions": {
+    "ByteArray": {
+      "dataType": "bytes"
+    },
+    "Int": {
+      "dataType": "integer"
+    },
+    "spend/CurrencySymbol": {
+      "title": "CurrencySymbol",
+      "anyOf": [
+        {
+          "title": "CurrencySymbol",
+          "dataType": "constructor",
+          "index": 0,
+          "fields": [
+            {
+              "$ref": "#/definitions/ByteArray"
+            },
+            {
+              "$ref": "#/definitions/ByteArray"
+            }
+          ]
+        }
+      ]
+    },
+    "spend/PoolBorrowRedeemer": {
+      "title": "PoolBorrowRedeemer",
+      "anyOf": [
+        {
+          "title": "PoolBorrowRedeemer",
+          "dataType": "constructor",
+          "index": 0,
+          "fields": [
+            {
+              "$ref": "#/definitions/spend~1CurrencySymbol"
+            },
+            {
+              "$ref": "#/definitions/Int"
+            }
+          ]
+        }
+      ]
+    },
+    "spend/PoolDatum": {
+      "title": "PoolDatum",
+      "anyOf": [
+        {
+          "title": "PoolDatum",
+          "dataType": "constructor",
+          "index": 0,
+          "fields": [
+            {
+              "$ref": "#/definitions/spend~1CurrencySymbol"
+            },
+            {
+              "$ref": "#/definitions/Int"
+            },
+            {
+              "$ref": "#/definitions/Int"
+            }
+          ]
+        }
+      ]
+    },
+    "spend/PoolDepositRedeemer": {
+      "title": "PoolDepositRedeemer",
+      "anyOf": [
+        {
+          "title": "PoolDepositRedeemer",
+          "dataType": "constructor",
+          "index": 0,
+          "fields": [
+            {
+              "$ref": "#/definitions/spend~1CurrencySymbol"
+            },
+            {
+              "$ref": "#/definitions/Int"
+            }
+          ]
+        }
+      ]
+    },
+    "spend/PoolRedeemer": {
+      "title": "PoolRedeemer",
+      "anyOf": [
+        {
+          "title": "PoolRedeemer",
+          "dataType": "constructor",
+          "index": 0,
+          "fields": [
+            {
+              "$ref": "#/definitions/spend~1PoolRedeemerType"
+            }
+          ]
+        }
+      ]
+    },
+    "spend/PoolRedeemerType": {
+      "title": "PoolRedeemerType",
+      "anyOf": [
+        {
+          "title": "PoolWithdraw",
+          "dataType": "constructor",
+          "index": 0,
+          "fields": [
+            {
+              "$ref": "#/definitions/Int"
+            }
+          ]
+        },
+        {
+          "title": "PoolDeposit",
+          "dataType": "constructor",
+          "index": 1,
+          "fields": [
+            {
+              "$ref": "#/definitions/spend~1PoolDepositRedeemer"
+            }
+          ]
+        },
+        {
+          "title": "PoolBorrow",
+          "dataType": "constructor",
+          "index": 2,
+          "fields": [
+            {
+              "$ref": "#/definitions/spend~1PoolBorrowRedeemer"
+            }
+          ]
+        }
+      ]
+    }
+  }
 }

--- a/examples/hello_world/plutus.json
+++ b/examples/hello_world/plutus.json
@@ -37,6 +37,7 @@
           "index": 0,
           "fields": [
             {
+              "title": "owner",
               "$ref": "#/definitions/ByteArray"
             }
           ]
@@ -52,6 +53,7 @@
           "index": 0,
           "fields": [
             {
+              "title": "msg",
               "$ref": "#/definitions/ByteArray"
             }
           ]

--- a/examples/hello_world/plutus.json
+++ b/examples/hello_world/plutus.json
@@ -9,43 +9,54 @@
     {
       "title": "hello_world.spend",
       "datum": {
-        "title": "Datum",
+        "title": "datum",
         "schema": {
-          "anyOf": [
-            {
-              "title": "Datum",
-              "dataType": "constructor",
-              "index": 0,
-              "fields": [
-                {
-                  "title": "owner",
-                  "dataType": "bytes"
-                }
-              ]
-            }
-          ]
+          "$ref": "#/definitions/hello_world~1Datum"
         }
       },
       "redeemer": {
-        "title": "Redeemer",
+        "title": "redeemer",
         "schema": {
-          "anyOf": [
-            {
-              "title": "Redeemer",
-              "dataType": "constructor",
-              "index": 0,
-              "fields": [
-                {
-                  "title": "msg",
-                  "dataType": "bytes"
-                }
-              ]
-            }
-          ]
+          "$ref": "#/definitions/hello_world~1Redeemer"
         }
       },
       "compiledCode": "58dd0100003232323232323232222533300632323232533300a002100114a06464660026eb0cc010c014cc010c014019200048040dd7198021802804240006002002444a66601e00429404c8c94ccc038cdc78010018a5113330050050010033012003375c602000466e3cdd71980098010022400091010d48656c6c6f2c20576f726c64210022323330010014800000c888cccc030cdc3802001008119980200219b8000348008c0480040048c024dd50008a4c2c6002002444a66600e004293099802980098040011998018019804801000ab9a5736aae7955cfaba15745",
       "hash": "46872294cadbacb2c3214086c0129ede75cf9f767e95a449f996685f"
     }
-  ]
+  ],
+  "definitions": {
+    "ByteArray": {
+      "dataType": "bytes"
+    },
+    "hello_world/Datum": {
+      "title": "Datum",
+      "anyOf": [
+        {
+          "title": "Datum",
+          "dataType": "constructor",
+          "index": 0,
+          "fields": [
+            {
+              "$ref": "#/definitions/ByteArray"
+            }
+          ]
+        }
+      ]
+    },
+    "hello_world/Redeemer": {
+      "title": "Redeemer",
+      "anyOf": [
+        {
+          "title": "Redeemer",
+          "dataType": "constructor",
+          "index": 0,
+          "fields": [
+            {
+              "$ref": "#/definitions/ByteArray"
+            }
+          ]
+        }
+      ]
+    }
+  }
 }


### PR DESCRIPTION
Fixes #416 
  
- :round_pushpin: **Add failing test scenario for recursive types.**
  
- :round_pushpin: **Make blueprint code slightly more resilient to changes.**
    Leverage traits instead of hard-coded type parameters.

- :round_pushpin: **Introduce indirection for fields.**
  
- :round_pushpin: **Fix blueprint generation for recursive types.**
    This was a bit tricky and I ended up breaking things down a lot and
  trying different path. This commit is the result of the most
  satisfying one.

  It introduces a new 'concept' and types: Definitions and Reference.
  These elements are meant to reflect JSON pointers and JSON-schema
  definitions which we now use for pretty much all user-defined
  data-types.

  In fact, Schemas are no longer inlined, but are always referencing
  some schema under "definitions".

  This indirection is necessary in order to cope with recursive types.
  And while it's only truly necessary for recursive types, using it
  consistently makes it both easier to produce and easier to consume.

  ---

  The blueprint generation for recursive types here also works thanks to
  the 'Definitions' data-structure wrapper around a BTreeMap. This uses
  a strategy where:

  (1) schemas are only generated if they haven't been seen before
  (2) schemas are marked as seen BEFORE actually being generated (to
  effectively stop a recursive generation).

  This relies on one important aspect: the key must be uniquely
  identifying a given schema. Which means that we have to monomorphize
  data-types with generic parameters also here, and use keys that are
  specialized in one data-type.

  ---

  In this large overhaul we've also lost one thing which I didn't bother
  re-introducing yet to keep the work manageable: title for record
  fields. Before, we use to pull those from record constructor when
  available, yet now, every record constructor has been replaced by a
  `$ref`. We could theoritically attach a title to the reference. I'll
  try to quickly add that in a later commit.

- :round_pushpin: **Update blueprints from acceptance tests and hello, world.**
  
- :round_pushpin: **Re-introduce field title & description in referenced schemas.**
  