### PR TITLE
rm unused pub func

### DIFF
--- a/crates/uplc/src/builder.rs
+++ b/crates/uplc/src/builder.rs
@@ -379,7 +379,7 @@ impl Term<Name> {
             )
     }
 
-    pub fn assert_on_list(self) -> Self {
+    pub fn expect_on_list(self) -> Self {
         self.lambda(EXPECT_ON_LIST)
             .apply(Term::var(EXPECT_ON_LIST).apply(Term::var(EXPECT_ON_LIST)))
             .lambda(EXPECT_ON_LIST)

--- a/crates/uplc/src/builder.rs
+++ b/crates/uplc/src/builder.rs
@@ -378,27 +378,4 @@ impl Term<Name> {
                     .lambda(CONSTR_GET_FIELD),
             )
     }
-
-    pub fn expect_on_list(self) -> Self {
-        self.lambda(EXPECT_ON_LIST)
-            .apply(Term::var(EXPECT_ON_LIST).apply(Term::var(EXPECT_ON_LIST)))
-            .lambda(EXPECT_ON_LIST)
-            .apply(
-                Term::var("__list_to_check")
-                    .delayed_choose_list(
-                        Term::unit(),
-                        Term::var("__check_with")
-                            .apply(Term::head_list().apply(Term::var("__list_to_check")))
-                            .choose_unit(
-                                Term::var(EXPECT_ON_LIST)
-                                    .apply(Term::var(EXPECT_ON_LIST))
-                                    .apply(Term::tail_list().apply(Term::var("__list_to_check")))
-                                    .apply(Term::var("__check_with")),
-                            ),
-                    )
-                    .lambda("__check_with")
-                    .lambda("__list_to_check")
-                    .lambda(EXPECT_ON_LIST),
-            )
-    }
 }


### PR DESCRIPTION
The method name looked dated. First commit changes it. 

It's actually not used at least within aiken --- possibly why it seemed to have out of date name. 
Second commit removes the method entirely which is maybe more appropriate. Dunno 