### PR TITLE
fix: Scope issues caused by common ancestor scope being the value instead of the assignment

### DIFF
--- a/crates/uplc/src/optimize.rs
+++ b/crates/uplc/src/optimize.rs
@@ -17,5 +17,9 @@ pub fn aiken_optimize_and_intern(program: Program<Name>) -> Program<Name> {
 
     let program: Program<Name> = program_named.try_into().unwrap();
 
-    program.lambda_reduce().inline_reduce()
+    program
+        .lambda_reduce()
+        .inline_reduce()
+        .lambda_reduce()
+        .inline_reduce()
 }


### PR DESCRIPTION
In when statements and let the value shared a common ancestor with expressions below. Now the value will not have a common ancestor with expressions below.