### PR TITLE
bump rustc version for nix

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -31,7 +31,7 @@
         deno = unstable.legacyPackages.${system}.deno;
 
         rustPkgs = pkgs.rustBuilder.makePackageSet {
-          rustVersion = "1.64.0";
+          rustVersion = "1.66.1";
           packageFun = import ./Cargo.nix;
         };
 


### PR DESCRIPTION
This is a sticking plaster  

Otherwise hit 
```
error[E0658]: let...else statements are unstable
```
I don't know why cargo2nix seems to be so far behind rustc.
