### PR TITLE
fix: LSP bugs on vscode+windows

### DIFF
--- a/crates/aiken-lsp/src/server.rs
+++ b/crates/aiken-lsp/src/server.rs
@@ -634,9 +634,6 @@ impl Server {
                     data: None,
                 };
 
-                #[cfg(target_os = "windows")]
-                let path = path;
-
                 #[cfg(not(target_os = "windows"))]
                 let path = path.canonicalize()?;
 

--- a/crates/aiken-lsp/src/server.rs
+++ b/crates/aiken-lsp/src/server.rs
@@ -163,7 +163,21 @@ impl Server {
                 aiken_lang::format::pretty(&mut new_text, module, extra, src);
             }
             None => {
-                let src = fs::read_to_string(path).map_err(ProjectError::from)?;
+
+              
+                let src = {
+                    #[cfg(not(target_os = "windows"))] {
+                        fs::read_to_string(path).map_err(ProjectError::from)?
+                    }
+                    #[cfg(target_os = "windows")] {
+                        let temp = match urlencoding::decode(path) {
+                            Ok(decoded) => decoded.to_string(),
+                            Err(_) => path.to_owned()
+                        };
+                        fs::read_to_string(temp.trim_start_matches("/")).map_err(ProjectError::from)?
+                    }
+                };
+                       
 
                 let (module, extra) = parser::module(&src, ModuleKind::Lib).map_err(|errs| {
                     aiken_project::error::Error::from_parse_errors(errs, Path::new(path), &src)
@@ -620,6 +634,10 @@ impl Server {
                     data: None,
                 };
 
+                #[cfg(target_os = "windows")]
+                let path = path;
+
+                #[cfg(not(target_os = "windows"))]
                 let path = path.canonicalize()?;
 
                 self.push_diagnostic(path.clone(), lsp_diagnostic.clone());

--- a/crates/aiken-lsp/src/server.rs
+++ b/crates/aiken-lsp/src/server.rs
@@ -163,21 +163,21 @@ impl Server {
                 aiken_lang::format::pretty(&mut new_text, module, extra, src);
             }
             None => {
-
-              
                 let src = {
-                    #[cfg(not(target_os = "windows"))] {
+                    #[cfg(not(target_os = "windows"))]
+                    {
                         fs::read_to_string(path).map_err(ProjectError::from)?
                     }
-                    #[cfg(target_os = "windows")] {
+                    #[cfg(target_os = "windows")]
+                    {
                         let temp = match urlencoding::decode(path) {
                             Ok(decoded) => decoded.to_string(),
-                            Err(_) => path.to_owned()
+                            Err(_) => path.to_owned(),
                         };
-                        fs::read_to_string(temp.trim_start_matches("/")).map_err(ProjectError::from)?
+                        fs::read_to_string(temp.trim_start_matches("/"))
+                            .map_err(ProjectError::from)?
                     }
                 };
-                       
 
                 let (module, extra) = parser::module(&src, ModuleKind::Lib).map_err(|errs| {
                     aiken_project::error::Error::from_parse_errors(errs, Path::new(path), &src)


### PR DESCRIPTION
This PR aims to fix two issues with vscode on windows:

1. Diagnostics do not show up as expected: canonicalizing the path makes it not match the original, so vscode doesnt know which file it is connected to and only shows issues in the "problems" pane.

2. Formatting fails because the path is url encoded and begins with a slash (resulting in file not found)