### PR TITLE
Enhance tx simulate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Changed
 
+- **aiken-lang**: Tx Simulate now returns a list of execution budgets for each
+redeemer instead of calculating the total units required to run all the scripts.
 - **aiken-lang**: Now code gen uses a tree abstraction to build the Aiken
   Intermediary Representation. This now fixes quite a number of minor issues
   while making the code more maintainable. This is a large leap towards a stable

--- a/crates/aiken/src/cmd/tx/simulate.rs
+++ b/crates/aiken/src/cmd/tx/simulate.rs
@@ -120,7 +120,7 @@ pub fn exec(
                 redeemer.index
             )
         };
-
+        
         let result = tx::eval_phase_two(
             tx_babbage,
             &resolved_inputs,
@@ -133,13 +133,15 @@ pub fn exec(
 
         match result {
             Ok(redeemers) => {
-                let total_budget_used =
+                // this should allow N scripts to be
+                let total_budget_used: Vec<ExBudget> =
                     redeemers
                         .iter()
-                        .fold(ExBudget { mem: 0, cpu: 0 }, |accum, curr| ExBudget {
-                            mem: accum.mem + curr.ex_units.mem as i64,
-                            cpu: accum.cpu + curr.ex_units.steps as i64,
-                        });
+                        .map(|curr| ExBudget {
+                            mem: curr.ex_units.mem as i64,
+                            cpu: curr.ex_units.steps as i64,
+                        })
+                        .collect();
 
                 eprintln!("\n");
                 println!(

--- a/crates/uplc/src/tx/eval.rs
+++ b/crates/uplc/src/tx/eval.rs
@@ -377,7 +377,8 @@ fn get_tx_info_v2(
         .map(|output| TxOut::V2(sort_tx_out_value(&output.into())))
         .collect();
 
-    let fee = Value::Coin(body.fee);
+    // let fee = Value::Coin(body.fee);
+    let fee = Value::Coin(0);
 
     let mint = sort_mint(&body.mint.clone().unwrap_or(KeyValuePairs::Indef(vec![])));
 

--- a/crates/uplc/src/tx/eval.rs
+++ b/crates/uplc/src/tx/eval.rs
@@ -377,8 +377,7 @@ fn get_tx_info_v2(
         .map(|output| TxOut::V2(sort_tx_out_value(&output.into())))
         .collect();
 
-    // let fee = Value::Coin(body.fee);
-    let fee = Value::Coin(0);
+    let fee = Value::Coin(body.fee);
 
     let mint = sort_mint(&body.mint.clone().unwrap_or(KeyValuePairs::Indef(vec![])));
 

--- a/crates/uplc/src/tx/tests.rs
+++ b/crates/uplc/src/tx/tests.rs
@@ -10,7 +10,7 @@ use crate::machine::cost_model::ExBudget;
 use super::{eval_phase_two, ResolvedInput, SlotConfig};
 
 #[test]
-fn test_eval() {
+fn test_eval_0() {
     /*
 
     PlutusV2
@@ -251,24 +251,26 @@ fn test_eval() {
             .unwrap();
 
             assert_eq!(redeemers.len(), 1);
-
-            let total_budget_used =
-                redeemers
-                    .iter()
-                    .fold(ExBudget { mem: 0, cpu: 0 }, |accum, curr| ExBudget {
-                        mem: accum.mem + curr.ex_units.mem as i64,
-                        cpu: accum.cpu + curr.ex_units.steps as i64,
-                    });
+            
+            let total_budget_used: Vec<ExBudget> =
+                    redeemers
+                        .iter()
+                        .map(|curr| ExBudget {
+                            mem: curr.ex_units.mem as i64,
+                            cpu: curr.ex_units.steps as i64,
+                        })
+                        .collect();
 
             println!("{total_budget_used:?}");
+            
+            // N scripts return an N length vector of ExBudgets
+            let expected_budgets: Vec<ExBudget> = vec![
+                ExBudget { mem: 747528, cpu: 217294271 },
+            ];
 
             assert_eq!(
                 total_budget_used,
-                // Numbers came uplc evaluate
-                ExBudget {
-                    cpu: 217294271,
-                    mem: 747528
-                }
+                expected_budgets
             );
         }
         _ => unreachable!(),
@@ -523,23 +525,26 @@ fn test_eval_1() {
 
             assert_eq!(redeemers.len(), 1);
 
-            let total_budget_used =
-                redeemers
-                    .iter()
-                    .fold(ExBudget { mem: 0, cpu: 0 }, |accum, curr| ExBudget {
-                        mem: accum.mem + curr.ex_units.mem as i64,
-                        cpu: accum.cpu + curr.ex_units.steps as i64,
-                    });
+            let total_budget_used: Vec<ExBudget> =
+                    redeemers
+                        .iter()
+                        .map(|curr| ExBudget {
+                            mem: curr.ex_units.mem as i64,
+                            cpu: curr.ex_units.steps as i64,
+                        })
+                        .collect();
 
             println!("{total_budget_used:?}");
+            
+            // N scripts return an N length vector of ExBudgets
+            let expected_budgets: Vec<ExBudget> = vec![
+                ExBudget { mem: 738928, cpu: 215316271 },
+            ];
 
             assert_eq!(
                 total_budget_used,
                 // Numbers came uplc evaluate
-                ExBudget {
-                    cpu: 215316271,
-                    mem: 738928
-                }
+                expected_budgets
             );
         }
         _ => unreachable!(),
@@ -629,23 +634,26 @@ fn test_eval_2() {
 
             assert_eq!(redeemers.len(), 1);
 
-            let total_budget_used =
-                redeemers
-                    .iter()
-                    .fold(ExBudget { mem: 0, cpu: 0 }, |accum, curr| ExBudget {
-                        mem: accum.mem + curr.ex_units.mem as i64,
-                        cpu: accum.cpu + curr.ex_units.steps as i64,
-                    });
+            let total_budget_used: Vec<ExBudget> =
+                    redeemers
+                        .iter()
+                        .map(|curr| ExBudget {
+                            mem: curr.ex_units.mem as i64,
+                            cpu: curr.ex_units.steps as i64,
+                        })
+                        .collect();
 
             println!("{total_budget_used:?}");
+            
+            // N scripts return an N length vector of ExBudgets
+            let expected_budgets: Vec<ExBudget> = vec![
+                ExBudget { mem: 655782, cpu: 188449458 },
+            ];
 
             assert_eq!(
                 total_budget_used,
                 // Numbers came uplc evaluate
-                ExBudget {
-                    cpu: 188449458,
-                    mem: 655782
-                }
+                expected_budgets
             );
         }
         _ => unreachable!(),
@@ -894,23 +902,26 @@ fn test_eval_3() {
 
             assert_eq!(redeemers.len(), 1);
 
-            let total_budget_used =
-                redeemers
-                    .iter()
-                    .fold(ExBudget { mem: 0, cpu: 0 }, |accum, curr| ExBudget {
-                        mem: accum.mem + curr.ex_units.mem as i64,
-                        cpu: accum.cpu + curr.ex_units.steps as i64,
-                    });
+            let total_budget_used: Vec<ExBudget> =
+                    redeemers
+                        .iter()
+                        .map(|curr| ExBudget {
+                            mem: curr.ex_units.mem as i64,
+                            cpu: curr.ex_units.steps as i64,
+                        })
+                        .collect();
 
             println!("{total_budget_used:?}");
+            
+            // N scripts return an N length vector of ExBudgets
+            let expected_budgets: Vec<ExBudget> = vec![
+                ExBudget { mem: 583272, cpu: 182855351 },
+            ];
 
             assert_eq!(
                 total_budget_used,
                 // Numbers came uplc evaluate
-                ExBudget {
-                    cpu: 182855351,
-                    mem: 583272
-                }
+                expected_budgets
             );
         }
         _ => unreachable!(),
@@ -1080,23 +1091,26 @@ fn test_eval_5() {
 
             assert_eq!(redeemers.len(), 1);
 
-            let total_budget_used =
-                redeemers
-                    .iter()
-                    .fold(ExBudget { mem: 0, cpu: 0 }, |accum, curr| ExBudget {
-                        mem: accum.mem + curr.ex_units.mem as i64,
-                        cpu: accum.cpu + curr.ex_units.steps as i64,
-                    });
+            let total_budget_used: Vec<ExBudget> =
+                    redeemers
+                        .iter()
+                        .map(|curr| ExBudget {
+                            mem: curr.ex_units.mem as i64,
+                            cpu: curr.ex_units.steps as i64,
+                        })
+                        .collect();
 
             println!("{total_budget_used:?}");
+            
+            // N scripts return an N length vector of ExBudgets
+            let expected_budgets: Vec<ExBudget> = vec![
+                ExBudget { mem: 114126, cpu: 40098159 },
+            ];
 
             assert_eq!(
                 total_budget_used,
                 // Numbers came uplc evaluate
-                ExBudget {
-                    cpu: 40098159,
-                    mem: 114126
-                }
+                expected_budgets
             );
         }
         _ => unreachable!(),
@@ -1185,23 +1199,26 @@ fn test_eval_6() {
 
             assert_eq!(redeemers.len(), 1);
 
-            let total_budget_used =
-                redeemers
-                    .iter()
-                    .fold(ExBudget { mem: 0, cpu: 0 }, |accum, curr| ExBudget {
-                        mem: accum.mem + curr.ex_units.mem as i64,
-                        cpu: accum.cpu + curr.ex_units.steps as i64,
-                    });
+            let total_budget_used: Vec<ExBudget> =
+                    redeemers
+                        .iter()
+                        .map(|curr| ExBudget {
+                            mem: curr.ex_units.mem as i64,
+                            cpu: curr.ex_units.steps as i64,
+                        })
+                        .collect();
 
             println!("{total_budget_used:?}");
+            
+            // N scripts return an N length vector of ExBudgets
+            let expected_budgets: Vec<ExBudget> = vec![
+                ExBudget { mem: 4002, cpu: 6231248 },
+            ];
 
             assert_eq!(
                 total_budget_used,
                 // Numbers came uplc evaluate
-                ExBudget {
-                    cpu: 6231248,
-                    mem: 4002
-                }
+                expected_budgets
             );
         }
         _ => unreachable!(),
@@ -1290,23 +1307,26 @@ fn test_eval_7() {
 
             assert_eq!(redeemers.len(), 1);
 
-            let total_budget_used =
-                redeemers
-                    .iter()
-                    .fold(ExBudget { mem: 0, cpu: 0 }, |accum, curr| ExBudget {
-                        mem: accum.mem + curr.ex_units.mem as i64,
-                        cpu: accum.cpu + curr.ex_units.steps as i64,
-                    });
+            let total_budget_used: Vec<ExBudget> =
+                    redeemers
+                        .iter()
+                        .map(|curr| ExBudget {
+                            mem: curr.ex_units.mem as i64,
+                            cpu: curr.ex_units.steps as i64,
+                        })
+                        .collect();
 
             println!("{total_budget_used:?}");
+            
+            // N scripts return an N length vector of ExBudgets
+            let expected_budgets: Vec<ExBudget> = vec![
+                ExBudget { mem: 2954794, cpu: 1221507148 },
+            ];
 
             assert_eq!(
                 total_budget_used,
                 // Numbers came uplc evaluate
-                ExBudget {
-                    cpu: 1221507148,
-                    mem: 2954794
-                }
+                expected_budgets
             );
         }
         _ => unreachable!(),
@@ -1546,23 +1566,26 @@ fn test_eval_8() {
 
             assert_eq!(redeemers.len(), 1);
 
-            let total_budget_used =
-                redeemers
-                    .iter()
-                    .fold(ExBudget { mem: 0, cpu: 0 }, |accum, curr| ExBudget {
-                        mem: accum.mem + curr.ex_units.mem as i64,
-                        cpu: accum.cpu + curr.ex_units.steps as i64,
-                    });
+            let total_budget_used: Vec<ExBudget> =
+                    redeemers
+                        .iter()
+                        .map(|curr| ExBudget {
+                            mem: curr.ex_units.mem as i64,
+                            cpu: curr.ex_units.steps as i64,
+                        })
+                        .collect();
 
             println!("{total_budget_used:?}");
+            
+            // N scripts return an N length vector of ExBudgets
+            let expected_budgets: Vec<ExBudget> = vec![
+                ExBudget { mem: 2691678, cpu: 711173018 },
+            ];
 
             assert_eq!(
                 total_budget_used,
                 // Numbers came uplc evaluate
-                ExBudget {
-                    cpu: 711173018,
-                    mem: 2691678
-                }
+                expected_budgets
             );
         }
         _ => unreachable!(),


### PR DESCRIPTION
This PR changes the returned data structure from the `tx simulate` command. Instead of calculating the total execution budget from all the scripts inside the vector of redeemers, it returns a vector of ExBudgets.

The output for a single script is now

```bash
[{'mem': 443656, 'cpu': 171399581}]
```

and for multiscript

```bash
[{'mem': 568735, 'cpu': 212877955}, {'mem': 356523, 'cpu': 133054577}]
```

The order of the ExBudget vector should follow the order of the Redeemer vector.

I am still on the hunt for the fee issue. Any smart contracts that have fee logic always fail. But at least tx simulate can now handle multi-script transactions in a helpful way.