### PR TITLE
feat: add Nix Overlay

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -38,6 +38,8 @@
           default = packages.aiken;
         };
 
+        overlays.default = final: prev: { aiken = packages.aiken; };
+
         aikenCmds = commonCategory "Aiken Development" [{
           name = "aiken";
           help = "Aiken toolchain";
@@ -46,7 +48,7 @@
 
         gitRev = if (builtins.hasAttr "rev" self) then self.rev else "dirty";
       in {
-        inherit packages;
+        inherit packages overlays;
 
         devShells.aiken = pkgs.mkShell {
           name = "aiken";


### PR DESCRIPTION
This PR add adds a nixpkgs overlay that allows nix users to add aiken to their `nixpkgs` reference, which is in many ways much easier to do than to actually export flake inputs to submodules. To use, you need to add the overlay to the listing, like so:

```nix
let
  pkgs = import nixpkgs {
    overlays = [ aiken.overlays.default ];
  };
```