### PR TITLE
Lucid Issue

### DIFF
--- a/crates/uplc/src/tx/error.rs
+++ b/crates/uplc/src/tx/error.rs
@@ -10,7 +10,7 @@ pub enum Error {
     FlatDecode(#[from] flat_rs::de::Error),
     #[error("{0}")]
     FragmentDecode(#[from] pallas_primitives::Error),
-    #[error("{}", .0)]
+    #[error("{}\n\n{:#?}\n\n{}", .0, .1, .2.join("\n"))]
     Machine(machine::Error, ExBudget, Vec<String>),
     #[error("Native script can't be executed in phase-two")]
     NativeScriptPhaseTwo,


### PR DESCRIPTION
fixes https://github.com/spacebudz/lucid/issues/166

It seems this is still safe to do because `tx simulate` explicitly matches on this error anyways.

Bringing this back sorts out an issue that was reported via lucid.

The other option would be to just have this same format string in an extra match in `lucid` where it uses `eval_phase_two_raw`