### PR TITLE
Fix span offset

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1408,9 +1408,9 @@ dependencies = [
 
 [[package]]
 name = "miette"
-version = "5.7.0"
+version = "5.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7abdc09c381c9336b9f2e9bd6067a9a5290d20e2d2e2296f275456121c33ae89"
+checksum = "a236ff270093b0b67451bc50a509bd1bad302cb1d3c7d37d5efe931238581fa9"
 dependencies = [
  "backtrace",
  "backtrace-ext",
@@ -1429,9 +1429,9 @@ dependencies = [
 
 [[package]]
 name = "miette-derive"
-version = "5.7.0"
+version = "5.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8842972f23939443013dfd3720f46772b743e86f1a81d120d4b6fb090f87de1c"
+checksum = "4901771e1d44ddb37964565c654a3223ba41a594d02b8da471cc4464912b5cfa"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/crates/aiken-lang/Cargo.toml
+++ b/crates/aiken-lang/Cargo.toml
@@ -18,7 +18,7 @@ hex = "0.4.3"
 indexmap = "1.9.2"
 indoc = "2.0.1"
 itertools = "0.10.5"
-miette = "5.5.0"
+miette = "5.9.0"
 ordinal = "0.3.2"
 owo-colors = { version = "3.5.0", features = ["supports-colors"] }
 strum = "0.24.1"

--- a/crates/aiken-lang/src/parser/extra.rs
+++ b/crates/aiken-lang/src/parser/extra.rs
@@ -23,16 +23,12 @@ pub struct Comment<'a> {
 
 impl<'a> From<(&Span, &'a str)> for Comment<'a> {
     fn from(src: (&Span, &'a str)) -> Comment<'a> {
-        fn char_indice(s: &str, i: usize) -> usize {
-            s.char_indices().nth(i).unwrap_or((i, ' ')).0
-        }
-
-        let start = char_indice(src.1, src.0.start);
-        let end = char_indice(src.1, src.0.end);
-
+        let start = src.0.start;
+        let end = src.0.end;
         Comment {
-            start: src.0.start,
-            content: src.1.get(start..end).expect("From span to comment"),
+            start,
+            content: std::str::from_utf8(src.1.as_bytes()[start..end].as_ref())
+                .expect("From span to comment"),
         }
     }
 }

--- a/crates/aiken-lang/src/tests/parser.rs
+++ b/crates/aiken-lang/src/tests/parser.rs
@@ -4796,3 +4796,103 @@ fn first_class_binop() {
         })],
     );
 }
+
+#[test]
+fn parse_unicode_offset_1() {
+    use expr::UntypedExpr::*;
+
+    let code = indoc! {r#"
+      fn foo() {
+        let x = "★"
+        x
+      }
+    "#};
+
+    assert_definitions(
+        code,
+        vec![ast::Definition::Fn(Function {
+            arguments: vec![],
+            body: Sequence {
+                location: Span::new((), 13..30),
+                expressions: vec![
+                    Assignment {
+                        location: Span::new((), 13..26),
+                        value: Box::new(ByteArray {
+                            location: Span::new((), 21..26),
+                            bytes: vec![226, 152, 133],
+                            preferred_format: ast::ByteArrayFormatPreference::Utf8String,
+                        }),
+                        pattern: ast::Pattern::Var {
+                            location: Span::new((), 17..18),
+                            name: "x".to_string(),
+                        },
+                        kind: ast::AssignmentKind::Let,
+                        annotation: None,
+                    },
+                    Var {
+                        location: Span::new((), 29..30),
+                        name: "x".to_string(),
+                    },
+                ],
+            },
+            doc: None,
+            location: Span::new((), 0..8),
+            name: "foo".to_string(),
+            public: false,
+            return_annotation: None,
+            return_type: (),
+            end_position: 31,
+            can_error: true,
+        })],
+    )
+}
+
+#[test]
+fn parse_unicode_offset_2() {
+    use expr::UntypedExpr::*;
+
+    let code = indoc! {r#"
+      fn foo() {
+        let x = "*"
+        x
+      }
+    "#};
+
+    assert_definitions(
+        code,
+        vec![ast::Definition::Fn(Function {
+            arguments: vec![],
+            body: Sequence {
+                location: Span::new((), 13..28),
+                expressions: vec![
+                    Assignment {
+                        location: Span::new((), 13..24),
+                        value: Box::new(ByteArray {
+                            location: Span::new((), 21..24),
+                            bytes: vec![42],
+                            preferred_format: ast::ByteArrayFormatPreference::Utf8String,
+                        }),
+                        pattern: ast::Pattern::Var {
+                            location: Span::new((), 17..18),
+                            name: "x".to_string(),
+                        },
+                        kind: ast::AssignmentKind::Let,
+                        annotation: None,
+                    },
+                    Var {
+                        location: Span::new((), 27..28),
+                        name: "x".to_string(),
+                    },
+                ],
+            },
+            doc: None,
+            location: Span::new((), 0..8),
+            name: "foo".to_string(),
+            public: false,
+            return_annotation: None,
+            return_type: (),
+            end_position: 29,
+            can_error: true,
+        })],
+    )
+}

--- a/crates/aiken-project/Cargo.toml
+++ b/crates/aiken-project/Cargo.toml
@@ -23,7 +23,7 @@ hex = "0.4.3"
 ignore = "0.4.20"
 indexmap = "1.9.2"
 itertools = "0.10.5"
-miette = { version = "5.5.0", features = ["fancy"] }
+miette = { version = "5.9.0", features = ["fancy"] }
 minicbor = "0.19.1"
 owo-colors = { version = "3.5.0", features = ["supports-colors"] }
 pallas = "0.18.0"


### PR DESCRIPTION
Fixes #642 (maybe?)

- :round_pushpin: **Use byte count for token span in the lexer.**
    Somehow, miette doesn't play well with spans when using chars indices.
  So we have to count the number of bytes in strings / chars, so that
  spans align accordingly.

- :round_pushpin: **Bump miette to 5.9.0**
    No particular reason, but it's good to be up-to-date with our dependencies.
