### PR TITLE
`aiken docs`: Module prefix when there's only 1 module

### DIFF
--- a/crates/aiken-project/src/docs.rs
+++ b/crates/aiken-project/src/docs.rs
@@ -579,8 +579,9 @@ fn find_modules_prefix(modules: &[DocLink]) -> String {
 }
 
 fn do_find_modules_prefix(current_prefix: &str, modules: &[DocLink]) -> String {
-    if modules.len() == 1 {
-        return current_prefix.to_string();
+    match modules {
+        [_] => return current_prefix.to_string(),
+        _ => { /* continue */ }
     }
 
     let prefix = modules

--- a/crates/aiken-project/src/docs.rs
+++ b/crates/aiken-project/src/docs.rs
@@ -579,6 +579,10 @@ fn find_modules_prefix(modules: &[DocLink]) -> String {
 }
 
 fn do_find_modules_prefix(current_prefix: &str, modules: &[DocLink]) -> String {
+    if modules.len() == 1 {
+        return current_prefix.to_string();
+    }
+
     let prefix = modules
         .iter()
         .fold(None, |previous_prefix, module| {
@@ -592,7 +596,6 @@ fn do_find_modules_prefix(current_prefix: &str, modules: &[DocLink]) -> String {
             let prefix = name.split('/').next().unwrap_or_default().to_string();
 
             match previous_prefix {
-                None if modules.len() == 1 => None, // just 1 module
                 None if prefix != module.name => Some(prefix),
                 Some(..) if Some(prefix) == previous_prefix => previous_prefix,
                 _ => Some(String::new()),

--- a/crates/aiken-project/src/docs.rs
+++ b/crates/aiken-project/src/docs.rs
@@ -592,6 +592,7 @@ fn do_find_modules_prefix(current_prefix: &str, modules: &[DocLink]) -> String {
             let prefix = name.split('/').next().unwrap_or_default().to_string();
 
             match previous_prefix {
+                None if modules.len() == 1 => None, // just 1 module
                 None if prefix != module.name => Some(prefix),
                 Some(..) if Some(prefix) == previous_prefix => previous_prefix,
                 _ => Some(String::new()),
@@ -620,7 +621,8 @@ fn find_modules_prefix_test() {
             name: "aiken/list".to_string(),
             path: String::new()
         }]),
-        "aiken/list".to_string()
+        // "aiken/list".to_string()
+        "".to_string()
     );
 
     assert_eq!(

--- a/crates/aiken-project/src/docs.rs
+++ b/crates/aiken-project/src/docs.rs
@@ -579,9 +579,8 @@ fn find_modules_prefix(modules: &[DocLink]) -> String {
 }
 
 fn do_find_modules_prefix(current_prefix: &str, modules: &[DocLink]) -> String {
-    match modules {
-        [_] => return current_prefix.to_string(),
-        _ => { /* continue */ }
+    if let [_] = modules {
+        return current_prefix.to_string();
     }
 
     let prefix = modules


### PR DESCRIPTION
When there's only 1 module in the project (eg: https://github.com/ariady-putra/tx_util), `aiken docs` lists `/` as the module name instead of using the full module name. So I added a match-arm during pattern matching to handle 1 module.

|Before|After|
|---|---|
|![2023-07-17 10 42 23  770a9d099b8e](https://github.com/aiken-lang/aiken/assets/2069784/8bb62238-46fb-4149-94e1-3b659d7f7355)|![2023-07-17 10 43 48  c75381ce2ab6](https://github.com/aiken-lang/aiken/assets/2069784/892ab6cd-2406-430f-b56e-ed7daf61d081)|
|![2023-07-17 10 43 00  64bb48e894f1](https://github.com/aiken-lang/aiken/assets/2069784/a1620abc-3a87-4548-bc63-b996cc3986d7)|![2023-07-17 10 44 05  a58a36311a51](https://github.com/aiken-lang/aiken/assets/2069784/9cdc80ae-09b5-4f2b-945a-39c0c5afb7f1)|

Run #[test] in `docs` module: OK, tested with `cargo run docs -o ~/docs ~/aiken/tx_util` from the `crates/aiken` (where `~/aiken/tx_util` contains 1 module; result is `After` column above)

Retested with normal project containing multiple modules `cargo run docs -o ~/docs ~/aiken/morbid`:
![2023-07-17 10 45 09  96397bcf17dd](https://github.com/aiken-lang/aiken/assets/2069784/bc519ae6-9839-4f7d-9cd0-9eb07e899eba)
