### PR TITLE
`and`/`or` chains

### DIFF
--- a/crates/aiken-lang/src/ast.rs
+++ b/crates/aiken-lang/src/ast.rs
@@ -103,7 +103,6 @@ impl TypedModule {
 fn str_to_keyword(word: &str) -> Option<Token> {
     // Alphabetical keywords:
     match word {
-        "assert" => Some(Token::Expect),
         "expect" => Some(Token::Expect),
         "else" => Some(Token::Else),
         "is" => Some(Token::Is),

--- a/crates/aiken-lang/src/ast.rs
+++ b/crates/aiken-lang/src/ast.rs
@@ -116,7 +116,11 @@ fn str_to_keyword(word: &str) -> Option<Token> {
         "type" => Some(Token::Type),
         "trace" => Some(Token::Trace),
         "test" => Some(Token::Test),
+        // TODO: remove this in a future release
         "error" => Some(Token::Fail),
+        "fail" => Some(Token::Fail),
+        "and" => Some(Token::And),
+        "or" => Some(Token::Or),
         "validator" => Some(Token::Validator),
         _ => None,
     }
@@ -779,6 +783,15 @@ pub enum BinOp {
     ModInt,
 }
 
+impl From<LogicalOpChainKind> for BinOp {
+    fn from(value: LogicalOpChainKind) -> Self {
+        match value {
+            LogicalOpChainKind::And => BinOp::And,
+            LogicalOpChainKind::Or => BinOp::Or,
+        }
+    }
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum UnOp {
     // !
@@ -1222,6 +1235,21 @@ impl chumsky::Span for Span {
 
     fn end(&self) -> Self::Offset {
         self.end
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum LogicalOpChainKind {
+    And,
+    Or,
+}
+
+impl Display for LogicalOpChainKind {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            LogicalOpChainKind::And => write!(f, "and"),
+            LogicalOpChainKind::Or => write!(f, "or"),
+        }
     }
 }
 

--- a/crates/aiken-lang/src/ast.rs
+++ b/crates/aiken-lang/src/ast.rs
@@ -6,7 +6,11 @@ use crate::{
 };
 use miette::Diagnostic;
 use owo_colors::{OwoColorize, Stream::Stdout};
-use std::{fmt, ops::Range, sync::Arc};
+use std::{
+    fmt::{self, Display},
+    ops::Range,
+    sync::Arc,
+};
 use vec1::Vec1;
 
 pub const ASSERT_VARIABLE: &str = "_try";

--- a/crates/aiken-lang/src/expr.rs
+++ b/crates/aiken-lang/src/expr.rs
@@ -533,6 +533,12 @@ pub enum UntypedExpr {
         location: Span,
         value: Box<Self>,
     },
+
+    LogicalOpChain {
+        kind: LogicalOpChainKind,
+        expressions: Vec<Self>,
+        location: Span,
+    },
 }
 
 pub const DEFAULT_TODO_STR: &str = "aiken::todo";
@@ -716,6 +722,7 @@ impl UntypedExpr {
             | Self::FieldAccess { location, .. }
             | Self::RecordUpdate { location, .. }
             | Self::UnOp { location, .. }
+            | Self::LogicalOpChain { location, .. }
             | Self::If { location, .. } => *location,
             Self::Sequence {
                 location,

--- a/crates/aiken-lang/src/expr.rs
+++ b/crates/aiken-lang/src/expr.rs
@@ -5,8 +5,9 @@ use vec1::Vec1;
 use crate::{
     ast::{
         self, Annotation, Arg, AssignmentKind, BinOp, ByteArrayFormatPreference, CallArg,
-        DefinitionLocation, IfBranch, ParsedCallArg, Pattern, RecordUpdateSpread, Span, TraceKind,
-        TypedClause, TypedRecordUpdateArg, UnOp, UntypedClause, UntypedRecordUpdateArg,
+        DefinitionLocation, IfBranch, LogicalOpChainKind, ParsedCallArg, Pattern,
+        RecordUpdateSpread, Span, TraceKind, TypedClause, TypedRecordUpdateArg, UnOp,
+        UntypedClause, UntypedRecordUpdateArg,
     },
     builtins::void,
     parser::token::Base,

--- a/crates/aiken-lang/src/parser/expr/and_or_chain.rs
+++ b/crates/aiken-lang/src/parser/expr/and_or_chain.rs
@@ -1,0 +1,72 @@
+use chumsky::prelude::*;
+
+use crate::{
+    ast::LogicalOpChainKind,
+    expr::UntypedExpr,
+    parser::{error::ParseError, token::Token},
+};
+
+pub fn parser(
+    expression: Recursive<'_, Token, UntypedExpr, ParseError>,
+) -> impl Parser<Token, UntypedExpr, Error = ParseError> + '_ {
+    choice((
+        just(Token::And).to(LogicalOpChainKind::And),
+        just(Token::Or).to(LogicalOpChainKind::Or),
+    ))
+    .then(
+        expression
+            .separated_by(just(Token::Comma))
+            .allow_trailing()
+            .delimited_by(just(Token::LeftBrace), just(Token::RightBrace)),
+    )
+    .map_with_span(|(kind, exprs), span| UntypedExpr::LogicalOpChain {
+        kind,
+        expressions: exprs,
+        location: span,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::assert_expr;
+
+    #[test]
+    fn and_chain() {
+        assert_expr!(
+            r#"
+            and {
+              1 == 2,
+              something,
+            }
+            "#
+        );
+    }
+
+    #[test]
+    fn or_chain() {
+        assert_expr!(
+            r#"
+            or {
+              1 == 2,
+              something,
+            }
+            "#
+        );
+    }
+
+    #[test]
+    fn and_or_chain() {
+        assert_expr!(
+            r#"
+            or {
+              1 == 2,
+              something,
+              and {
+                1 == 2,
+                something,
+              },
+            }
+            "#
+        );
+    }
+}

--- a/crates/aiken-lang/src/parser/expr/chained.rs
+++ b/crates/aiken-lang/src/parser/expr/chained.rs
@@ -1,6 +1,5 @@
 use chumsky::prelude::*;
 
-use super::anonymous_binop::parser as anonymous_binop;
 use super::anonymous_function::parser as anonymous_function;
 use super::assignment;
 use super::block::parser as block;
@@ -14,6 +13,7 @@ use super::string::parser as string;
 use super::tuple::parser as tuple;
 use super::var::parser as var;
 use super::when::parser as when;
+use super::{and_or_chain, anonymous_binop::parser as anonymous_binop};
 
 use crate::{
     expr::UntypedExpr,
@@ -33,6 +33,7 @@ pub fn parser<'a>(
         field_access::parser(),
         call(expression.clone()),
     ));
+
     chain_start(sequence, expression)
         .then(chain.repeated())
         .foldl(|expr, chain| match chain {
@@ -60,6 +61,7 @@ pub fn chain_start<'a>(
         record_update(expression.clone()),
         record(expression.clone()),
         field_access::constructor(),
+        and_or_chain(expression.clone()),
         var(),
         tuple(expression.clone()),
         bytearray(),

--- a/crates/aiken-lang/src/parser/expr/mod.rs
+++ b/crates/aiken-lang/src/parser/expr/mod.rs
@@ -1,6 +1,7 @@
 use chumsky::prelude::*;
 use vec1::Vec1;
 
+mod and_or_chain;
 mod anonymous_binop;
 pub mod anonymous_function;
 pub mod assignment;
@@ -19,6 +20,7 @@ mod tuple;
 mod var;
 pub mod when;
 
+pub use and_or_chain::parser as and_or_chain;
 pub use anonymous_function::parser as anonymous_function;
 pub use block::parser as block;
 pub use bytearray::parser as bytearray;

--- a/crates/aiken-lang/src/parser/expr/snapshots/and_chain.snap
+++ b/crates/aiken-lang/src/parser/expr/snapshots/and_chain.snap
@@ -1,0 +1,32 @@
+---
+source: crates/aiken-lang/src/parser/expr/and_or_chain.rs
+description: "Code:\n\nand {\n  1 == 2,\n  something,\n}\n"
+---
+LogicalOpChain {
+    kind: And,
+    expressions: [
+        BinOp {
+            location: 8..14,
+            name: Eq,
+            left: UInt {
+                location: 8..9,
+                value: "1",
+                base: Decimal {
+                    numeric_underscore: false,
+                },
+            },
+            right: UInt {
+                location: 13..14,
+                value: "2",
+                base: Decimal {
+                    numeric_underscore: false,
+                },
+            },
+        },
+        Var {
+            location: 18..27,
+            name: "something",
+        },
+    ],
+    location: 0..30,
+}

--- a/crates/aiken-lang/src/parser/expr/snapshots/and_or_chain.snap
+++ b/crates/aiken-lang/src/parser/expr/snapshots/and_or_chain.snap
@@ -1,0 +1,60 @@
+---
+source: crates/aiken-lang/src/parser/expr/and_or_chain.rs
+description: "Code:\n\nor {\n  1 == 2,\n  something,\n  and {\n    1 == 2,\n    something,\n  },\n}\n"
+---
+LogicalOpChain {
+    kind: Or,
+    expressions: [
+        BinOp {
+            location: 7..13,
+            name: Eq,
+            left: UInt {
+                location: 7..8,
+                value: "1",
+                base: Decimal {
+                    numeric_underscore: false,
+                },
+            },
+            right: UInt {
+                location: 12..13,
+                value: "2",
+                base: Decimal {
+                    numeric_underscore: false,
+                },
+            },
+        },
+        Var {
+            location: 17..26,
+            name: "something",
+        },
+        LogicalOpChain {
+            kind: And,
+            expressions: [
+                BinOp {
+                    location: 40..46,
+                    name: Eq,
+                    left: UInt {
+                        location: 40..41,
+                        value: "1",
+                        base: Decimal {
+                            numeric_underscore: false,
+                        },
+                    },
+                    right: UInt {
+                        location: 45..46,
+                        value: "2",
+                        base: Decimal {
+                            numeric_underscore: false,
+                        },
+                    },
+                },
+                Var {
+                    location: 52..61,
+                    name: "something",
+                },
+            ],
+            location: 30..66,
+        },
+    ],
+    location: 0..69,
+}

--- a/crates/aiken-lang/src/parser/expr/snapshots/or_chain.snap
+++ b/crates/aiken-lang/src/parser/expr/snapshots/or_chain.snap
@@ -1,0 +1,32 @@
+---
+source: crates/aiken-lang/src/parser/expr/and_or_chain.rs
+description: "Code:\n\nor {\n  1 == 2,\n  something,\n}\n"
+---
+LogicalOpChain {
+    kind: Or,
+    expressions: [
+        BinOp {
+            location: 7..13,
+            name: Eq,
+            left: UInt {
+                location: 7..8,
+                value: "1",
+                base: Decimal {
+                    numeric_underscore: false,
+                },
+            },
+            right: UInt {
+                location: 12..13,
+                value: "2",
+                base: Decimal {
+                    numeric_underscore: false,
+                },
+            },
+        },
+        Var {
+            location: 17..26,
+            name: "something",
+        },
+    ],
+    location: 0..29,
+}

--- a/crates/aiken-lang/src/parser/lexer.rs
+++ b/crates/aiken-lang/src/parser/lexer.rs
@@ -222,11 +222,12 @@ pub fn lexer() -> impl Parser<char, Vec<(Token, Span)>, Error = ParseError> {
 
     let keyword = text::ident().map(|s: String| match s.as_str() {
         "trace" => Token::Trace,
-        "fail" => Token::Fail,
-        // TODO: delete this eventually
+        // TODO: remove this in a future release
         "error" => Token::Fail,
+        "fail" => Token::Fail,
         "as" => Token::As,
-        "assert" => Token::Expect,
+        "and" => Token::And,
+        "or" => Token::Or,
         "expect" => Token::Expect,
         "const" => Token::Const,
         "fn" => Token::Fn,

--- a/crates/aiken-lang/src/parser/token.rs
+++ b/crates/aiken-lang/src/parser/token.rs
@@ -56,6 +56,8 @@ pub enum Token {
     Vbar,        // '|'
     VbarVbar,    // '||'
     AmperAmper,  // '&&'
+    And,         // and
+    Or,          // or
     NewLinePipe, // '↳|>'
     Pipe,        // '|>'
     Dot,         // '.'
@@ -143,6 +145,8 @@ impl fmt::Display for Token {
             Token::Vbar => "|",
             Token::VbarVbar => "||",
             Token::AmperAmper => "&&",
+            Token::And => "and",
+            Token::Or => "or",
             Token::NewLinePipe => "↳|>",
             Token::Pipe => "|>",
             Token::Dot => ".",

--- a/crates/aiken-lang/src/tests/check.rs
+++ b/crates/aiken-lang/src/tests/check.rs
@@ -945,12 +945,12 @@ fn trace_non_strings() {
 #[test]
 fn trace_if_false_ok() {
     let source_code = r#"
-        fn or(a: Bool, b: Bool) {
+        fn or_func(a: Bool, b: Bool) {
            (a || b)?
         }
 
         test foo() {
-            or(True, False)?
+            or_func(True, False)?
         }
 
         test bar() {

--- a/crates/aiken-lang/src/tests/check.rs
+++ b/crates/aiken-lang/src/tests/check.rs
@@ -662,6 +662,27 @@ fn expect_sugar_incorrect_type() {
 }
 
 #[test]
+fn logical_op_chain_expressions_should_be_bool() {
+    let source_code = r#"
+        fn foo() {
+          and {
+            1 == 1,
+            False,
+            or {
+              2 == 3,
+              1
+            }
+          }
+        }
+    "#;
+
+    assert!(matches!(
+        check(parse(source_code)),
+        Err((_, Error::CouldNotUnify { .. }))
+    ))
+}
+
+#[test]
 fn anonymous_function_scoping() {
     let source_code = r#"
         fn reduce(list, f, i) {

--- a/crates/aiken-lang/src/tests/format.rs
+++ b/crates/aiken-lang/src/tests/format.rs
@@ -250,7 +250,7 @@ fn format_nested_function_calls() {
               _ -> fail "expected inline datum"
             },
           ]
-          |> list.and
+          |> list.and_func
         }
     "#
     );

--- a/crates/aiken-lang/src/tests/format.rs
+++ b/crates/aiken-lang/src/tests/format.rs
@@ -21,6 +21,15 @@ fn format_simple_module() {
 }
 
 #[test]
+fn format_logical_op_chain() {
+    assert_format!(
+        r#"
+      fn smth() { and { foo, bar, or { bar, foo }} }
+    "#
+    );
+}
+
+#[test]
 fn format_if() {
     assert_format!(
         r#"

--- a/crates/aiken-lang/src/tests/snapshots/format_logical_op_chain.snap
+++ b/crates/aiken-lang/src/tests/snapshots/format_logical_op_chain.snap
@@ -1,0 +1,15 @@
+---
+source: crates/aiken-lang/src/tests/format.rs
+description: "Code:\n\nfn smth() { and { foo, bar, or { bar, foo }} }\n"
+---
+fn smth() {
+  and {
+    foo,
+    bar,
+    or {
+      bar,
+      foo,
+    },
+  }
+}
+

--- a/crates/aiken-lang/src/tests/snapshots/format_nested_function_calls.snap
+++ b/crates/aiken-lang/src/tests/snapshots/format_nested_function_calls.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/aiken-lang/src/tests/format.rs
-description: "Code:\n\nfn foo(output) {\n  [\n    output.address.stake_credential == Some(\n    Inline(\n    VerificationKeyCredential(\n      #\"66666666666666666666666666666666666666666666666666666666\",\n    ))\n    )\n    ,\n    when output.datum is {\n      InlineDatum(_) -> True\n      _ -> fail \"expected inline datum\"\n    },\n  ]\n  |> list.and\n}\n"
+description: "Code:\n\nfn foo(output) {\n  [\n    output.address.stake_credential == Some(\n    Inline(\n    VerificationKeyCredential(\n      #\"66666666666666666666666666666666666666666666666666666666\",\n    ))\n    )\n    ,\n    when output.datum is {\n      InlineDatum(_) -> True\n      _ -> fail \"expected inline datum\"\n    },\n  ]\n  |> list.and_func\n}\n"
 ---
 fn foo(output) {
   [
@@ -16,6 +16,6 @@ fn foo(output) {
       _ -> fail @"expected inline datum"
     },
   ]
-    |> list.and
+    |> list.and_func
 }
 

--- a/crates/aiken-lang/src/tipo/error.rs
+++ b/crates/aiken-lang/src/tipo/error.rs
@@ -1,6 +1,6 @@
 use super::Type;
 use crate::{
-    ast::{Annotation, BinOp, CallArg, Span, UntypedPattern},
+    ast::{Annotation, BinOp, CallArg, LogicalOpChainKind, Span, UntypedPattern},
     expr::{self, UntypedExpr},
     format::Formatter,
     levenshtein,
@@ -55,7 +55,22 @@ impl Diagnostic for UnknownLabels {
 
 #[derive(Debug, thiserror::Error, Diagnostic, Clone)]
 pub enum Error {
-    #[error("I discovered a type cast from Data without an annotation")]
+    #[error("I discovered an {} chain with less than 2 expressions.", op.if_supports_color(Stdout, |s| s.purple()))]
+    #[diagnostic(code("illegal::logical_op_chain"))]
+    #[diagnostic(help(
+        "Logical {}/{} chains require at least 2 expressions. You are missing {}.",
+        "and".if_supports_color(Stdout, |s| s.purple()),
+        "or".if_supports_color(Stdout, |s| s.purple()),
+        missing
+    ))]
+    LogicalOpChainMissingExpr {
+        op: LogicalOpChainKind,
+        #[label]
+        location: Span,
+        missing: u8,
+    },
+
+    #[error("I discovered a type cast from Data without an annotation.")]
     #[diagnostic(code("illegal::type_cast"))]
     #[diagnostic(help("Try adding an annotation...\n\n{}", format_suggestion(value)))]
     CastDataNoAnn {


### PR DESCRIPTION
A new syntax for writing long chains of `&&` and `||` binary operations. Even with some formatting `&&` and `||` chains can look a little ugly and be hard to clearly reason about. The new syntax also really helps with being able to visually disambiguate potentially confusing precedence in long BinOp chains.

### and

```
and {
  1 == 1,
  True,
  foo_bar,
}
```

### or

```
or {
  1 == 1,
  and {
    True,
    2 == 3,
  },
  foo_bar
}
```