### PR TITLE
`aiken new`: Try to get the latest tag of stdlib

### DIFF
--- a/crates/aiken-project/Cargo.toml
+++ b/crates/aiken-project/Cargo.toml
@@ -32,7 +32,7 @@ petgraph = "0.6.3"
 pulldown-cmark = { version = "0.9.2", default-features = false }
 rayon = "1.7.0"
 regex = "1.7.1"
-reqwest = "0.11.14"
+reqwest = { version = "0.11.14", features = ["blocking", "json"] }
 serde = { version = "1.0.152", features = ["derive"] }
 serde_json = { version = "1.0.94", features = ["preserve_order"] }
 strip-ansi-escapes = "0.1.1"

--- a/crates/aiken-project/src/config.rs
+++ b/crates/aiken-project/src/config.rs
@@ -1,4 +1,4 @@
-use crate::{package_name::PackageName, paths, Error};
+use crate::{github::repo::LatestRelease, package_name::PackageName, paths, Error};
 use aiken_lang::ast::Span;
 use miette::NamedSource;
 use serde::{Deserialize, Serialize};
@@ -65,7 +65,10 @@ impl Config {
                     owner: "aiken-lang".to_string(),
                     repo: "stdlib".to_string(),
                 },
-                version: "1.5.0".to_string(),
+                version: match LatestRelease::of("aiken-lang/stdlib") {
+                    Ok(stdlib) => stdlib.tag_name,
+                    _ => "1.5.0".to_string(),
+                },
                 source: Platform::Github,
             }],
         }

--- a/crates/aiken-project/src/github/mod.rs
+++ b/crates/aiken-project/src/github/mod.rs
@@ -1,0 +1,1 @@
+pub mod repo;

--- a/crates/aiken-project/src/github/repo.rs
+++ b/crates/aiken-project/src/github/repo.rs
@@ -1,0 +1,22 @@
+use reqwest::{blocking::Client, header::USER_AGENT, Error};
+use serde::Deserialize;
+
+#[derive(Deserialize)]
+pub struct LatestRelease {
+    pub tag_name: String,
+}
+
+impl LatestRelease {
+    pub fn of<Repo: AsRef<str>>(repo: Repo) -> Result<Self, Error> {
+        Ok({
+            Client::new()
+                .get(format!(
+                    "https://api.github.com/repos/{}/releases/latest",
+                    repo.as_ref()
+                ))
+                .header(USER_AGENT, "aiken")
+                .send()?
+                .json::<Self>()?
+        })
+    }
+}

--- a/crates/aiken-project/src/lib.rs
+++ b/crates/aiken-project/src/lib.rs
@@ -4,6 +4,7 @@ pub mod deps;
 pub mod docs;
 pub mod error;
 pub mod format;
+pub mod github;
 pub mod module;
 pub mod options;
 pub mod package_name;


### PR DESCRIPTION
When running `aiken new` it tries to retrieve the latest release tag https://github.com/aiken-lang/aiken/issues/672#issue-1796508316, fallback to hardcoded value (eg. when there's no internet connection or Github server down, etc.)