### PR TITLE
rename `error` to `fail`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@
 ### Changed
 
 - **uplc**: make list type and pair type parsing match the plutus core spec
+- **aiken-lang**: rename `error` to `fail`
+- **aiken-lang**: new failing test syntax `test name() fail {`
 
 ### Removed
 

--- a/crates/aiken-lang/src/ast.rs
+++ b/crates/aiken-lang/src/ast.rs
@@ -116,7 +116,7 @@ fn str_to_keyword(word: &str) -> Option<Token> {
         "type" => Some(Token::Type),
         "trace" => Some(Token::Trace),
         "test" => Some(Token::Test),
-        "error" => Some(Token::ErrorTerm),
+        "error" => Some(Token::Fail),
         "validator" => Some(Token::Validator),
         _ => None,
     }

--- a/crates/aiken-lang/src/expr.rs
+++ b/crates/aiken-lang/src/expr.rs
@@ -552,7 +552,7 @@ impl UntypedExpr {
         }
     }
 
-    pub fn error(reason: Option<Self>, location: Span) -> Self {
+    pub fn fail(reason: Option<Self>, location: Span) -> Self {
         UntypedExpr::Trace {
             location,
             kind: TraceKind::Error,

--- a/crates/aiken-lang/src/format.rs
+++ b/crates/aiken-lang/src/format.rs
@@ -873,7 +873,7 @@ impl<'comments> Formatter<'comments> {
     ) -> Document<'a> {
         let (keyword, default_text) = match kind {
             TraceKind::Trace => ("trace", None),
-            TraceKind::Error => ("error", Some(DEFAULT_ERROR_STR.to_string())),
+            TraceKind::Error => ("fail", Some(DEFAULT_ERROR_STR.to_string())),
             TraceKind::Todo => ("todo", Some(DEFAULT_TODO_STR.to_string())),
         };
 

--- a/crates/aiken-lang/src/format.rs
+++ b/crates/aiken-lang/src/format.rs
@@ -239,6 +239,7 @@ impl<'comments> Formatter<'comments> {
                 return_annotation,
                 body,
                 *end_position,
+                false,
             ),
 
             Definition::Validator(Validator {
@@ -258,12 +259,13 @@ impl<'comments> Formatter<'comments> {
                 ..
             }) => self.definition_fn(
                 &false,
-                if *can_error { "!test" } else { "test" },
+                "test",
                 name,
                 args,
                 &None,
                 body,
                 *end_position,
+                *can_error,
             ),
 
             Definition::TypeAlias(TypeAlias {
@@ -483,13 +485,15 @@ impl<'comments> Formatter<'comments> {
         return_annotation: &'a Option<Annotation>,
         body: &'a UntypedExpr,
         end_location: usize,
+        can_error: bool,
     ) -> Document<'a> {
         // Fn name and args
         let head = pub_(*public)
             .append(keyword)
             .append(" ")
             .append(name)
-            .append(wrap_args(args.iter().map(|e| (self.fn_arg(e), false))));
+            .append(wrap_args(args.iter().map(|e| (self.fn_arg(e), false))))
+            .append(if can_error { " fail" } else { "" });
 
         // Add return annotation
         let head = match return_annotation {
@@ -532,6 +536,7 @@ impl<'comments> Formatter<'comments> {
                 &fun.return_annotation,
                 &fun.body,
                 fun.end_position,
+                false,
             )
             .group();
         let first_fn = commented(fun_doc_comments.append(first_fn).group(), fun_comments);
@@ -551,6 +556,7 @@ impl<'comments> Formatter<'comments> {
                         &other.return_annotation,
                         &other.body,
                         other.end_position,
+                        false,
                     )
                     .group();
 

--- a/crates/aiken-lang/src/parser/definition/snapshots/def_test_fail.snap
+++ b/crates/aiken-lang/src/parser/definition/snapshots/def_test_fail.snap
@@ -1,22 +1,22 @@
 ---
 source: crates/aiken-lang/src/parser/definition/test.rs
-description: "Code:\n\n!test invalid_inputs() {\n  expect True = False\n\n  False\n}\n"
+description: "Code:\n\ntest invalid_inputs() fail {\n  expect True = False\n\n  False\n}\n"
 ---
 Test(
     Function {
         arguments: [],
         body: Sequence {
-            location: 27..55,
+            location: 31..59,
             expressions: [
                 Assignment {
-                    location: 27..46,
+                    location: 31..50,
                     value: Var {
-                        location: 41..46,
+                        location: 45..50,
                         name: "False",
                     },
                     pattern: Constructor {
                         is_record: false,
-                        location: 34..38,
+                        location: 38..42,
                         name: "True",
                         arguments: [],
                         module: None,
@@ -28,18 +28,18 @@ Test(
                     annotation: None,
                 },
                 Var {
-                    location: 50..55,
+                    location: 54..59,
                     name: "False",
                 },
             ],
         },
         doc: None,
-        location: 0..22,
+        location: 0..26,
         name: "invalid_inputs",
         public: false,
         return_annotation: None,
         return_type: (),
-        end_position: 56,
+        end_position: 60,
         can_error: true,
     },
 )

--- a/crates/aiken-lang/src/parser/expr/fail_todo.rs
+++ b/crates/aiken-lang/src/parser/expr/fail_todo.rs
@@ -17,9 +17,9 @@ pub fn parser(
         just(Token::Todo)
             .ignore_then(message().or_not())
             .map_with_span(UntypedExpr::todo),
-        just(Token::ErrorTerm)
+        just(Token::Fail)
             .ignore_then(message().or_not())
-            .map_with_span(UntypedExpr::error),
+            .map_with_span(UntypedExpr::fail),
     ))
 }
 
@@ -31,7 +31,7 @@ mod tests {
     fn error_basic() {
         assert_expr!(
             r#"
-            error @"foo"
+            fail @"foo"
             "#
         );
     }
@@ -40,7 +40,7 @@ mod tests {
     fn error_sugar() {
         assert_expr!(
             r#"
-            error "foo"
+            fail "foo"
             "#
         );
     }

--- a/crates/aiken-lang/src/parser/expr/mod.rs
+++ b/crates/aiken-lang/src/parser/expr/mod.rs
@@ -7,7 +7,7 @@ pub mod assignment;
 mod block;
 pub(crate) mod bytearray;
 mod chained;
-mod error_todo;
+mod fail_todo;
 mod if_else;
 mod int;
 mod list;
@@ -23,7 +23,7 @@ pub use anonymous_function::parser as anonymous_function;
 pub use block::parser as block;
 pub use bytearray::parser as bytearray;
 pub use chained::parser as chained;
-pub use error_todo::parser as error_todo;
+pub use fail_todo::parser as fail_todo;
 pub use if_else::parser as if_else;
 pub use int::parser as int;
 pub use list::parser as list;
@@ -43,7 +43,7 @@ pub fn parser(
 ) -> impl Parser<Token, UntypedExpr, Error = ParseError> + '_ {
     recursive(|expression| {
         choice((
-            error_todo(sequence.clone()),
+            fail_todo(sequence.clone()),
             pure_expression(sequence, expression),
         ))
     })

--- a/crates/aiken-lang/src/parser/expr/snapshots/error_basic.snap
+++ b/crates/aiken-lang/src/parser/expr/snapshots/error_basic.snap
@@ -1,15 +1,15 @@
 ---
-source: crates/aiken-lang/src/parser/expr/error_todo.rs
-description: "Code:\n\nerror @\"foo\"\n"
+source: crates/aiken-lang/src/parser/expr/fail_todo.rs
+description: "Code:\n\nfail @\"foo\"\n"
 ---
 Trace {
     kind: Error,
-    location: 0..12,
+    location: 0..11,
     then: ErrorTerm {
-        location: 0..12,
+        location: 0..11,
     },
     text: String {
-        location: 6..12,
+        location: 5..11,
         value: "foo",
     },
 }

--- a/crates/aiken-lang/src/parser/expr/snapshots/error_sugar.snap
+++ b/crates/aiken-lang/src/parser/expr/snapshots/error_sugar.snap
@@ -1,15 +1,15 @@
 ---
-source: crates/aiken-lang/src/parser/expr/error_todo.rs
-description: "Code:\n\nerror \"foo\"\n"
+source: crates/aiken-lang/src/parser/expr/fail_todo.rs
+description: "Code:\n\nfail \"foo\"\n"
 ---
 Trace {
     kind: Error,
-    location: 0..11,
+    location: 0..10,
     then: ErrorTerm {
-        location: 0..11,
+        location: 0..10,
     },
     text: String {
-        location: 6..11,
+        location: 5..10,
         value: "foo",
     },
 }

--- a/crates/aiken-lang/src/parser/expr/when/clause.rs
+++ b/crates/aiken-lang/src/parser/expr/when/clause.rs
@@ -63,7 +63,7 @@ mod tests {
         assert_expr!(
             r#"
             when val is {
-              Bar1{..} -> error
+              Bar1{..} -> fail
             }
             "#
         );

--- a/crates/aiken-lang/src/parser/expr/when/snapshots/when_clause_solo_error.snap
+++ b/crates/aiken-lang/src/parser/expr/when/snapshots/when_clause_solo_error.snap
@@ -1,16 +1,16 @@
 ---
 source: crates/aiken-lang/src/parser/expr/when/clause.rs
-description: "Code:\n\nwhen val is {\n  Bar1{..} -> error\n}\n"
+description: "Code:\n\nwhen val is {\n  Bar1{..} -> fail\n}\n"
 ---
 When {
-    location: 0..35,
+    location: 0..34,
     subject: Var {
         location: 5..8,
         name: "val",
     },
     clauses: [
         UntypedClause {
-            location: 16..33,
+            location: 16..32,
             patterns: [
                 Constructor {
                     is_record: true,
@@ -26,12 +26,12 @@ When {
             guard: None,
             then: Trace {
                 kind: Error,
-                location: 28..33,
+                location: 28..32,
                 then: ErrorTerm {
-                    location: 28..33,
+                    location: 28..32,
                 },
                 text: String {
-                    location: 28..33,
+                    location: 28..32,
                     value: "aiken::error",
                 },
             },

--- a/crates/aiken-lang/src/parser/lexer.rs
+++ b/crates/aiken-lang/src/parser/lexer.rs
@@ -222,7 +222,9 @@ pub fn lexer() -> impl Parser<char, Vec<(Token, Span)>, Error = ParseError> {
 
     let keyword = text::ident().map(|s: String| match s.as_str() {
         "trace" => Token::Trace,
-        "error" => Token::ErrorTerm,
+        "fail" => Token::Fail,
+        // TODO: delete this eventually
+        "error" => Token::Fail,
         "as" => Token::As,
         "assert" => Token::Expect,
         "expect" => Token::Expect,

--- a/crates/aiken-lang/src/parser/token.rs
+++ b/crates/aiken-lang/src/parser/token.rs
@@ -74,7 +74,7 @@ pub enum Token {
     Fn,
     If,
     Else,
-    ErrorTerm,
+    Fail,
     Expect,
     Is,
     Let,
@@ -170,7 +170,7 @@ impl fmt::Display for Token {
             Token::Trace => "trace",
             Token::Type => "type",
             Token::Test => "test",
-            Token::ErrorTerm => "error",
+            Token::Fail => "fail",
             Token::Validator => "validator",
         };
         write!(f, "\"{s}\"")

--- a/crates/aiken-lang/src/tests/format.rs
+++ b/crates/aiken-lang/src/tests/format.rs
@@ -247,7 +247,7 @@ fn test_format_nested_function_calls() {
             ,
             when output.datum is {
               InlineDatum(_) -> True
-              _ -> error "expected inline datum"
+              _ -> fail "expected inline datum"
             },
           ]
           |> list.and
@@ -271,13 +271,13 @@ fn test_format_trace_todo_error() {
         fn foo_3() {
           when x is {
             Foo -> True
-            _ -> error
+            _ -> fail
           }
         }
 
         fn foo_4() {
           if 14 == 42 {
-            error "I don't think so"
+            fail "I don't think so"
           } else {
             trace "been there"
             True

--- a/crates/aiken-lang/src/tests/format.rs
+++ b/crates/aiken-lang/src/tests/format.rs
@@ -507,12 +507,12 @@ fn test_format_match_record() {
 fn test_format_fail() {
     assert_format!(
         r#"
-      !test foo() {
-        expect Some(a) = bar
+        test foo() fail {
+          expect Some(a) = bar
 
-        a
-      }
-    "#
+          a
+        }
+        "#
     );
 }
 

--- a/crates/aiken-lang/src/tests/snapshots/format_fail.snap
+++ b/crates/aiken-lang/src/tests/snapshots/format_fail.snap
@@ -1,8 +1,8 @@
 ---
 source: crates/aiken-lang/src/tests/format.rs
-description: "Code:\n\n!test foo() {\n  expect Some(a) = bar\n\n  a\n}\n"
+description: "Code:\n\ntest foo() fail {\n  expect Some(a) = bar\n\n  a\n}\n"
 ---
-!test foo() {
+test foo() fail {
   expect Some(a) = bar
 
   a

--- a/crates/aiken-lang/src/tests/snapshots/format_nested_function_calls.snap
+++ b/crates/aiken-lang/src/tests/snapshots/format_nested_function_calls.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/aiken-lang/src/tests/format.rs
-description: "Code:\n\nfn foo(output) {\n  [\n    output.address.stake_credential == Some(\n    Inline(\n    VerificationKeyCredential(\n      #\"66666666666666666666666666666666666666666666666666666666\",\n    ))\n    )\n    ,\n    when output.datum is {\n      InlineDatum(_) -> True\n      _ -> error \"expected inline datum\"\n    },\n  ]\n  |> list.and\n}\n"
+description: "Code:\n\nfn foo(output) {\n  [\n    output.address.stake_credential == Some(\n    Inline(\n    VerificationKeyCredential(\n      #\"66666666666666666666666666666666666666666666666666666666\",\n    ))\n    )\n    ,\n    when output.datum is {\n      InlineDatum(_) -> True\n      _ -> fail \"expected inline datum\"\n    },\n  ]\n  |> list.and\n}\n"
 ---
 fn foo(output) {
   [
@@ -13,7 +13,7 @@ fn foo(output) {
     ),
     when output.datum is {
       InlineDatum(_) -> True
-      _ -> error @"expected inline datum"
+      _ -> fail @"expected inline datum"
     },
   ]
     |> list.and

--- a/crates/aiken-lang/src/tests/snapshots/format_trace_todo_error.snap
+++ b/crates/aiken-lang/src/tests/snapshots/format_trace_todo_error.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/aiken-lang/src/tests/format.rs
-description: "Code:\n\nfn foo_1() {\n  todo\n}\n\nfn foo_2() {\n  todo \"my custom message\"\n}\n\nfn foo_3() {\n  when x is {\n    Foo -> True\n    _ -> error\n  }\n}\n\nfn foo_4() {\n  if 14 == 42 {\n    error \"I don't think so\"\n  } else {\n    trace \"been there\"\n    True\n  }\n}\n"
+description: "Code:\n\nfn foo_1() {\n  todo\n}\n\nfn foo_2() {\n  todo \"my custom message\"\n}\n\nfn foo_3() {\n  when x is {\n    Foo -> True\n    _ -> fail\n  }\n}\n\nfn foo_4() {\n  if 14 == 42 {\n    fail \"I don't think so\"\n  } else {\n    trace \"been there\"\n    True\n  }\n}\n"
 ---
 fn foo_1() {
   todo
@@ -13,13 +13,13 @@ fn foo_2() {
 fn foo_3() {
   when x is {
     Foo -> True
-    _ -> error
+    _ -> fail
   }
 }
 
 fn foo_4() {
   if 14 == 42 {
-    error @"I don't think so"
+    fail @"I don't think so"
   } else {
     trace @"been there"
     True

--- a/crates/aiken-project/src/tests/gen_uplc.rs
+++ b/crates/aiken-project/src/tests/gen_uplc.rs
@@ -2601,7 +2601,7 @@ fn when_bool_is_true() {
           True ->
             True
           False ->
-            error
+            fail
         }
       }    
     "#;
@@ -2622,7 +2622,7 @@ fn when_bool_is_true_switched_cases() {
       test it() {
         when True is {
           False ->
-            error
+            fail
           True ->
             True
         }
@@ -2645,7 +2645,7 @@ fn when_bool_is_false() {
       test it() {
         when False is {
           False ->
-            error
+            fail
           True ->
             True
         }

--- a/examples/acceptance_tests/script_context/validators/basic.ak
+++ b/examples/acceptance_tests/script_context/validators/basic.ak
@@ -28,7 +28,7 @@ fn assert_purpose(purpose) {
       ref.transaction_id == TransactionId(
         #"0000000000000000000000000000000000000000000000000000000000000000",
       ) && ref.output_index == 0
-    _ -> error @"script purpose isn't 'Spend'"
+    _ -> fail @"script purpose isn't 'Spend'"
   }
 }
 
@@ -49,6 +49,6 @@ fn assert_outputs(transaction) {
         output.reference_script == None,
       ]
         |> list.and
-    _ -> error @"unexpected number of outputs"
+    _ -> fail @"unexpected number of outputs"
   }
 }

--- a/examples/acceptance_tests/script_context/validators/deploy.ak
+++ b/examples/acceptance_tests/script_context/validators/deploy.ak
@@ -40,7 +40,7 @@ fn assert_outputs(outputs) {
   when outputs is {
     [output_1, output_2, ..] ->
       assert_first_output(output_1) && assert_second_output(output_2)
-    _ -> error @"expected transaction to have (at least) 2 outputs"
+    _ -> fail @"expected transaction to have (at least) 2 outputs"
   }
 }
 
@@ -67,7 +67,7 @@ fn assert_second_output(output) {
     ),
     when output.datum is {
       InlineDatum(_) -> True
-      _ -> error @"expected inline datum"
+      _ -> fail @"expected inline datum"
     },
   ]
     |> list.and

--- a/examples/acceptance_tests/script_context/validators/mint.ak
+++ b/examples/acceptance_tests/script_context/validators/mint.ak
@@ -29,7 +29,7 @@ fn assert_mint(purpose, transaction) {
   let tokens = value.tokens(transaction.mint, policy_id)
 
   when dict.get(tokens, #"666f6f") is {
-    None -> error @"token not found"
+    None -> fail @"token not found"
     Some(quantity) -> quantity == 1337
   }
 }

--- a/examples/acceptance_tests/script_context/validators/withdrawals.ak
+++ b/examples/acceptance_tests/script_context/validators/withdrawals.ak
@@ -23,11 +23,11 @@ validator {
 
     [
       when dict.get(ctx.transaction.withdrawals, alice) is {
-        None -> error @"alice's withdrawal not found"
+        None -> fail @"alice's withdrawal not found"
         Some(value) -> value == 42
       },
       when dict.get(ctx.transaction.withdrawals, bob) is {
-        None -> error @"bob's withdrawal not found"
+        None -> fail @"bob's withdrawal not found"
         Some(value) -> value == 14
       },
       dict.keys(ctx.transaction.withdrawals) == [alice, bob],


### PR DESCRIPTION
- We decided on discord that we're going to rename error to fail.
- I did things in such a way that the formatter will automatically fix this for people. At some point after a few releases we can remove `"error"` from the lexer.
- I even renamed `Token::ErrorTerm`. But I left `UntypedExpr::ErrorTerm` alone because there are some big changes in the Air tree branch that I don't want to cause conflicts with.
- Test definitions for expected failures have been updated as well `test name() fail {`. This is way more consistent with the new keyword and it ties in with the plans I have for the new `pure` keyword and `pure` function definitions. This kind of syntax is inspired by swift `func myFunc() throws -> String`. cc @KtorZ