### PR TITLE
rm unnecessary mut

### DIFF
--- a/crates/aiken-lang/src/gen_uplc.rs
+++ b/crates/aiken-lang/src/gen_uplc.rs
@@ -1903,7 +1903,7 @@ impl<'a> CodeGenerator<'a> {
     }
 
     pub fn clause_pattern(
-        &mut self,
+        &self,
         pattern: &Pattern<PatternConstructor, Arc<Type>>,
         subject_tipo: &Arc<Type>,
         props: &mut ClauseProperties,
@@ -2329,7 +2329,7 @@ impl<'a> CodeGenerator<'a> {
     }
 
     fn nested_clause_condition(
-        &mut self,
+        &self,
         pattern: &Pattern<PatternConstructor, Arc<Type>>,
         subject_tipo: &Arc<Type>,
         props: &mut ClauseProperties,


### PR DESCRIPTION
Some refs using mut where I don't think they're needed. 

It's bit tricky to keep track of how the compilation pipeline works. 
I think within `CodeGenerator::build` only in calls to `self.assignment` is there a mutation. 

This PR isolates mutations a bit more.
