### PR TITLE
print todo's type when printing the todo warning

### DIFF
--- a/crates/aiken-lang/src/tipo/error.rs
+++ b/crates/aiken-lang/src/tipo/error.rs
@@ -1287,7 +1287,12 @@ pub enum Warning {
     },
 
     #[error("I found a todo left in the code.\n")]
-    #[diagnostic(help("You probably want to replace that one with real code... eventually."))]
+    #[diagnostic(
+        help(
+            "You probably want to replace that one with real code... eventually. The expected type is {}",
+            tipo.to_pretty_with_names(HashMap::new(), 0).if_supports_color(Stderr, |s| s.purple())
+        )
+    )]
     #[diagnostic(code("todo"))]
     Todo {
         #[label]


### PR DESCRIPTION
closes #446

<img width="1029" alt="Screenshot 2023-03-15 at 4 28 13 PM" src="https://user-images.githubusercontent.com/12070598/225434751-fdd667b7-866c-41cd-96ea-da8de1151dfa.png">
