### PR TITLE
Provide better compiler feedback for type holes in annotations.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,12 +8,15 @@
 
 ### Changed
 
+- **aiken-project**: tests filtering with `-m` during check now happens in `Project::collect_tests`
+- **aiken-project**: fixed generation of blueprints for recursive and mutually recursive data-types
+
 - **aiken-lang**: block `Data` and `String` from unifying when casting
 - **aiken-lang**: remove ability for a type with many variants with matching field labels and types to support field access
-- **aiken-project**: tests filtering with `-m` during check now happens in `Project::collect_tests`
 - **aiken-lang**: various uplc code gen fixes
-- **aiken-project**: recursive issue with blueprints fixed
 - **aiken-lang**: update todo warning to include type
+- **aiken-lang**: `|>` operator can now be formatted as a single (short) line or forced over multiline in a flexible manner
+- **aiken-lang**: the compiler now provides better feedback for type holes (i.e. `_`) in type annotations
 
 ## [v0.0.29] - 2023-MM-DD
 

--- a/crates/aiken-lang/src/tipo/environment.rs
+++ b/crates/aiken-lang/src/tipo/environment.rs
@@ -1039,8 +1039,6 @@ impl<'a> Environment<'a> {
                 // Construct type from annotations
                 let mut hydrator = Hydrator::new();
 
-                hydrator.permit_holes(true);
-
                 let mut arg_types = Vec::new();
 
                 for arg in args {
@@ -1097,8 +1095,6 @@ impl<'a> Environment<'a> {
 
                 // Construct type from annotations
                 let mut hydrator = Hydrator::new();
-
-                hydrator.permit_holes(false);
 
                 let mut arg_types = Vec::new();
 

--- a/crates/aiken-lang/src/tipo/expr.rs
+++ b/crates/aiken-lang/src/tipo/expr.rs
@@ -1917,12 +1917,8 @@ impl<'a, 'b> ExprTyper<'a, 'b> {
     }
 
     pub fn new(environment: &'a mut Environment<'b>, tracing: Tracing) -> Self {
-        let mut hydrator = Hydrator::new();
-
-        hydrator.permit_holes(true);
-
         Self {
-            hydrator,
+            hydrator: Hydrator::new(),
             environment,
             tracing,
             ungeneralised_function_used: false,


### PR DESCRIPTION
It is now possible to leave a hole in a type annotation and have the compiler fill-in the expected type of us. This is a pretty useful debugging tool when playing with complex functions.

Fixes #449 

<img width="570" alt="Screenshot 2023-03-16 at 14 02 32" src="https://user-images.githubusercontent.com/5680256/225625046-0cf9b08e-119f-4235-8302-fd9b599f685e.png">

<img width="457" alt="Screenshot 2023-03-16 at 14 03 53" src="https://user-images.githubusercontent.com/5680256/225625404-0ef5ac2c-4bea-4235-afcd-2ab9003338f6.png">

