### PR TITLE
add a panic hook, present issue link

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Added
 
-N/A
+- **aiken**: added panic hook to present a link to make a bug report
 
 ### Fixed
 

--- a/crates/aiken/src/main.rs
+++ b/crates/aiken/src/main.rs
@@ -48,6 +48,8 @@ impl Default for Cmd {
 fn main() -> miette::Result<()> {
     panic_handler();
 
+    panic!("dam no way!");
+
     match Cmd::default() {
         Cmd::New(args) => new::exec(args),
         Cmd::Fmt(args) => fmt::exec(args),
@@ -90,7 +92,14 @@ fn panic_handler() {
 
         let location = info.location().map_or_else(
             || "".into(),
-            |location| format!("{}:{}\n\n    ", location.file(), location.line()),
+            |location| {
+                format!(
+                    "{}:{}:{}\n\n    ",
+                    location.file(),
+                    location.line(),
+                    location.column(),
+                )
+            },
         );
 
         let error_message = indoc::formatdoc! {


### PR DESCRIPTION
If anything ever panics, which should include unwraps, then we present something that look like the image below. It's a bit more helpful than the default error that a user will see.

closes #525 

<img width="854" alt="Screenshot 2023-06-13 at 8 12 42 PM" src="https://github.com/aiken-lang/aiken/assets/12070598/58bc20f6-838a-4283-ae1e-abbf4d99e3f2">
