### PR TITLE
Update UPLC pretty printing / parsing to match plutus spec

### DIFF
--- a/crates/uplc/src/parser.rs
+++ b/crates/uplc/src/parser.rs
@@ -7,7 +7,7 @@ use crate::{
 
 use interner::Interner;
 use num_bigint::BigInt;
-use pallas_primitives::{alonzo::PlutusData, Fragment};
+use pallas_primitives::{alonzo::PlutusData};
 use peg::{error::ParseError, str::LineCol};
 
 pub mod interner;

--- a/crates/uplc/src/parser.rs
+++ b/crates/uplc/src/parser.rs
@@ -158,17 +158,17 @@ peg::parser! {
           = "data" _+ d:data() { Constant::Data(d) }
 
         rule constant_list() -> Constant
-          = "list" _* "<" _* t:type_info() _* ">" _+ ls:list(Some(&t)) {
+          = "(" _* "list" _* t:type_info() _* ")" _+ ls:list(Some(&t)) {
             Constant::ProtoList(t, ls)
           }
 
         rule constant_pair() -> Constant
-          = "pair" _* "<" _* l:type_info() _* "," r:type_info() _* ">" _+ p:pair(Some((&l, &r))) {
+          = "(" _* "pair" _+ l:type_info() _+ r:type_info() _* ")" _+ p:pair(Some((&l, &r))) {
             Constant::ProtoPair(l, r, p.0.into(), p.1.into())
           }
 
         rule pair(type_info: Option<(&Type, &Type)>) -> (Constant, Constant)
-          = "[" _* x:typed_constant(type_info.map(|t| t.0)) _* "," _* y:typed_constant(type_info.map(|t| t.1)) _* "]" { (x, y) }
+          = "(" _* x:typed_constant(type_info.map(|t| t.0)) _* "," _* y:typed_constant(type_info.map(|t| t.1)) _* ")" { (x, y) }
 
         rule number() -> isize
           = n:$("-"* ['0'..='9']+) {? n.parse().or(Err("isize")) }
@@ -262,10 +262,10 @@ peg::parser! {
           / _* "bytestring" { Type::ByteString }
           / _* "string" { Type::String }
           / _* "data" { Type::Data }
-          / _* "list" _* "<" _* t:type_info() _* ">" {
+          / _* "(" _* "list" _+ t:type_info() _* ")" _* {
               Type::List(t.into())
             }
-          / _* "pair" _* "<" l:type_info() "," r:type_info() ">" {
+          / _* "(" _* "pair" _+ l:type_info() _+ r:type_info() _* ")" _* {
               Type::Pair(l.into(), r.into())
             }
 

--- a/crates/uplc/src/parser.rs
+++ b/crates/uplc/src/parser.rs
@@ -7,7 +7,7 @@ use crate::{
 
 use interner::Interner;
 use num_bigint::BigInt;
-use pallas_primitives::{alonzo::PlutusData};
+use pallas_primitives::alonzo::PlutusData;
 use peg::{error::ParseError, str::LineCol};
 
 pub mod interner;

--- a/crates/uplc/src/pretty.rs
+++ b/crates/uplc/src/pretty.rs
@@ -252,7 +252,7 @@ impl Constant {
                 .append(RcDoc::text(")")),
 
             Constant::Data(data) => RcDoc::text("(")
-                .append(Self::to_doc_list_plutus_data(&data))
+                .append(Self::to_doc_list_plutus_data(data))
                 .append(RcDoc::text(")")),
         }
     }
@@ -266,7 +266,7 @@ impl Constant {
                 .append(RcDoc::space())
                 .append(RcDoc::text("["))
                 .append(RcDoc::intersperse(
-                    fields.iter().map(|f| Self::to_doc_list_plutus_data(f)),
+                    fields.iter().map(Self::to_doc_list_plutus_data),
                     RcDoc::text(", "),
                 ))
                 .append(RcDoc::text("]")),
@@ -297,7 +297,7 @@ impl Constant {
                 .append(RcDoc::space())
                 .append(RcDoc::text("["))
                 .append(RcDoc::intersperse(
-                    a.iter().map(|item| Self::to_doc_list_plutus_data(item)),
+                    a.iter().map(Self::to_doc_list_plutus_data),
                     RcDoc::text(", "),
                 ))
                 .append(RcDoc::text("]")),

--- a/crates/uplc/src/pretty.rs
+++ b/crates/uplc/src/pretty.rs
@@ -1,12 +1,10 @@
 use crate::{
     ast::{Constant, Program, Term, Type},
     flat::Binder,
-    plutus_data_to_bytes,
 };
-use pallas_codec::utils::KeyValuePairs;
-use pallas_primitives::babbage::{PlutusData, Constr};
+use pallas_primitives::babbage::{Constr, PlutusData};
 use pretty::RcDoc;
-use std::{ascii::escape_default, io::Read};
+use std::ascii::escape_default;
 
 impl<'a, T> Program<T>
 where
@@ -255,14 +253,14 @@ impl Constant {
 
             Constant::Data(data) => RcDoc::text("(")
                 .append(Self::to_doc_list_plutus_data(&data))
-                .append(RcDoc::text(")"))
+                .append(RcDoc::text(")")),
         }
     }
 
     // This feels a little awkward here; not sure if it should be upstreamed to pallas
     fn to_doc_list_plutus_data(data: &PlutusData) -> RcDoc<()> {
         match data {
-            PlutusData::Constr(Constr{ tag, fields, ..}) => RcDoc::text("Constr")
+            PlutusData::Constr(Constr { tag, fields, .. }) => RcDoc::text("Constr")
                 .append(RcDoc::space())
                 .append(RcDoc::as_string(tag))
                 .append(RcDoc::space())
@@ -276,22 +274,21 @@ impl Constant {
                 .append(RcDoc::space())
                 .append(RcDoc::text("["))
                 .append(RcDoc::intersperse(
-                    kvp.iter().map(|(key, value)| RcDoc::text("(")
-                        .append(Self::to_doc_list_plutus_data(key))
-                        .append(RcDoc::text(", "))
-                        .append(Self::to_doc_list_plutus_data(value))
-                        .append(RcDoc::text(")")),
-                    ),
+                    kvp.iter().map(|(key, value)| {
+                        RcDoc::text("(")
+                            .append(Self::to_doc_list_plutus_data(key))
+                            .append(RcDoc::text(", "))
+                            .append(Self::to_doc_list_plutus_data(value))
+                            .append(RcDoc::text(")"))
+                    }),
                     RcDoc::text(", "),
                 ))
                 .append(RcDoc::text("]")),
-            PlutusData::BigInt(bi) => RcDoc::text("I")
-                .append(RcDoc::space())
-                .append(match bi {
-                    pallas_primitives::babbage::BigInt::Int(v) => RcDoc::text(v.to_string()),
-                    pallas_primitives::babbage::BigInt::BigUInt(v) => RcDoc::text(v.to_string()),
-                    pallas_primitives::babbage::BigInt::BigNInt(v) => RcDoc::text(v.to_string()),
-                }),
+            PlutusData::BigInt(bi) => RcDoc::text("I").append(RcDoc::space()).append(match bi {
+                pallas_primitives::babbage::BigInt::Int(v) => RcDoc::text(v.to_string()),
+                pallas_primitives::babbage::BigInt::BigUInt(v) => RcDoc::text(v.to_string()),
+                pallas_primitives::babbage::BigInt::BigNInt(v) => RcDoc::text(v.to_string()),
+            }),
             PlutusData::BoundedBytes(bs) => RcDoc::text("B")
                 .append(RcDoc::space())
                 .append(RcDoc::text("#"))

--- a/crates/uplc/tests/pretty_tests.rs
+++ b/crates/uplc/tests/pretty_tests.rs
@@ -1,58 +1,64 @@
 use num_bigint::ToBigInt;
 use uplc::{
-    ast::{Constant, DeBruijn, Term, Type},
-    Constr, PlutusData,
+    ast::{Constant, Term, Type, Name},
+    Constr, PlutusData, parser::term,
 };
 
 // Examples sourced from https://github.com/input-output-hk/plutus/issues/4751#issuecomment-1538377273
 
+fn round_trip(old_term: Term::<Name>, pp: &str) {
+    //assert_eq!(old_term.to_pretty(), pp);
+    let new_term = term(pp).expect("failed to parse");
+    assert_eq!(new_term, old_term);
+}
+
 #[test]
 fn constant_list_integer() {
-    let term = Term::<DeBruijn>::Constant(
-        Constant::ProtoList(
-            Type::Integer.into(),
-            vec![
-                Constant::Integer(0.to_bigint().unwrap()),
-                Constant::Integer(1.to_bigint().unwrap()),
-                Constant::Integer(2.to_bigint().unwrap()),
-            ],
-        )
-        .into(),
+    round_trip(
+        Term::<Name>::Constant(
+            Constant::ProtoList(
+                Type::Integer.into(),
+                vec![
+                    Constant::Integer(0.to_bigint().unwrap()),
+                    Constant::Integer(1.to_bigint().unwrap()),
+                    Constant::Integer(2.to_bigint().unwrap()),
+                ],
+            )
+            .into(),
+        ),
+        "(con (list integer) [0, 1, 2])",
     );
-    assert_eq!(term.to_pretty(), "(con (list integer) [0, 1, 2])");
 }
 
 #[test]
 fn constant_pair_bool_bytestring() {
-    let term = Term::<DeBruijn>::Constant(
-        Constant::ProtoPair(
-            Type::Bool.into(),
-            Type::ByteString.into(),
-            Constant::Bool(true).into(),
-            Constant::ByteString(vec![0x01, 0x23, 0x45]).into(),
-        )
-        .into(),
-    );
-    assert_eq!(
-        term.to_pretty(),
-        "(con (pair bool bytestring) (True, #012345))"
+    round_trip(
+        Term::<Name>::Constant(
+            Constant::ProtoPair(
+                Type::Bool.into(),
+                Type::ByteString.into(),
+                Constant::Bool(true).into(),
+                Constant::ByteString(vec![0x01, 0x23, 0x45]).into(),
+            )
+            .into(),
+        ),
+        "(con (pair bool bytestring) (True, #012345))",
     );
 }
 
 #[test]
 fn constant_pair_unit_string() {
-    let term = Term::<DeBruijn>::Constant(
-        Constant::ProtoPair(
-            Type::Unit.into(),
-            Type::String.into(),
-            Constant::Unit.into(),
-            Constant::String("hello universe".into()).into(),
-        )
-        .into(),
-    );
-    assert_eq!(
-        term.to_pretty(),
-        "(con (pair unit string) ((), \"hello universe\"))"
+    round_trip(
+        Term::<Name>::Constant(
+            Constant::ProtoPair(
+                Type::Unit.into(),
+                Type::String.into(),
+                Constant::Unit.into(),
+                Constant::String("hello universe".into()).into(),
+            )
+            .into(),
+        ),
+        "(con (pair unit string) ((), \"hello universe\"))",
     )
 }
 
@@ -61,100 +67,104 @@ fn constant_deeply_nested_list() {
     let t0 = Type::Integer;
     let t1 = Type::List(t0.clone().into());
     let t2 = Type::List(t1.clone().into());
-    let term = Term::<DeBruijn>::Constant(
-        Constant::ProtoList(
-            t2,
-            vec![
-                Constant::ProtoList(
-                    t1.clone(),
-                    vec![
-                        Constant::ProtoList(
-                            t0.clone(),
-                            vec![Constant::Integer(-1.to_bigint().unwrap())],
-                        ),
-                        Constant::ProtoList(t0.clone(), vec![]),
-                    ],
-                ),
-                Constant::ProtoList(
-                    t1.clone(),
-                    vec![
-                        Constant::ProtoList(t0.clone(), vec![]),
-                        Constant::ProtoList(
-                            t0.clone(),
-                            vec![
-                                Constant::Integer(2.to_bigint().unwrap()),
-                                Constant::Integer(3.to_bigint().unwrap()),
-                            ],
-                        ),
-                    ],
-                ),
-            ],
-        )
-        .into(),
-    );
-    assert_eq!(
-        term.to_pretty(),
-        "(con (list (list (list integer))) [[[-1], []], [[], [2, 3]]])"
+    round_trip(
+        Term::<Name>::Constant(
+            Constant::ProtoList(
+                t2,
+                vec![
+                    Constant::ProtoList(
+                        t1.clone(),
+                        vec![
+                            Constant::ProtoList(
+                                t0.clone(),
+                                vec![Constant::Integer(-1.to_bigint().unwrap())],
+                            ),
+                            Constant::ProtoList(t0.clone(), vec![]),
+                        ],
+                    ),
+                    Constant::ProtoList(
+                        t1.clone(),
+                        vec![
+                            Constant::ProtoList(t0.clone(), vec![]),
+                            Constant::ProtoList(
+                                t0.clone(),
+                                vec![
+                                    Constant::Integer(2.to_bigint().unwrap()),
+                                    Constant::Integer(3.to_bigint().unwrap()),
+                                ],
+                            ),
+                        ],
+                    ),
+                ],
+            )
+            .into(),
+        ),
+        "(con (list (list (list integer))) [[[-1], []], [[], [2, 3]]])",
     );
 }
 
 #[test]
 fn constant_data_constr() {
-    let term = Term::<DeBruijn>::Constant(
-        Constant::Data(PlutusData::Constr(Constr::<PlutusData> {
-            tag: 1,
-            any_constructor: None,
-            fields: vec![PlutusData::BigInt(pallas_primitives::alonzo::BigInt::Int(
-                2.into(),
-            ))],
-        }))
-        .into(),
+    round_trip(
+        Term::<Name>::Constant(
+            Constant::Data(PlutusData::Constr(Constr::<PlutusData> {
+                tag: 1,
+                any_constructor: None,
+                fields: vec![PlutusData::BigInt(pallas_primitives::alonzo::BigInt::Int(
+                    2.into(),
+                ))],
+            }))
+            .into(),
+        ),
+        "(con data (Constr 1 [I 2]))",
     );
-    assert_eq!(term.to_pretty(), "(con data (Constr 1 [I 2]))");
 }
 
 #[test]
 fn constant_data_map() {
-    let term = Term::<DeBruijn>::Constant(
-        Constant::Data(PlutusData::Map(uplc::KeyValuePairs::Def(vec![
-            (
-                PlutusData::BigInt(pallas_primitives::alonzo::BigInt::Int(0.into())),
-                PlutusData::BoundedBytes(vec![0x00].into()),
-            ),
-            (
-                PlutusData::BigInt(pallas_primitives::alonzo::BigInt::Int(1.into())),
-                PlutusData::BoundedBytes(vec![0x0f].into()),
-            ),
-        ])))
-        .into(),
-    );
-    assert_eq!(
-        term.to_pretty(),
-        "(con data (Map [(I 0, B #00), (I 1, B #0f)]))"
+    round_trip(
+        Term::<Name>::Constant(
+            Constant::Data(PlutusData::Map(uplc::KeyValuePairs::Def(vec![
+                (
+                    PlutusData::BigInt(pallas_primitives::alonzo::BigInt::Int(0.into())),
+                    PlutusData::BoundedBytes(vec![0x00].into()),
+                ),
+                (
+                    PlutusData::BigInt(pallas_primitives::alonzo::BigInt::Int(1.into())),
+                    PlutusData::BoundedBytes(vec![0x0f].into()),
+                ),
+            ])))
+            .into(),
+        ),
+        "(con data (Map [(I 0, B #00), (I 1, B #0f)]))",
     );
 }
 
 #[test]
 fn constant_data_list() {
-    let term = Term::<DeBruijn>::Constant(
-        Constant::Data(PlutusData::Array(vec![
-            PlutusData::BigInt(pallas_primitives::alonzo::BigInt::Int(0.into())),
-            PlutusData::BigInt(pallas_primitives::alonzo::BigInt::Int(1.into())),
-        ]))
-        .into(),
+    round_trip(
+        Term::<Name>::Constant(
+            Constant::Data(PlutusData::Array(vec![
+                PlutusData::BigInt(pallas_primitives::alonzo::BigInt::Int(0.into())),
+                PlutusData::BigInt(pallas_primitives::alonzo::BigInt::Int(1.into())),
+            ]))
+            .into(),
+        ),
+        "(con data (List [I 0, I 1]))",
     );
-    assert_eq!(term.to_pretty(), "(con data (List [I 0, I 1]))");
 }
 
 #[test]
 fn constant_data_int() {
-    let term = Term::<DeBruijn>::Constant(
-        Constant::Data(PlutusData::BigInt(pallas_primitives::alonzo::BigInt::Int(
-            2.into(),
-        )))
-        .into(),
+    round_trip(
+        Term::<Name>::Constant(
+            Constant::Data(PlutusData::BigInt(pallas_primitives::alonzo::BigInt::Int(
+                2.into(),
+            )))
+            .into(),
+        ),
+        "(con data (I 2))",
     );
-    assert_eq!(term.to_pretty(), "(con data (I 2))");
 
     // TODO: large integers currently encode as bytestrings, which isn't great
     /*
@@ -171,8 +181,10 @@ fn constant_data_int() {
 
 #[test]
 fn constant_data_bytes() {
-    let term = Term::<DeBruijn>::Constant(
-        Constant::Data(PlutusData::BoundedBytes(vec![0x00, 0x1A].into())).into(),
+    round_trip(
+        Term::<Name>::Constant(
+            Constant::Data(PlutusData::BoundedBytes(vec![0x00, 0x1A].into())).into(),
+        ),
+        "(con data (B #001a))",
     );
-    assert_eq!(term.to_pretty(), "(con data (B #001a))");
 }

--- a/crates/uplc/tests/pretty_tests.rs
+++ b/crates/uplc/tests/pretty_tests.rs
@@ -1,12 +1,13 @@
 use num_bigint::ToBigInt;
 use uplc::{
-    ast::{Constant, Term, Type, Name},
-    Constr, PlutusData, parser::term,
+    ast::{Constant, Name, Term, Type},
+    parser::term,
+    Constr, PlutusData,
 };
 
 // Examples sourced from https://github.com/input-output-hk/plutus/issues/4751#issuecomment-1538377273
 
-fn round_trip(old_term: Term::<Name>, pp: &str) {
+fn round_trip(old_term: Term<Name>, pp: &str) {
     //assert_eq!(old_term.to_pretty(), pp);
     let new_term = term(pp).expect("failed to parse");
     assert_eq!(new_term, old_term);

--- a/crates/uplc/tests/pretty_tests.rs
+++ b/crates/uplc/tests/pretty_tests.rs
@@ -18,7 +18,7 @@ fn constant_list_integer() {
     round_trip(
         Term::<Name>::Constant(
             Constant::ProtoList(
-                Type::Integer.into(),
+                Type::Integer,
                 vec![
                     Constant::Integer(0.to_bigint().unwrap()),
                     Constant::Integer(1.to_bigint().unwrap()),
@@ -36,8 +36,8 @@ fn constant_pair_bool_bytestring() {
     round_trip(
         Term::<Name>::Constant(
             Constant::ProtoPair(
-                Type::Bool.into(),
-                Type::ByteString.into(),
+                Type::Bool,
+                Type::ByteString,
                 Constant::Bool(true).into(),
                 Constant::ByteString(vec![0x01, 0x23, 0x45]).into(),
             )
@@ -52,8 +52,8 @@ fn constant_pair_unit_string() {
     round_trip(
         Term::<Name>::Constant(
             Constant::ProtoPair(
-                Type::Unit.into(),
-                Type::String.into(),
+                Type::Unit,
+                Type::String,
                 Constant::Unit.into(),
                 Constant::String("hello universe".into()).into(),
             )
@@ -78,17 +78,17 @@ fn constant_deeply_nested_list() {
                         vec![
                             Constant::ProtoList(
                                 t0.clone(),
-                                vec![Constant::Integer(-1.to_bigint().unwrap())],
+                                vec![Constant::Integer((-1).to_bigint().unwrap())],
                             ),
                             Constant::ProtoList(t0.clone(), vec![]),
                         ],
                     ),
                     Constant::ProtoList(
-                        t1.clone(),
+                        t1,
                         vec![
                             Constant::ProtoList(t0.clone(), vec![]),
                             Constant::ProtoList(
-                                t0.clone(),
+                                t0,
                                 vec![
                                     Constant::Integer(2.to_bigint().unwrap()),
                                     Constant::Integer(3.to_bigint().unwrap()),

--- a/crates/uplc/tests/pretty_tests.rs
+++ b/crates/uplc/tests/pretty_tests.rs
@@ -1,0 +1,125 @@
+use num_bigint::{ToBigInt};
+use uplc::{
+    ast::{DeBruijn, Constant, Type, Term}, PlutusData, Constr,
+};
+
+// Examples sourced from https://github.com/input-output-hk/plutus/issues/4751#issuecomment-1538377273
+
+#[test]
+fn constant_list_integer() {
+    let term  = Term::<DeBruijn>::Constant(Constant::ProtoList(Type::Integer.into(), vec![
+        Constant::Integer(0.to_bigint().unwrap()),
+        Constant::Integer(1.to_bigint().unwrap()),
+        Constant::Integer(2.to_bigint().unwrap()),
+    ]).into());
+    assert_eq!(term.to_pretty(), "(con (list integer) [0, 1, 2])");
+}
+
+#[test]
+fn constant_pair_bool_bytestring() {
+    let term  = Term::<DeBruijn>::Constant(Constant::ProtoPair(
+        Type::Bool.into(), Type::ByteString.into(),
+        Constant::Bool(true).into(), Constant::ByteString(vec![0x01, 0x23, 0x45]).into(),
+    ).into());
+    assert_eq!(term.to_pretty(), "(con (pair bool bytestring) (True, #012345))");
+}
+
+#[test]
+fn constant_pair_unit_string() {
+    let term = Term::<DeBruijn>::Constant(Constant::ProtoPair(
+        Type::Unit.into(), Type::String.into(),
+        Constant::Unit.into(), Constant::String("hello universe".into()).into(),
+    ).into());
+    assert_eq!(term.to_pretty(), "(con (pair unit string) ((), \"hello universe\"))")
+}
+
+#[test]
+fn constant_deeply_nested_list() {
+    let t0 = Type::Integer;
+    let t1 = Type::List(t0.clone().into());
+    let t2 = Type::List(t1.clone().into());
+    let term = Term::<DeBruijn>::Constant(Constant::ProtoList(t2, vec![
+        Constant::ProtoList(t1.clone(), vec![
+            Constant::ProtoList(t0.clone(), vec![
+                Constant::Integer(-1.to_bigint().unwrap()),
+            ]),
+            Constant::ProtoList(t0.clone(), vec![])
+        ]),
+        Constant::ProtoList(t1.clone(), vec![
+            Constant::ProtoList(t0.clone(), vec![]),
+            Constant::ProtoList(t0.clone(), vec![
+                Constant::Integer(2.to_bigint().unwrap()),
+                Constant::Integer(3.to_bigint().unwrap())
+            ]),
+        ])
+    ]).into());
+    assert_eq!(term.to_pretty(), "(con (list (list (list integer))) [[[-1], []], [[], [2, 3]]])");
+}
+
+#[test]
+fn constant_data_constr() {
+    let term = Term::<DeBruijn>::Constant(Constant::Data(
+        PlutusData::Constr(Constr::<PlutusData> {
+            tag: 1,
+            any_constructor: None,
+            fields: vec![PlutusData::BigInt(pallas_primitives::alonzo::BigInt::Int(2.into()))] 
+        })
+    ).into());
+    assert_eq!(term.to_pretty(), "(con data (Constr 1 [I 2]))");
+}
+
+#[test]
+fn constant_data_map() {
+    let term = Term::<DeBruijn>::Constant(Constant::Data(
+        PlutusData::Map(uplc::KeyValuePairs::Def(vec![
+            (
+                PlutusData::BigInt(pallas_primitives::alonzo::BigInt::Int(0.into())),
+                PlutusData::BoundedBytes(vec![0x00].into()),
+            ),
+            (
+                PlutusData::BigInt(pallas_primitives::alonzo::BigInt::Int(1.into())),
+                PlutusData::BoundedBytes(vec![0x0f].into()),
+            ),
+        ]))
+    ).into());
+    assert_eq!(term.to_pretty(), "(con data (Map [(I 0, B #00), (I 1, B #0f)]))");
+}
+
+#[test]
+fn constant_data_list() {
+    let term = Term::<DeBruijn>::Constant(Constant::Data(
+        PlutusData::Array(vec![
+            PlutusData::BigInt(pallas_primitives::alonzo::BigInt::Int(0.into())),
+            PlutusData::BigInt(pallas_primitives::alonzo::BigInt::Int(1.into())),
+        ])
+    ).into());
+    assert_eq!(term.to_pretty(), "(con data (List [I 0, I 1]))");
+}
+
+#[test]
+fn constant_data_int() {
+    let term = Term::<DeBruijn>::Constant(Constant::Data(
+        PlutusData::BigInt(pallas_primitives::alonzo::BigInt::Int(2.into())),
+    ).into());
+    assert_eq!(term.to_pretty(), "(con data (I 2))");
+
+    // TODO: large integers currently encode as bytestrings, which isn't great
+    /*
+    let term = Term::<DeBruijn>::Constant(Constant::Data(
+        PlutusData::BigInt(pallas_primitives::alonzo::BigInt::BigUInt(vec![2,3,4].into())),
+    ).into());
+    assert_eq!(term.to_pretty(), "(con data (I 131844))");
+    let term = Term::<DeBruijn>::Constant(Constant::Data(
+        PlutusData::BigInt(pallas_primitives::alonzo::BigInt::BigNInt(vec![FF,FD,FC,FC].into())),
+    ).into());
+    assert_eq!(term.to_pretty(), "(con data (I -131844))");
+    */
+}
+
+#[test]
+fn constant_data_bytes() {
+    let term = Term::<DeBruijn>::Constant(Constant::Data(
+        PlutusData::BoundedBytes(vec![0x00, 0x1A].into()),
+    ).into());
+    assert_eq!(term.to_pretty(), "(con data (B #001a))");
+}

--- a/crates/uplc/tests/pretty_tests.rs
+++ b/crates/uplc/tests/pretty_tests.rs
@@ -1,36 +1,59 @@
-use num_bigint::{ToBigInt};
+use num_bigint::ToBigInt;
 use uplc::{
-    ast::{DeBruijn, Constant, Type, Term}, PlutusData, Constr,
+    ast::{Constant, DeBruijn, Term, Type},
+    Constr, PlutusData,
 };
 
 // Examples sourced from https://github.com/input-output-hk/plutus/issues/4751#issuecomment-1538377273
 
 #[test]
 fn constant_list_integer() {
-    let term  = Term::<DeBruijn>::Constant(Constant::ProtoList(Type::Integer.into(), vec![
-        Constant::Integer(0.to_bigint().unwrap()),
-        Constant::Integer(1.to_bigint().unwrap()),
-        Constant::Integer(2.to_bigint().unwrap()),
-    ]).into());
+    let term = Term::<DeBruijn>::Constant(
+        Constant::ProtoList(
+            Type::Integer.into(),
+            vec![
+                Constant::Integer(0.to_bigint().unwrap()),
+                Constant::Integer(1.to_bigint().unwrap()),
+                Constant::Integer(2.to_bigint().unwrap()),
+            ],
+        )
+        .into(),
+    );
     assert_eq!(term.to_pretty(), "(con (list integer) [0, 1, 2])");
 }
 
 #[test]
 fn constant_pair_bool_bytestring() {
-    let term  = Term::<DeBruijn>::Constant(Constant::ProtoPair(
-        Type::Bool.into(), Type::ByteString.into(),
-        Constant::Bool(true).into(), Constant::ByteString(vec![0x01, 0x23, 0x45]).into(),
-    ).into());
-    assert_eq!(term.to_pretty(), "(con (pair bool bytestring) (True, #012345))");
+    let term = Term::<DeBruijn>::Constant(
+        Constant::ProtoPair(
+            Type::Bool.into(),
+            Type::ByteString.into(),
+            Constant::Bool(true).into(),
+            Constant::ByteString(vec![0x01, 0x23, 0x45]).into(),
+        )
+        .into(),
+    );
+    assert_eq!(
+        term.to_pretty(),
+        "(con (pair bool bytestring) (True, #012345))"
+    );
 }
 
 #[test]
 fn constant_pair_unit_string() {
-    let term = Term::<DeBruijn>::Constant(Constant::ProtoPair(
-        Type::Unit.into(), Type::String.into(),
-        Constant::Unit.into(), Constant::String("hello universe".into()).into(),
-    ).into());
-    assert_eq!(term.to_pretty(), "(con (pair unit string) ((), \"hello universe\"))")
+    let term = Term::<DeBruijn>::Constant(
+        Constant::ProtoPair(
+            Type::Unit.into(),
+            Type::String.into(),
+            Constant::Unit.into(),
+            Constant::String("hello universe".into()).into(),
+        )
+        .into(),
+    );
+    assert_eq!(
+        term.to_pretty(),
+        "(con (pair unit string) ((), \"hello universe\"))"
+    )
 }
 
 #[test]
@@ -38,40 +61,62 @@ fn constant_deeply_nested_list() {
     let t0 = Type::Integer;
     let t1 = Type::List(t0.clone().into());
     let t2 = Type::List(t1.clone().into());
-    let term = Term::<DeBruijn>::Constant(Constant::ProtoList(t2, vec![
-        Constant::ProtoList(t1.clone(), vec![
-            Constant::ProtoList(t0.clone(), vec![
-                Constant::Integer(-1.to_bigint().unwrap()),
-            ]),
-            Constant::ProtoList(t0.clone(), vec![])
-        ]),
-        Constant::ProtoList(t1.clone(), vec![
-            Constant::ProtoList(t0.clone(), vec![]),
-            Constant::ProtoList(t0.clone(), vec![
-                Constant::Integer(2.to_bigint().unwrap()),
-                Constant::Integer(3.to_bigint().unwrap())
-            ]),
-        ])
-    ]).into());
-    assert_eq!(term.to_pretty(), "(con (list (list (list integer))) [[[-1], []], [[], [2, 3]]])");
+    let term = Term::<DeBruijn>::Constant(
+        Constant::ProtoList(
+            t2,
+            vec![
+                Constant::ProtoList(
+                    t1.clone(),
+                    vec![
+                        Constant::ProtoList(
+                            t0.clone(),
+                            vec![Constant::Integer(-1.to_bigint().unwrap())],
+                        ),
+                        Constant::ProtoList(t0.clone(), vec![]),
+                    ],
+                ),
+                Constant::ProtoList(
+                    t1.clone(),
+                    vec![
+                        Constant::ProtoList(t0.clone(), vec![]),
+                        Constant::ProtoList(
+                            t0.clone(),
+                            vec![
+                                Constant::Integer(2.to_bigint().unwrap()),
+                                Constant::Integer(3.to_bigint().unwrap()),
+                            ],
+                        ),
+                    ],
+                ),
+            ],
+        )
+        .into(),
+    );
+    assert_eq!(
+        term.to_pretty(),
+        "(con (list (list (list integer))) [[[-1], []], [[], [2, 3]]])"
+    );
 }
 
 #[test]
 fn constant_data_constr() {
-    let term = Term::<DeBruijn>::Constant(Constant::Data(
-        PlutusData::Constr(Constr::<PlutusData> {
+    let term = Term::<DeBruijn>::Constant(
+        Constant::Data(PlutusData::Constr(Constr::<PlutusData> {
             tag: 1,
             any_constructor: None,
-            fields: vec![PlutusData::BigInt(pallas_primitives::alonzo::BigInt::Int(2.into()))] 
-        })
-    ).into());
+            fields: vec![PlutusData::BigInt(pallas_primitives::alonzo::BigInt::Int(
+                2.into(),
+            ))],
+        }))
+        .into(),
+    );
     assert_eq!(term.to_pretty(), "(con data (Constr 1 [I 2]))");
 }
 
 #[test]
 fn constant_data_map() {
-    let term = Term::<DeBruijn>::Constant(Constant::Data(
-        PlutusData::Map(uplc::KeyValuePairs::Def(vec![
+    let term = Term::<DeBruijn>::Constant(
+        Constant::Data(PlutusData::Map(uplc::KeyValuePairs::Def(vec![
             (
                 PlutusData::BigInt(pallas_primitives::alonzo::BigInt::Int(0.into())),
                 PlutusData::BoundedBytes(vec![0x00].into()),
@@ -80,27 +125,35 @@ fn constant_data_map() {
                 PlutusData::BigInt(pallas_primitives::alonzo::BigInt::Int(1.into())),
                 PlutusData::BoundedBytes(vec![0x0f].into()),
             ),
-        ]))
-    ).into());
-    assert_eq!(term.to_pretty(), "(con data (Map [(I 0, B #00), (I 1, B #0f)]))");
+        ])))
+        .into(),
+    );
+    assert_eq!(
+        term.to_pretty(),
+        "(con data (Map [(I 0, B #00), (I 1, B #0f)]))"
+    );
 }
 
 #[test]
 fn constant_data_list() {
-    let term = Term::<DeBruijn>::Constant(Constant::Data(
-        PlutusData::Array(vec![
+    let term = Term::<DeBruijn>::Constant(
+        Constant::Data(PlutusData::Array(vec![
             PlutusData::BigInt(pallas_primitives::alonzo::BigInt::Int(0.into())),
             PlutusData::BigInt(pallas_primitives::alonzo::BigInt::Int(1.into())),
-        ])
-    ).into());
+        ]))
+        .into(),
+    );
     assert_eq!(term.to_pretty(), "(con data (List [I 0, I 1]))");
 }
 
 #[test]
 fn constant_data_int() {
-    let term = Term::<DeBruijn>::Constant(Constant::Data(
-        PlutusData::BigInt(pallas_primitives::alonzo::BigInt::Int(2.into())),
-    ).into());
+    let term = Term::<DeBruijn>::Constant(
+        Constant::Data(PlutusData::BigInt(pallas_primitives::alonzo::BigInt::Int(
+            2.into(),
+        )))
+        .into(),
+    );
     assert_eq!(term.to_pretty(), "(con data (I 2))");
 
     // TODO: large integers currently encode as bytestrings, which isn't great
@@ -118,8 +171,8 @@ fn constant_data_int() {
 
 #[test]
 fn constant_data_bytes() {
-    let term = Term::<DeBruijn>::Constant(Constant::Data(
-        PlutusData::BoundedBytes(vec![0x00, 0x1A].into()),
-    ).into());
+    let term = Term::<DeBruijn>::Constant(
+        Constant::Data(PlutusData::BoundedBytes(vec![0x00, 0x1A].into())).into(),
+    );
     assert_eq!(term.to_pretty(), "(con data (B #001a))");
 }


### PR DESCRIPTION
This is a WIP for #625;

This updates the pretty printing code to match the spec outlined here: https://github.com/input-output-hk/plutus/issues/4751#issuecomment-1538377273

There's no easy way that I could find to print PlutusData, or specifically BigInt's, so this isn't *fully* compliant yet.  Maybe some of this should be upstreamed into pallas? What do you think @scarmuega ?

Also, I need to update the parsing.  But I wanted to get some early feedback.