### PR TITLE
Flexible pipe operator

### DIFF
--- a/crates/aiken-lang/src/expr.rs
+++ b/crates/aiken-lang/src/expr.rs
@@ -456,6 +456,7 @@ pub enum UntypedExpr {
 
     PipeLine {
         expressions: Vec1<Self>,
+        one_liner: bool,
     },
 
     Assignment {

--- a/crates/aiken-lang/src/parser/token.rs
+++ b/crates/aiken-lang/src/parser/token.rs
@@ -44,15 +44,16 @@ pub enum Token {
     Bang,     // '!'
     Question, // '?'
     Equal,
-    EqualEqual, // '=='
-    NotEqual,   // '!='
-    Vbar,       // '|'
-    VbarVbar,   // '||'
-    AmperAmper, // '&&'
-    Pipe,       // '|>'
-    Dot,        // '.'
-    RArrow,     // '->'
-    DotDot,     // '..'
+    EqualEqual,  // '=='
+    NotEqual,    // '!='
+    Vbar,        // '|'
+    VbarVbar,    // '||'
+    AmperAmper,  // '&&'
+    NewLinePipe, // '↳|>'
+    Pipe,        // '|>'
+    Dot,         // '.'
+    RArrow,      // '->'
+    DotDot,      // '..'
     EndOfFile,
     // Docs/Extra
     Comment,
@@ -134,6 +135,7 @@ impl fmt::Display for Token {
             Token::Vbar => "|",
             Token::VbarVbar => "||",
             Token::AmperAmper => "&&",
+            Token::NewLinePipe => "↳|>",
             Token::Pipe => "|>",
             Token::Dot => ".",
             Token::RArrow => "->",

--- a/crates/aiken-lang/src/pretty.rs
+++ b/crates/aiken-lang/src/pretty.rs
@@ -10,7 +10,6 @@
 //! ## Extensions
 //!
 //! - `ForcedBreak` from Elixir.
-//! - `FlexBreak` from Elixir.
 #![allow(clippy::wrong_self_convention)]
 
 use std::collections::VecDeque;
@@ -132,9 +131,6 @@ pub enum Document<'a> {
     /// Forces contained groups to break
     ForceBroken(Box<Self>),
 
-    /// May break contained document based on best fit, thus flex break
-    FlexBreak(Box<Self>),
-
     /// Renders `broken` if group is broken, `unbroken` otherwise
     Break {
         broken: &'a str,
@@ -215,8 +211,6 @@ fn fits(
                 Mode::Broken | Mode::ForcedBroken => return true,
                 Mode::Unbroken => current_width += unbroken.len() as isize,
             },
-
-            Document::FlexBreak(doc) => docs.push_front((indent, mode, doc)),
 
             Document::Vec(vec) => {
                 for doc in vec.iter().rev() {
@@ -347,7 +341,7 @@ fn format(
                 docs.push_front((indent + i, mode, doc));
             }
 
-            Document::Group(doc) | Document::FlexBreak(doc) => {
+            Document::Group(doc) => {
                 let mut group_docs = VecDeque::new();
 
                 group_docs.push_front((indent, Mode::Unbroken, doc.as_ref()));
@@ -467,7 +461,7 @@ impl<'a> Document<'a> {
             Str(s) => s.is_empty(),
             // assuming `broken` and `unbroken` are equivalent
             Break { broken, .. } => broken.is_empty(),
-            ForceBroken(d) | FlexBreak(d) | Nest(_, d) | Group(d) => d.is_empty(),
+            ForceBroken(d) | Nest(_, d) | Group(d) => d.is_empty(),
             Vec(docs) => docs.iter().all(|d| d.is_empty()),
         }
     }

--- a/crates/aiken-lang/src/tests/format.rs
+++ b/crates/aiken-lang/src/tests/format.rs
@@ -347,7 +347,7 @@ fn test_nested_function_calls() {
               _ -> error @"expected inline datum"
             },
           ]
-          |> list.and
+            |> list.and
         }
     "#};
 
@@ -559,4 +559,51 @@ fn test_unicode() {
     "#};
 
     assert_fmt(src, src);
+}
+
+#[test]
+fn test_preserve_pipe() {
+    let src = indoc! { r#"
+        fn foo() {
+          a |> b |> c |> d
+        }
+
+        fn foo() {
+          a
+            // Foo
+            |> b// Some comments
+            |> c
+            |> d
+        }
+
+        fn baz() {
+          // Commented
+          however |> it_automatically_breaks |> into_multiple_lines |> anytime_when |> it_is_too_long // What?
+        }
+    "#};
+
+    let expected = indoc! { r#"
+        fn foo() {
+          a |> b |> c |> d
+        }
+
+        fn foo() {
+          a // Foo
+            |> b // Some comments
+            |> c
+            |> d
+        }
+
+        fn baz() {
+          // Commented
+          however
+            |> it_automatically_breaks
+            |> into_multiple_lines
+            |> anytime_when
+            |> it_is_too_long
+          // What?
+        }
+    "#};
+
+    assert_fmt(src, expected);
 }

--- a/crates/aiken-lang/src/tests/parser.rs
+++ b/crates/aiken-lang/src/tests/parser.rs
@@ -545,6 +545,7 @@ fn pipeline() {
                 tipo: (),
             }],
             body: expr::UntypedExpr::PipeLine {
+                one_liner: false,
                 expressions: vec1::vec1![
                     expr::UntypedExpr::BinOp {
                         location: Span::new((), 31..36),
@@ -717,6 +718,7 @@ fn let_bindings() {
                     expr::UntypedExpr::Assignment {
                         location: Span::new((), 23..70),
                         value: Box::new(expr::UntypedExpr::PipeLine {
+                            one_liner: false,
                             expressions: vec1::vec1![
                                 expr::UntypedExpr::BinOp {
                                     location: Span::new((), 35..40),
@@ -1105,6 +1107,7 @@ fn anonymous_function() {
                         annotation: None,
                     },
                     expr::UntypedExpr::PipeLine {
+                        one_liner: true,
                         expressions: vec1::vec1![
                             expr::UntypedExpr::Int {
                                 location: Span::new((), 71..72),

--- a/crates/aiken-lang/src/tipo/expr.rs
+++ b/crates/aiken-lang/src/tipo/expr.rs
@@ -274,7 +274,7 @@ impl<'a, 'b> ExprTyper<'a, 'b> {
                 location, value, ..
             } => Ok(self.infer_string(value, location)),
 
-            UntypedExpr::PipeLine { expressions } => self.infer_pipeline(expressions),
+            UntypedExpr::PipeLine { expressions, .. } => self.infer_pipeline(expressions),
 
             UntypedExpr::Fn {
                 location,


### PR DESCRIPTION
Fixes #442 
  
- :round_pushpin: **Support flexible pipe operator formatting**
    Rules are now as follows:

  - If a pipeline contains a newline, then the entire pipeline is formatted over multiple lines.
  - If it doesn't, then it's formatted as a single-line UNLESS it cannot fit; in which case, we fallback to multiline again.

- :round_pushpin: **Remove unused 'FlexBreak'**
    The difference between 'FlexBreak' and 'Break(Mode::Strict/Flexible)' as always confused me; and turned out that the 'FlexBreak' thingy is never used. This is dead-code, so I removed it.
