### PR TITLE
blueprint apply definition lookup error

### DIFF
--- a/crates/aiken-project/src/blueprint/definitions.rs
+++ b/crates/aiken-project/src/blueprint/definitions.rs
@@ -36,7 +36,7 @@ impl<T> Definitions<T> {
     /// Retrieve a definition, if it exists.
     pub fn lookup(&self, reference: &Reference) -> Option<&T> {
         self.inner
-            .get(reference.as_key())
+            .get(&reference.to_json_pointer())
             .map(|v| v
               .as_ref()
               .expect("All registered definitions are 'Some'. 'None' state is only transient during registration")
@@ -110,6 +110,10 @@ impl Reference {
     /// treated as path delimiter in pointers paths).
     pub(crate) fn as_json_pointer(&self) -> String {
         format!("#/definitions/{}", self.as_key().replace('/', "~1"))
+    }
+
+    pub(crate) fn to_json_pointer(&self) -> String {
+        self.as_key().replace("~1", "/")
     }
 }
 


### PR DESCRIPTION
When trying to apply some parameters we kept facing this error.

Upon further inspection is seems like `lookup` was using `Reference::as_key` which returns the definition ref with `~1`. The definitions map does not contain keys in that format, the keys in this map use `/` instead of `~1`.

We've updated `as_key` to always replace `~1` with `/` so that lookups work as expected.

<img width="1311" alt="Screenshot 2023-05-31 at 12 19 30 AM" src="https://github.com/aiken-lang/aiken/assets/49739331/448db5c7-56f9-4a4c-bc70-4619a0e48152">
