### PR TITLE
Nix Updates

### DIFF
--- a/crates/aiken/src/lib.rs
+++ b/crates/aiken/src/lib.rs
@@ -23,7 +23,7 @@ where
         env::current_dir().into_diagnostic()?
     };
 
-    let mut project = match Project::new(project_path, Terminal::default()) {
+    let mut project = match Project::new(project_path, Terminal) {
         Ok(p) => p,
         Err(e) => {
             e.report();

--- a/flake.nix
+++ b/flake.nix
@@ -24,7 +24,7 @@
           version = "1.0.13-alpha";
 
           buildInputs = with pkgs; [ openssl ] ++ osxDependencies;
-          nativeBuildInputs = with pkgs; [ pkg-config openssl ];
+          nativeBuildInputs = with pkgs; [ pkg-config openssl.dev ];
 
           src = pkgs.lib.cleanSourceWith { src = self; };
 

--- a/flake.nix
+++ b/flake.nix
@@ -29,6 +29,13 @@
           src = pkgs.lib.cleanSourceWith { src = self; };
 
           cargoLock.lockFile = ./Cargo.lock;
+
+          meta = with pkgs.lib; {
+            description = "Cardano smart contract language and toolchain";
+            homepage = "https://github.com/aiken-lang/aiken";
+            license = licenses.asl20;
+            mainProgram = "aiken";
+          };
         };
 
         commonCategory = y: builtins.map (x: x // { category = y; });

--- a/flake.nix
+++ b/flake.nix
@@ -21,7 +21,7 @@
 
         aiken = pkgs.rustPlatform.buildRustPackage {
           name = "aiken";
-          version = "1.0.11-alpha";
+          version = "1.0.13-alpha";
 
           buildInputs = with pkgs; [ openssl ] ++ osxDependencies;
           nativeBuildInputs = with pkgs; [ pkg-config openssl ];

--- a/flake.nix
+++ b/flake.nix
@@ -25,6 +25,7 @@
 
           buildInputs = with pkgs; [ openssl ] ++ osxDependencies;
           nativeBuildInputs = with pkgs; [ pkg-config openssl.dev ];
+          cargoBuildFlags = [ "--package aiken" ];
 
           src = pkgs.lib.cleanSourceWith { src = self; };
 

--- a/flake.nix
+++ b/flake.nix
@@ -19,9 +19,13 @@
 
         deno = nixpkgs.legacyPackages.${system}.deno;
 
+        cargoTomlContents = builtins.readFile ./crates/aiken/Cargo.toml;
+        version = (builtins.fromTOML cargoTomlContents).package.version;
+
         aiken = pkgs.rustPlatform.buildRustPackage {
+          inherit version;
+
           name = "aiken";
-          version = "1.0.13-alpha";
 
           buildInputs = with pkgs; [ openssl ] ++ osxDependencies;
           nativeBuildInputs = with pkgs; [ pkg-config openssl.dev ];


### PR DESCRIPTION
* Update version on nix recipe
* Add some metadata
* (hopefully) Fix problem where if you add aiken as a NixOS package, it does not show on path
* Make build process just a little bit leaner
* Infer crate version from `aiken`'s Cargo.toml