### PR TITLE
Improve UX around dependency fetching

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Added
 
 - **aiken**: add ability to force warnings to cause a failing exit code on check, build, and docs
+- **aiken-lang**: automatically resolve and fetch latest revision of a package on build when a branch is specified as version
 
 ### Fixed
 

--- a/crates/aiken-project/src/config.rs
+++ b/crates/aiken-project/src/config.rs
@@ -16,14 +16,14 @@ pub struct Config {
     pub dependencies: Vec<Dependency>,
 }
 
-#[derive(Deserialize, Serialize, Clone)]
+#[derive(Deserialize, Serialize, Clone, Debug)]
 pub struct Repository {
     pub user: String,
     pub project: String,
     pub platform: Platform,
 }
 
-#[derive(Deserialize, Serialize, PartialEq, Eq, Clone, Copy)]
+#[derive(Deserialize, Serialize, PartialEq, Eq, Clone, Copy, Debug)]
 #[serde(rename_all = "lowercase")]
 pub enum Platform {
     Github,
@@ -31,7 +31,7 @@ pub enum Platform {
     Bitbucket,
 }
 
-#[derive(Deserialize, Serialize, PartialEq, Eq, Clone)]
+#[derive(Deserialize, Serialize, PartialEq, Eq, Clone, Debug)]
 pub struct Dependency {
     pub name: PackageName,
     pub version: String,

--- a/crates/aiken-project/src/deps.rs
+++ b/crates/aiken-project/src/deps.rs
@@ -10,7 +10,7 @@ use crate::{
     error::Error,
     package_name::PackageName,
     paths,
-    telemetry::{Event, EventListener},
+    telemetry::{DownloadSource, Event, EventListener},
 };
 
 use self::{

--- a/crates/aiken-project/src/deps.rs
+++ b/crates/aiken-project/src/deps.rs
@@ -133,12 +133,7 @@ impl From<&Manifest> for LocalPackages {
     }
 }
 
-pub fn download<T>(
-    event_listener: &T,
-    use_manifest: UseManifest,
-    root_path: &Path,
-    config: &Config,
-) -> Result<Manifest, Error>
+pub fn download<T>(event_listener: &T, root_path: &Path, config: &Config) -> Result<Manifest, Error>
 where
     T: EventListener,
 {
@@ -164,13 +159,7 @@ where
 
     let runtime = tokio::runtime::Runtime::new().expect("Unable to start Tokio");
 
-    let (manifest, changed) = Manifest::load(
-        runtime.handle().clone(),
-        event_listener,
-        config,
-        use_manifest,
-        root_path,
-    )?;
+    let (manifest, changed) = Manifest::load(event_listener, config, root_path)?;
 
     let local = LocalPackages::load(root_path)?;
 

--- a/crates/aiken-project/src/deps.rs
+++ b/crates/aiken-project/src/deps.rs
@@ -26,7 +26,7 @@ pub enum UseManifest {
     No,
 }
 
-#[derive(Deserialize, Serialize)]
+#[derive(Deserialize, Serialize, Debug)]
 pub struct LocalPackages {
     packages: Vec<Dependency>,
 }

--- a/crates/aiken-project/src/deps/downloader.rs
+++ b/crates/aiken-project/src/deps/downloader.rs
@@ -92,8 +92,6 @@ impl<'a> Downloader<'a> {
 
         let bytes = response.bytes().await?;
 
-        // let PackageSource::Github { url } = &package.source;
-
         tokio::fs::write(&zipball_path, bytes).await?;
 
         Ok(true)

--- a/crates/aiken-project/src/deps/downloader.rs
+++ b/crates/aiken-project/src/deps/downloader.rs
@@ -11,6 +11,7 @@ use crate::{
     error::Error,
     package_name::PackageName,
     paths::{self, CacheKey},
+    telemetry::EventListener,
 };
 
 use super::manifest::Package;

--- a/crates/aiken-project/src/deps/manifest.rs
+++ b/crates/aiken-project/src/deps/manifest.rs
@@ -14,7 +14,7 @@ use crate::{
 
 use super::UseManifest;
 
-#[derive(Deserialize, Serialize)]
+#[derive(Deserialize, Serialize, Debug)]
 pub struct Manifest {
     pub requirements: Vec<Dependency>,
     pub packages: Vec<Package>,
@@ -88,7 +88,7 @@ impl Manifest {
     }
 }
 
-#[derive(Deserialize, Serialize, Clone)]
+#[derive(Deserialize, Serialize, Clone, Debug)]
 pub struct Package {
     pub name: PackageName,
     pub version: String,

--- a/crates/aiken-project/src/deps/manifest.rs
+++ b/crates/aiken-project/src/deps/manifest.rs
@@ -107,19 +107,6 @@ where
 {
     event_listener.handle_event(Event::ResolvingVersions);
 
-    // let resolved = hex::resolve_versions(
-    //     PackageFetcher::boxed(runtime.clone()),
-    //     mode,
-    //     config,
-    //     manifest,
-    // )?;
-
-    // let packages = runtime.block_on(future::try_join_all(
-    //     resolved
-    //         .into_iter()
-    //         .map(|(name, version)| lookup_package(name, version)),
-    // ))?;
-
     let manifest = Manifest {
         packages: config
             .dependencies

--- a/crates/aiken-project/src/error.rs
+++ b/crates/aiken-project/src/error.rs
@@ -107,6 +107,13 @@ pub enum Error {
     )]
     UnknownPackageVersion { package: Package },
 
+    #[error(
+        "I need to resolve a package {}/{}, but couldn't find it.",
+        package.name.owner,
+        package.name.repo,
+    )]
+    UnableToResolvePackage { package: Package },
+
     #[error("I couldn't parse the provided stake address.")]
     MalformedStakeAddress {
         error: Option<pallas::ledger::addresses::Error>,
@@ -188,6 +195,7 @@ impl GetSource for Error {
             Error::ZipExtract(_) => None,
             Error::JoinError(_) => None,
             Error::UnknownPackageVersion { .. } => None,
+            Error::UnableToResolvePackage { .. } => None,
             Error::Json { .. } => None,
             Error::MalformedStakeAddress { .. } => None,
             Error::NoValidatorNotFound { .. } => None,
@@ -213,6 +221,7 @@ impl GetSource for Error {
             Error::ZipExtract(_) => None,
             Error::JoinError(_) => None,
             Error::UnknownPackageVersion { .. } => None,
+            Error::UnableToResolvePackage { .. } => None,
             Error::Json { .. } => None,
             Error::MalformedStakeAddress { .. } => None,
             Error::NoValidatorNotFound { .. } => None,
@@ -247,6 +256,7 @@ impl Diagnostic for Error {
             Error::ZipExtract(_) => None,
             Error::JoinError(_) => None,
             Error::UnknownPackageVersion { .. } => Some(Box::new("aiken::packages::resolve")),
+            Error::UnableToResolvePackage { .. } => Some(Box::new("aiken::package::download")),
             Error::Json { .. } => None,
             Error::MalformedStakeAddress { .. } => None,
             Error::NoValidatorNotFound { .. } => None,
@@ -306,6 +316,7 @@ impl Diagnostic for Error {
             Error::ZipExtract(_) => None,
             Error::JoinError(_) => None,
             Error::UnknownPackageVersion{..} => Some(Box::new("Perhaps, double-check the package repository and version?")),
+            Error::UnableToResolvePackage{..} => Some(Box::new("The network is unavailable and the package isn't in the local cache either. Try connecting to the Internet so I can look it up?")),
             Error::Json(error) => Some(Box::new(format!("{error}"))),
             Error::MalformedStakeAddress { error } => Some(Box::new(format!("A stake address must be provided either as a base16-encoded string, or as a bech32-encoded string with the 'stake' or 'stake_test' prefix.{hint}", hint = match error {
                 Some(error) => format!("\n\nHere's the error I encountered: {error}"),
@@ -366,6 +377,7 @@ impl Diagnostic for Error {
             Error::ZipExtract(_) => None,
             Error::JoinError(_) => None,
             Error::UnknownPackageVersion { .. } => None,
+            Error::UnableToResolvePackage { .. } => None,
             Error::Json { .. } => None,
             Error::MalformedStakeAddress { .. } => None,
             Error::NoValidatorNotFound { .. } => None,
@@ -391,6 +403,7 @@ impl Diagnostic for Error {
             Error::ZipExtract(_) => None,
             Error::JoinError(_) => None,
             Error::UnknownPackageVersion { .. } => None,
+            Error::UnableToResolvePackage { .. } => None,
             Error::Json { .. } => None,
             Error::MalformedStakeAddress { .. } => None,
             Error::NoValidatorNotFound { .. } => None,
@@ -416,6 +429,7 @@ impl Diagnostic for Error {
             Error::ZipExtract { .. } => None,
             Error::JoinError { .. } => None,
             Error::UnknownPackageVersion { .. } => None,
+            Error::UnableToResolvePackage { .. } => None,
             Error::Json { .. } => None,
             Error::MalformedStakeAddress { .. } => None,
             Error::NoValidatorNotFound { .. } => None,
@@ -441,6 +455,7 @@ impl Diagnostic for Error {
             Error::ZipExtract { .. } => None,
             Error::JoinError { .. } => None,
             Error::UnknownPackageVersion { .. } => None,
+            Error::UnableToResolvePackage { .. } => None,
             Error::Json { .. } => None,
             Error::MalformedStakeAddress { .. } => None,
             Error::NoValidatorNotFound { .. } => None,

--- a/crates/aiken-project/src/lib.rs
+++ b/crates/aiken-project/src/lib.rs
@@ -27,7 +27,6 @@ use aiken_lang::{
     tipo::TypeInfo,
     IdGenerator,
 };
-use deps::UseManifest;
 use indexmap::IndexMap;
 use miette::NamedSource;
 use options::{CodeGenMode, Options};
@@ -491,12 +490,7 @@ where
     }
 
     fn compile_deps(&mut self) -> Result<(), Vec<Error>> {
-        let manifest = deps::download(
-            &self.event_listener,
-            UseManifest::Yes,
-            &self.root,
-            &self.config,
-        )?;
+        let manifest = deps::download(&self.event_listener, &self.root, &self.config)?;
 
         for package in manifest.packages {
             let lib = self.root.join(paths::build_deps_package(&package.name));

--- a/crates/aiken-project/src/package_name.rs
+++ b/crates/aiken-project/src/package_name.rs
@@ -6,7 +6,7 @@ use std::{
 };
 use thiserror::Error;
 
-#[derive(PartialEq, Eq, Hash, Clone)]
+#[derive(PartialEq, Eq, Hash, Clone, Debug)]
 pub struct PackageName {
     pub owner: String,
     pub repo: String,

--- a/crates/aiken-project/src/telemetry.rs
+++ b/crates/aiken-project/src/telemetry.rs
@@ -1,5 +1,5 @@
 use crate::script::EvalInfo;
-use std::path::PathBuf;
+use std::{fmt::Display, path::PathBuf};
 
 pub trait EventListener {
     fn handle_event(&self, _event: Event) {}
@@ -37,12 +37,30 @@ pub enum Event {
         tests: Vec<EvalInfo>,
     },
     WaitingForBuildDirLock,
-    DownloadingPackage {
+    ResolvingPackages {
+        name: String,
+    },
+    PackageResolveFallback {
         name: String,
     },
     PackagesDownloaded {
         start: tokio::time::Instant,
         count: usize,
+        source: DownloadSource,
     },
     ResolvingVersions,
+}
+
+pub enum DownloadSource {
+    Network,
+    Cache,
+}
+
+impl Display for DownloadSource {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            DownloadSource::Network => write!(f, "network"),
+            DownloadSource::Cache => write!(f, "cache"),
+        }
+    }
 }

--- a/examples/hello_world/aiken.lock
+++ b/examples/hello_world/aiken.lock
@@ -11,3 +11,6 @@ name = "aiken-lang/stdlib"
 version = "main"
 requirements = []
 source = "github"
+
+[etags]
+"aiken-lang/stdlib@main" = [{ secs_since_epoch = 1694181032, nanos_since_epoch = 345700000 }, "e9abc03ee3dbf98637e8e2d8b115e1c95573a4168dbbbe517e8499208b67b020"]


### PR DESCRIPTION
This PR is meant to improve the UX around `aiken build`, especially when using unpinned dependency versions (e.g. `main`). I got bitten by that once again (and we've seen plenty of people being confused by that too) after I tried to rebuild some local package depending on `aiken-lang/stdlib@main`. 

Now, `aiken build` will actually try to resolve the latest version of any package that isn't specified by:

- a git sha
- a tag

If the upstream package has changed, then it is downloaded and updated locally such that using `main` actually means using `main`. The upstream package resolution is throttle to once an hour to avoid overloading Github with many calls for people using LSP. It also works fine when the network isn't available and will use the most recent version in the system cache that we have fetched if it's unable to check for what is the latest version.

Here is some screenshots of the new behavior:

#### Pinned version already downloaded

<img width="1243" alt="Screenshot 2023-09-08 at 14 37 56" src="https://github.com/aiken-lang/aiken/assets/5680256/828c36ea-99f3-4898-876b-0243c66ebf42">

#### Unpinned version, checking version with upstream registry, using cache

<img width="989" alt="Screenshot 2023-09-08 at 14 39 21" src="https://github.com/aiken-lang/aiken/assets/5680256/4c056346-816e-4d2e-bf2c-a7d944b795f2">

#### Unpinned version, bypassing upstream check since done recently, using cache

<img width="991" alt="Screenshot 2023-09-08 at 16 05 45" src="https://github.com/aiken-lang/aiken/assets/5680256/39498e61-0684-4e6f-ae3b-61585023b214">

#### Unpinned version, local version outdated but network is offline, using cache

<img width="989" alt="Screenshot 2023-09-08 at 14 30 54" src="https://github.com/aiken-lang/aiken/assets/5680256/5b7b7841-ab37-4331-8b99-fd7ff88ad332">

##### Unpinned version, checking (outdated) version with upstream, re-downloading and updating cache

<img width="994" alt="Screenshot 2023-09-08 at 16 09 51" src="https://github.com/aiken-lang/aiken/assets/5680256/7d56be68-ee4f-4dae-acd6-34f290b5d72a">


---

- :round_pushpin: **Auto-derive 'Debug' trait instance for types in deps**
    Actually useful to debug / troubleshoot things.

- :round_pushpin: **Remove dead-code.**
  
- :round_pushpin: **Define 'is_git_sha_or_version' to assert whether a version is 'immutable'**
  Best-effort to assert whether a version refers is a git sha digest or a tag. When it is, we
avoid re-downloading it if it's already fetched. But when it isn't, and thus refer to a branch,
we always re-download it. Note however that the download might be short-circuited by the
system-wide package cache, so a download doesn't actually mean a network request.

The package cache is however smart-enough to assert whether a package in the cache must be
re-downloaded (using HTTP ETag). So this is mostly about delegating the re-downloading logic to
the global packages cache.

- :round_pushpin: **Always check package status when version is not pinned**
    When the version isn't a git sha or a tag, we always check that we got
  the last version of a particular dependency before building. This is
  to avoid those awkward moments where someone try to use something from
  the stdlib that is brand new, and despite using 'main' they get a
  strange build failure regarding how it's not available.

  An important note is that we don't actually re-download the package
  when the case occurs; we merely check an HTTP ETag from a (cheap) 'HEAD'
  request on the package registry. If the tag hasn't changed then that
  means the local version is correct.

  The behavior is completely bypassed if the version is specified using
  a git sha or a tag, as here, we can assume that fetching it once it
  enough (and that it can change). If a package maintainer force-pushed
  a tag however, there may be discrepency and the only way around that
  is to `rm -r ./build`.

- :round_pushpin: **Ensure that version resolution works offline**
    And so, even for unpinned package. In this case, we can't do a HEAD request. So we fallback by looking at what's available in the cache and using the most recently downloaded version from the cache. This is only a best effort as the most recently downloaded one may not be the actual latest. But common, this is a case where (a) someone didn't pin any version, (b) is trying to build on in an offline setup. We could possibly make that edge-case better but, let's see if anyone ever complains about it first.

- :round_pushpin: **Rework logs around dependency fetching.**
  
- :round_pushpin: **Remove unused code & data-type 'UseManifest'**
    If it's unused, it shall be gone. It obfuscate what functions are
  doing and require managing extra complexity for no reason.

- :round_pushpin: **Throttle calls to package registry for version resolution**
    The 'HEAD' call that is done to resolve package revisions from
  unpinned versions is already quite cheap, but it would still be better
  to avoid overloading Github with such calls; especially for users of a
  language-server that would compile on-the-fly very often. Upstream
  packages don't change often so there's no need to constantly check the
  etag.

  So we now keep a local version of etags that we fetched, as well as a
  timestamp from the last time we fetched them so that we only re-fetch
  them if more than an hour has elapsed. This should be fairly resilient
  while still massively improving the UX for people showing up after a
  day and trying to use latest 'main' features.

  This means that we now effectively have two caching levels:

  - In the manifest, we store previously fetched etags.
  - In the filesystem, we have a cache of already downloaded zip archives.

  The first cache is basically invalidated every hour, while the second
  cache is only invalidated when a etag changes. For pinned versions,
  nothing is invalidated as they are considered immutable.