### PR TITLE
Add an aiken blueprint hash command

### DIFF
--- a/crates/aiken/src/cmd/blueprint/hash.rs
+++ b/crates/aiken/src/cmd/blueprint/hash.rs
@@ -2,7 +2,7 @@ use crate::with_project;
 use aiken_lang::ast::Tracing;
 use std::path::PathBuf;
 
-/// Compute a minting scripts Policy ID
+/// Compute a validator's hash
 #[derive(clap::Args)]
 pub struct Args {
     /// Path to project
@@ -46,9 +46,9 @@ pub fn exec(
 
         let title = title.as_ref().or(validator.as_ref());
 
-        let policy = p.policy(title)?;
+        let address = p.address(title, None)?;
 
-        println!("{}", policy);
+        println!("{}", address.payment().to_hex());
 
         Ok(())
     })

--- a/crates/aiken/src/cmd/blueprint/mod.rs
+++ b/crates/aiken/src/cmd/blueprint/mod.rs
@@ -1,6 +1,7 @@
 pub mod address;
 pub mod apply;
 pub mod convert;
+pub mod hash;
 pub mod policy;
 
 use clap::Subcommand;
@@ -10,6 +11,7 @@ use clap::Subcommand;
 pub enum Cmd {
     Address(address::Args),
     Policy(policy::Args),
+    Hash(hash::Args),
     Apply(apply::Args),
     Convert(convert::Args),
 }
@@ -18,6 +20,7 @@ pub fn exec(cmd: Cmd) -> miette::Result<()> {
     match cmd {
         Cmd::Address(args) => address::exec(args),
         Cmd::Policy(args) => policy::exec(args),
+        Cmd::Hash(args) => hash::exec(args),
         Cmd::Apply(args) => apply::exec(args),
         Cmd::Convert(args) => convert::exec(args),
     }


### PR DESCRIPTION
Similar to blueprint address and blueprint policy, this just prints the hash of the validator; useful if you need the hash, and you don't want to pipe the address to a bech32 decoder and juggle the hex.

Apologies for not opening a discussion first, but I figure it was similar enough to what we did elsewhere.

Also, technically this does a bit of redundant work by computing the address, then pulling out the hash, but this way I could reuse some code, and so I figured it was fine.