### PR TITLE
Rationalize builder

### DIFF
--- a/crates/aiken-lang/src/gen_uplc/builder.rs
+++ b/crates/aiken-lang/src/gen_uplc/builder.rs
@@ -1194,7 +1194,7 @@ pub fn convert_data_to_type(term: Term<Name>, field_type: &Rc<Type>) -> Term<Nam
         Term::equals_integer()
             .apply(Term::integer(0.into()))
             .apply(Term::fst_pair().apply(Term::unconstr_data().apply(term)))
-            .delayed_if_else(Term::unit(), Term::Error)
+            .delayed_if_then_else(Term::unit(), Term::Error)
     } else if field_type.is_map() {
         Term::unmap_data().apply(term)
     } else if field_type.is_string() {
@@ -1332,7 +1332,7 @@ pub fn convert_type_to_data(term: Term<Name>, field_type: &Rc<Type>) -> Term<Nam
     } else if field_type.is_list() || field_type.is_tuple() {
         Term::list_data().apply(term)
     } else if field_type.is_bool() {
-        term.if_else(
+        term.if_then_else(
             Term::Constant(
                 UplcConstant::Data(PlutusData::Constr(Constr {
                     tag: convert_constr_to_tag(1).unwrap(),
@@ -1713,17 +1713,17 @@ pub fn wrap_as_multi_validator(
             spend_name
         );
 
-        let error_term = Term::Error.trace(Term::var("__incorrect_second_arg_type"));
+        let error_term = Term::Error.delayed_trace(Term::var("__incorrect_second_arg_type"));
 
         Term::var("__second_arg")
             .delayed_choose_data(
                 Term::equals_integer()
                     .apply(Term::integer(0.into()))
                     .apply(Term::var(CONSTR_INDEX_EXPOSER).apply(Term::var("__second_arg")))
-                    .delayed_if_else(
+                    .delayed_if_then_else(
                         mint.apply(Term::var("__first_arg"))
                             .apply(Term::var("__second_arg"))
-                            .trace(Term::string(format!(
+                            .delayed_trace(Term::string(format!(
                                 "Running 2 arg validator {}",
                                 mint_name
                             ))),
@@ -1732,7 +1732,7 @@ pub fn wrap_as_multi_validator(
                             .apply(Term::head_list().apply(
                                 Term::var(CONSTR_FIELDS_EXPOSER).apply(Term::var("__second_arg")),
                             ))
-                            .trace(Term::string(format!(
+                            .delayed_trace(Term::string(format!(
                                 "Running 3 arg validator {}",
                                 spend_name
                             ))),
@@ -1750,7 +1750,7 @@ pub fn wrap_as_multi_validator(
         Term::equals_integer()
             .apply(Term::integer(0.into()))
             .apply(Term::var(CONSTR_INDEX_EXPOSER).apply(Term::var("__second_arg")))
-            .delayed_if_else(
+            .delayed_if_then_else(
                 mint.apply(Term::var("__first_arg"))
                     .apply(Term::var("__second_arg")),
                 spend.apply(Term::var("__first_arg")).apply(

--- a/crates/aiken-project/src/tests/gen_uplc.rs
+++ b/crates/aiken-project/src/tests/gen_uplc.rs
@@ -192,7 +192,7 @@ fn acceptance_test_2_repeat() {
                                     Term::less_than_equals_integer()
                                         .apply(Term::var("n"))
                                         .apply(Term::integer(0.into()))
-                                        .delayed_if_else(
+                                        .delayed_if_then_else(
                                             Term::empty_list(),
                                             Term::mk_cons()
                                                 .apply(Term::b_data().apply(Term::var("x")))
@@ -200,7 +200,7 @@ fn acceptance_test_2_repeat() {
                                                     Term::var("repeat")
                                                         .apply(Term::var("repeat"))
                                                         .apply(
-                                                            Term::sub_integer()
+                                                            Term::subtract_integer()
                                                                 .apply(Term::var("n"))
                                                                 .apply(Term::integer(1.into())),
                                                         ),
@@ -685,7 +685,7 @@ fn acceptance_test_6_if_else() {
         Term::equals_integer()
             .apply(Term::integer(1.into()))
             .apply(Term::integer(1.into()))
-            .delayed_if_else(Term::bool(true), Term::bool(false)),
+            .delayed_if_then_else(Term::bool(true), Term::bool(false)),
         false,
     );
 }
@@ -889,9 +889,9 @@ fn acceptance_test_8_is_empty() {
                     .lambda("bytes"),
             )
             .apply(Term::byte_string(vec![]))
-            .delayed_if_else(
+            .delayed_if_then_else(
                 Term::bool(true),
-                Term::bool(true).if_else(Term::bool(false), Term::bool(true)),
+                Term::bool(true).if_then_else(Term::bool(false), Term::bool(true)),
             ),
         false,
     );
@@ -922,9 +922,9 @@ fn acceptance_test_8_is_not_empty() {
                     .lambda("bytes"),
             )
             .apply(Term::byte_string(vec![1]))
-            .delayed_if_else(
+            .delayed_if_then_else(
                 Term::bool(false),
-                Term::bool(false).if_else(Term::bool(false), Term::bool(true)),
+                Term::bool(false).if_then_else(Term::bool(false), Term::bool(true)),
             ),
         false,
     );
@@ -955,9 +955,9 @@ fn acceptance_test_9_is_empty() {
                     .lambda("bytes"),
             )
             .apply(Term::byte_string(vec![]))
-            .delayed_if_else(
+            .delayed_if_then_else(
                 Term::bool(true),
-                Term::bool(true).if_else(Term::bool(false), Term::bool(true)),
+                Term::bool(true).if_then_else(Term::bool(false), Term::bool(true)),
             ),
         false,
     );
@@ -994,7 +994,7 @@ fn acceptance_test_10_map_none() {
                         Term::equals_integer()
                             .apply(Term::integer(1.into()))
                             .apply(Term::var("constr_index"))
-                            .delayed_if_else(
+                            .delayed_if_then_else(
                                 Term::Constant(Constant::Data(Data::constr(1, vec![])).into()),
                                 Term::constr_data()
                                     .apply(Term::integer(0.into()))
@@ -1076,7 +1076,7 @@ fn acceptance_test_10_map_some() {
                         Term::equals_integer()
                             .apply(Term::integer(1.into()))
                             .apply(Term::var("constr_index"))
-                            .delayed_if_else(
+                            .delayed_if_then_else(
                                 Term::Constant(Constant::Data(Data::constr(1, vec![])).into()),
                                 Term::constr_data()
                                     .apply(Term::integer(0.into()))
@@ -1318,7 +1318,7 @@ fn acceptance_test_12_filter_even() {
                                             Term::empty_list(),
                                             Term::var("f")
                                                 .apply(Term::var("x"))
-                                                .delayed_if_else(
+                                                .delayed_if_then_else(
                                                     Term::mk_cons()
                                                         .apply(Term::i_data().apply(Term::var("x")))
                                                         .apply(
@@ -1388,7 +1388,7 @@ fn acceptance_test_14_list_creation() {
                     Term::mk_cons()
                         .apply(
                             Term::i_data().apply(
-                                Term::sub_integer()
+                                Term::subtract_integer()
                                     .apply(Term::integer(0.into()))
                                     .apply(Term::integer(2.into())),
                             ),
@@ -1397,7 +1397,7 @@ fn acceptance_test_14_list_creation() {
                             Term::mk_cons()
                                 .apply(
                                     Term::i_data().apply(
-                                        Term::sub_integer()
+                                        Term::subtract_integer()
                                             .apply(Term::integer(0.into()))
                                             .apply(Term::integer(1.into())),
                                     ),
@@ -1481,7 +1481,7 @@ fn acceptance_test_16_drop() {
                             .apply(Term::var("bytes"))
                             .apply(Term::var("n"))
                             .apply(
-                                Term::sub_integer()
+                                Term::subtract_integer()
                                     .apply(Term::var("length").apply(Term::var("bytes")))
                                     .apply(Term::var("n")),
                             )
@@ -1591,7 +1591,7 @@ fn acceptance_test_18_or_else() {
                         Term::equals_integer()
                             .apply(Term::integer(1.into()))
                             .apply(Term::var("subject"))
-                            .delayed_if_else(
+                            .delayed_if_then_else(
                                 Term::var("default"),
                                 Term::var("a")
                                     .lambda("a")
@@ -1654,7 +1654,7 @@ fn acceptance_test_19_map_none_wrap_int() {
                         Term::equals_integer()
                             .apply(Term::integer(1.into()))
                             .apply(Term::var("subject"))
-                            .delayed_if_else(
+                            .delayed_if_then_else(
                                 Term::data(Data::constr(1, vec![])),
                                 Term::constr_data()
                                     .apply(Term::integer(0.into()))
@@ -1724,7 +1724,7 @@ fn acceptance_test_19_map_wrap_void() {
                         Term::equals_integer()
                             .apply(Term::integer(1.into()))
                             .apply(Term::var("subject"))
-                            .delayed_if_else(
+                            .delayed_if_then_else(
                                 Term::data(Data::constr(1, vec![])),
                                 Term::constr_data()
                                     .apply(Term::integer(0.into()))
@@ -1795,7 +1795,7 @@ fn acceptance_test_20_map_some() {
                         Term::equals_integer()
                             .apply(Term::integer(1.into()))
                             .apply(Term::var("constr_index"))
-                            .delayed_if_else(
+                            .delayed_if_then_else(
                                 Term::Constant(Constant::Data(Data::constr(1, vec![])).into()),
                                 Term::constr_data()
                                     .apply(Term::integer(0.into()))
@@ -1890,7 +1890,7 @@ fn acceptance_test_22_filter_map() {
                                     Term::equals_integer()
                                         .apply(Term::integer(1.into()))
                                         .apply(Term::var("subject_index"))
-                                        .delayed_if_else(
+                                        .delayed_if_then_else(
                                             Term::var("ys"),
                                             Term::mk_cons()
                                                 .apply(Term::i_data().apply(Term::var("y")))
@@ -2082,12 +2082,12 @@ fn acceptance_test_24_map2() {
                         Term::equals_integer()
                             .apply(Term::integer(1.into()))
                             .apply(Term::var("opt_a_index"))
-                            .delayed_if_else(
+                            .delayed_if_then_else(
                                 Term::Constant(Constant::Data(Data::constr(1, vec![])).into()),
                                 Term::equals_integer()
                                     .apply(Term::integer(1.into()))
                                     .apply(Term::var("opt_b_index"))
-                                    .delayed_if_else(
+                                    .delayed_if_then_else(
                                         Term::Constant(
                                             Constant::Data(Data::constr(1, vec![])).into(),
                                         ),
@@ -2643,7 +2643,7 @@ fn expect_empty_list_on_filled_list() {
         Term::var("x")
             .delayed_choose_list(
                 Term::bool(true),
-                Term::Error.trace(Term::string("Expected no items for List")),
+                Term::Error.delayed_trace(Term::string("Expected no items for List")),
             )
             .lambda("x")
             .apply(Term::list_values(vec![
@@ -2670,7 +2670,7 @@ fn expect_empty_list_on_new_list() {
         Term::var("x")
             .delayed_choose_list(
                 Term::bool(true),
-                Term::Error.trace(Term::string("Expected no items for List")),
+                Term::Error.delayed_trace(Term::string("Expected no items for List")),
             )
             .lambda("x")
             .apply(Term::list_values(vec![])),
@@ -2694,7 +2694,7 @@ fn when_bool_is_true() {
     assert_uplc(
         src,
         Term::var("subject")
-            .delayed_if_else(Term::bool(true), Term::Error)
+            .delayed_if_then_else(Term::bool(true), Term::Error)
             .lambda("subject")
             .apply(Term::bool(true)),
         false,
@@ -2717,7 +2717,7 @@ fn when_bool_is_true_switched_cases() {
     assert_uplc(
         src,
         Term::var("subject")
-            .delayed_if_else(Term::bool(true), Term::Error)
+            .delayed_if_then_else(Term::bool(true), Term::Error)
             .lambda("subject")
             .apply(Term::bool(true)),
         false,
@@ -2740,7 +2740,7 @@ fn when_bool_is_false() {
     assert_uplc(
         src,
         Term::var("subject")
-            .delayed_if_else(Term::bool(true), Term::Error)
+            .delayed_if_then_else(Term::bool(true), Term::Error)
             .lambda("subject")
             .apply(Term::bool(false)),
         true,
@@ -2781,11 +2781,11 @@ fn when_tuple_deconstruction() {
         Term::equals_integer()
             .apply(Term::integer(0.into()))
             .apply(Term::var(CONSTR_INDEX_EXPOSER).apply(Term::var("dat")))
-            .if_else(
+            .if_then_else(
                 Term::equals_integer()
                     .apply(Term::integer(0.into()))
                     .apply(Term::var(CONSTR_INDEX_EXPOSER).apply(Term::var("red")))
-                    .if_else(
+                    .if_then_else(
                         Term::equals_integer()
                             .apply(
                                 Term::un_i_data().apply(
@@ -2795,9 +2795,9 @@ fn when_tuple_deconstruction() {
                                 ),
                             )
                             .apply(Term::var("x"))
-                            .delayed_if_else(
+                            .delayed_if_then_else(
                                 Term::bool(true),
-                                Term::bool(false).trace(Term::string("a.idx == x ? False")),
+                                Term::bool(false).delayed_trace(Term::string("a.idx == x ? False")),
                             )
                             .lambda("x")
                             .apply(
@@ -2830,11 +2830,11 @@ fn when_tuple_deconstruction() {
                     .apply(Term::var("dat"))
                     .apply(Term::var("red")),
             )
-            .delayed_if_else(
+            .delayed_if_then_else(
                 Term::unit(),
                 Term::Error
                     .apply(Term::Error.force())
-                    .trace(Term::string("Validator returned false")),
+                    .delayed_trace(Term::string("Validator returned false")),
             )
             .lambda("_")
             .apply(
@@ -2844,12 +2844,12 @@ fn when_tuple_deconstruction() {
                         Term::equals_integer()
                             .apply(Term::integer(0.into()))
                             .apply(Term::var("subject"))
-                            .delayed_if_else(
+                            .delayed_if_then_else(
                                 Term::tail_list()
                                     .apply(Term::var("red_constr_fields"))
                                     .delayed_choose_list(
                                         Term::unit(),
-                                        Term::Error.trace(Term::var(TOO_MANY_ITEMS)),
+                                        Term::Error.delayed_trace(Term::var(TOO_MANY_ITEMS)),
                                     )
                                     .lambda("field_1")
                                     .apply(Term::un_i_data().apply(
@@ -2862,14 +2862,15 @@ fn when_tuple_deconstruction() {
                                 Term::equals_integer()
                                     .apply(Term::integer(1.into()))
                                     .apply(Term::var("subject"))
-                                    .delayed_if_else(
+                                    .delayed_if_then_else(
                                         Term::var(CONSTR_FIELDS_EXPOSER)
                                             .apply(Term::var("red"))
                                             .delayed_choose_list(
                                                 Term::unit(),
-                                                Term::Error.trace(Term::var(CONSTR_NOT_EMPTY)),
+                                                Term::Error
+                                                    .delayed_trace(Term::var(CONSTR_NOT_EMPTY)),
                                             ),
-                                        Term::Error.trace(Term::var(CONSTR_INDEX_MISMATCH)),
+                                        Term::Error.delayed_trace(Term::var(CONSTR_INDEX_MISMATCH)),
                                     ),
                             )
                             .lambda("subject")
@@ -2888,14 +2889,14 @@ fn when_tuple_deconstruction() {
                         Term::equals_integer()
                             .apply(Term::integer(0.into()))
                             .apply(Term::var("subject"))
-                            .delayed_if_else(
+                            .delayed_if_then_else(
                                 Term::tail_list()
                                     .apply(Term::var("dat_constr_fields"))
                                     .delayed_choose_list(
                                         Term::unit().lambda("_").apply(
                                             Term::var("expect_Thing").apply(Term::var("field_1")),
                                         ),
-                                        Term::Error.trace(Term::var(TOO_MANY_ITEMS)),
+                                        Term::Error.delayed_trace(Term::var(TOO_MANY_ITEMS)),
                                     )
                                     .lambda("field_1")
                                     .apply(Term::head_list().apply(Term::var("dat_constr_fields")))
@@ -2906,14 +2907,15 @@ fn when_tuple_deconstruction() {
                                 Term::equals_integer()
                                     .apply(Term::integer(1.into()))
                                     .apply(Term::var("subject"))
-                                    .delayed_if_else(
+                                    .delayed_if_then_else(
                                         Term::var(CONSTR_FIELDS_EXPOSER)
                                             .apply(Term::var("dat"))
                                             .delayed_choose_list(
                                                 Term::unit(),
-                                                Term::Error.trace(Term::var(CONSTR_NOT_EMPTY)),
+                                                Term::Error
+                                                    .delayed_trace(Term::var(CONSTR_NOT_EMPTY)),
                                             ),
-                                        Term::Error.trace(Term::var(CONSTR_INDEX_MISMATCH)),
+                                        Term::Error.delayed_trace(Term::var(CONSTR_INDEX_MISMATCH)),
                                     ),
                             )
                             .lambda("subject")
@@ -2925,12 +2927,12 @@ fn when_tuple_deconstruction() {
                         Term::equals_integer()
                             .apply(Term::integer(0.into()))
                             .apply(Term::var("subject"))
-                            .delayed_if_else(
+                            .delayed_if_then_else(
                                 Term::tail_list()
                                     .apply(Term::var("field_1_constr_fields"))
                                     .delayed_choose_list(
                                         Term::unit(),
-                                        Term::Error.trace(Term::var(TOO_MANY_ITEMS)),
+                                        Term::Error.delayed_trace(Term::var(TOO_MANY_ITEMS)),
                                     )
                                     .lambda("idx")
                                     .apply(Term::un_i_data().apply(
@@ -2941,7 +2943,7 @@ fn when_tuple_deconstruction() {
                                         Term::var(CONSTR_FIELDS_EXPOSER)
                                             .apply(Term::var("field_1")),
                                     ),
-                                Term::Error.trace(Term::var(CONSTR_INDEX_MISMATCH)),
+                                Term::Error.delayed_trace(Term::var(CONSTR_INDEX_MISMATCH)),
                             )
                             .lambda("subject")
                             .apply(Term::var(CONSTR_INDEX_EXPOSER).apply(Term::var("field_1")))
@@ -3081,7 +3083,7 @@ fn generic_validator_type_test() {
         Term::equals_integer()
             .apply(Term::integer(0.into()))
             .apply(Term::var("subject"))
-            .delayed_if_else(
+            .delayed_if_then_else(
                 Term::bool(false),
                 Term::choose_unit(
                     Term::var("something"),
@@ -3097,7 +3099,7 @@ fn generic_validator_type_test() {
                                     .apply(Term::head_list().apply(Term::var("B_fields"))),
                             ),
                         )
-                        .delayed_if_else(Term::unit(), Term::Error),
+                        .delayed_if_then_else(Term::unit(), Term::Error),
                 )
                 .lambda("B_fields")
                 .apply(Term::var(CONSTR_FIELDS_EXPOSER).apply(Term::var("field_B")))
@@ -3110,11 +3112,11 @@ fn generic_validator_type_test() {
             )
             .lambda("subject")
             .apply(Term::var(CONSTR_INDEX_EXPOSER).apply(Term::var("r")))
-            .delayed_if_else(
+            .delayed_if_then_else(
                 Term::unit(),
                 Term::Error
                     .apply(Term::Error.force())
-                    .trace(Term::string("Validator returned false")),
+                    .delayed_trace(Term::string("Validator returned false")),
             )
             .lambda("_")
             .apply(
@@ -3124,17 +3126,17 @@ fn generic_validator_type_test() {
                         Term::equals_integer()
                             .apply(Term::integer(0.into()))
                             .apply(Term::var("subject"))
-                            .delayed_if_else(
+                            .delayed_if_then_else(
                                 Term::var(CONSTR_FIELDS_EXPOSER)
                                     .apply(Term::var("r"))
                                     .delayed_choose_list(
                                         Term::unit(),
-                                        Term::Error.trace(Term::var(CONSTR_NOT_EMPTY)),
+                                        Term::Error.delayed_trace(Term::var(CONSTR_NOT_EMPTY)),
                                     ),
                                 Term::equals_integer()
                                     .apply(Term::integer(1.into()))
                                     .apply(Term::var("subject"))
-                                    .delayed_if_else(
+                                    .delayed_if_then_else(
                                         Term::tail_list()
                                             .apply(Term::var("tail_1"))
                                             .delayed_choose_list(
@@ -3142,7 +3144,8 @@ fn generic_validator_type_test() {
                                                     Term::var("__expect_B")
                                                         .apply(Term::var("field_B")),
                                                 ),
-                                                Term::Error.trace(Term::var(TOO_MANY_ITEMS)),
+                                                Term::Error
+                                                    .delayed_trace(Term::var(TOO_MANY_ITEMS)),
                                             )
                                             .lambda("field_B")
                                             .apply(Term::head_list().apply(Term::var("tail_1")))
@@ -3160,14 +3163,17 @@ fn generic_validator_type_test() {
                                                             ),
                                                         ),
                                                     )
-                                                    .delayed_if_else(Term::unit(), Term::Error),
+                                                    .delayed_if_then_else(
+                                                        Term::unit(),
+                                                        Term::Error,
+                                                    ),
                                             )
                                             .lambda("r_fields")
                                             .apply(
                                                 Term::var(CONSTR_FIELDS_EXPOSER)
                                                     .apply(Term::var("r")),
                                             ),
-                                        Term::Error.trace(Term::var(CONSTR_INDEX_MISMATCH)),
+                                        Term::Error.delayed_trace(Term::var(CONSTR_INDEX_MISMATCH)),
                                     ),
                             )
                             .lambda("subject")
@@ -3179,12 +3185,12 @@ fn generic_validator_type_test() {
                         Term::equals_integer()
                             .apply(Term::integer(0.into()))
                             .apply(Term::var("subject"))
-                            .delayed_if_else(
+                            .delayed_if_then_else(
                                 Term::tail_list()
                                     .apply(Term::var("B_fields"))
                                     .delayed_choose_list(
                                         Term::unit(),
-                                        Term::Error.trace(Term::var(TOO_MANY_ITEMS)),
+                                        Term::Error.delayed_trace(Term::var(TOO_MANY_ITEMS)),
                                     )
                                     .lambda("something")
                                     .apply(
@@ -3195,14 +3201,14 @@ fn generic_validator_type_test() {
                                                     Term::head_list().apply(Term::var("B_fields")),
                                                 ),
                                             ))
-                                            .delayed_if_else(Term::unit(), Term::Error),
+                                            .delayed_if_then_else(Term::unit(), Term::Error),
                                     )
                                     .lambda("B_fields")
                                     .apply(
                                         Term::var(CONSTR_FIELDS_EXPOSER)
                                             .apply(Term::var("field_B")),
                                     ),
-                                Term::Error.trace(Term::var(CONSTR_INDEX_MISMATCH)),
+                                Term::Error.delayed_trace(Term::var(CONSTR_INDEX_MISMATCH)),
                             )
                             .lambda("subject")
                             .apply(Term::var(CONSTR_INDEX_EXPOSER).apply(Term::var("field_B")))
@@ -3656,9 +3662,9 @@ fn list_fields_unwrap() {
                     vec![Data::bytestring(vec![170]), Data::integer(0.into())],
                 )),
             ]))
-            .delayed_if_else(
+            .delayed_if_then_else(
                 Term::bool(true),
-                Term::bool(true).if_else(Term::bool(false), Term::bool(true)),
+                Term::bool(true).if_then_else(Term::bool(false), Term::bool(true)),
             )
             .constr_fields_exposer(),
         false,
@@ -3762,13 +3768,13 @@ fn foldl_type_mismatch() {
                         Term::equals_integer()
                             .apply(Term::integer(1.into()))
                             .apply(Term::var("mb_b_index"))
-                            .delayed_if_else(
+                            .delayed_if_then_else(
                                 Term::equals_data()
                                     .apply(Term::head_list().apply(
                                         Term::var(CONSTR_FIELDS_EXPOSER).apply(Term::var("o")),
                                     ))
                                     .apply(Term::var("addr1"))
-                                    .delayed_if_else(
+                                    .delayed_if_then_else(
                                         Term::constr_data().apply(Term::integer(0.into())).apply(
                                             Term::mk_cons()
                                                 .apply(Term::var("o"))
@@ -3878,7 +3884,7 @@ fn expect_head_no_tail() {
                 Term::equals_integer()
                     .apply(Term::var("h"))
                     .apply(Term::var("h")),
-                Term::Error.trace(Term::string(
+                Term::Error.delayed_trace(Term::string(
                     "List/Tuple/Constr contains more items than expected",
                 )),
             )
@@ -3912,19 +3918,19 @@ fn expect_head3_no_tail() {
                 Term::equals_integer()
                     .apply(Term::var("h"))
                     .apply(Term::var("h"))
-                    .delayed_if_else(
+                    .delayed_if_then_else(
                         Term::equals_integer()
                             .apply(Term::var("i"))
                             .apply(Term::var("i")),
                         Term::bool(false),
                     )
-                    .delayed_if_else(
+                    .delayed_if_then_else(
                         Term::equals_integer()
                             .apply(Term::var("j"))
                             .apply(Term::var("j")),
                         Term::bool(false),
                     ),
-                Term::Error.trace(Term::string(
+                Term::Error.delayed_trace(Term::string(
                     "List/Tuple/Constr contains more items than expected",
                 )),
             )
@@ -3966,19 +3972,19 @@ fn expect_head3_cast_data_no_tail() {
                 Term::equals_integer()
                     .apply(Term::var("h"))
                     .apply(Term::var("h"))
-                    .delayed_if_else(
+                    .delayed_if_then_else(
                         Term::equals_integer()
                             .apply(Term::var("i"))
                             .apply(Term::var("i")),
                         Term::bool(false),
                     )
-                    .delayed_if_else(
+                    .delayed_if_then_else(
                         Term::equals_integer()
                             .apply(Term::var("j"))
                             .apply(Term::var("j")),
                         Term::bool(false),
                     ),
-                Term::Error.trace(Term::string(
+                Term::Error.delayed_trace(Term::string(
                     "List/Tuple/Constr contains more items than expected",
                 )),
             )
@@ -4024,7 +4030,7 @@ fn expect_head_cast_data_no_tail() {
                 Term::equals_integer()
                     .apply(Term::var("h"))
                     .apply(Term::var("h")),
-                Term::Error.trace(Term::string(
+                Term::Error.delayed_trace(Term::string(
                     "List/Tuple/Constr contains more items than expected",
                 )),
             )
@@ -4163,7 +4169,7 @@ fn test_init_3() {
                     .apply(
                         Term::var("self")
                             .delayed_choose_list(
-                                Term::Error.trace(Term::string("unreachable")),
+                                Term::Error.delayed_trace(Term::string("unreachable")),
                                 Term::var("tail_1")
                                     .delayed_choose_list(
                                         Term::empty_list(),
@@ -4241,14 +4247,14 @@ fn list_clause_with_guard() {
                         .apply(
                             Term::var("self")
                                 .delayed_choose_list(
-                                    Term::Error.trace(Term::string("unreachable")),
+                                    Term::Error.delayed_trace(Term::string("unreachable")),
                                     Term::var("tail_1")
                                         .delayed_choose_list(
                                             Term::empty_list(),
                                             Term::var("tail_2")
                                                 .choose_list(
                                                     Term::var("clause_guard")
-                                                        .if_else(
+                                                        .if_then_else(
                                                             Term::mk_cons()
                                                                 .apply(
                                                                     Term::i_data()
@@ -4380,14 +4386,14 @@ fn list_clause_with_guard2() {
                         .apply(
                             Term::var("self")
                                 .delayed_choose_list(
-                                    Term::Error.trace(Term::string("unreachable")),
+                                    Term::Error.delayed_trace(Term::string("unreachable")),
                                     Term::var("tail_1")
                                         .delayed_choose_list(
                                             Term::empty_list(),
                                             Term::var("tail_1")
                                                 .choose_list(
                                                     Term::var("clause_guard")
-                                                        .if_else(
+                                                        .if_then_else(
                                                             Term::empty_list().delay(),
                                                             Term::var("clauses_delayed"),
                                                         )
@@ -4512,14 +4518,14 @@ fn list_clause_with_guard3() {
                         .apply(
                             Term::var("self")
                                 .delayed_choose_list(
-                                    Term::Error.trace(Term::string("unreachable")),
+                                    Term::Error.delayed_trace(Term::string("unreachable")),
                                     Term::var("tail_1")
                                         .delayed_choose_list(
                                             Term::empty_list(),
                                             Term::var("self")
                                                 .choose_list(
                                                     Term::var("clause_guard")
-                                                        .if_else(
+                                                        .if_then_else(
                                                             Term::var("g").delay(),
                                                             Term::var("clauses_delayed"),
                                                         )
@@ -4651,14 +4657,14 @@ fn list_clause_with_assign() {
                         .apply(
                             Term::var("self")
                                 .delayed_choose_list(
-                                    Term::Error.trace(Term::string("unreachable")),
+                                    Term::Error.delayed_trace(Term::string("unreachable")),
                                     Term::var("tail_1")
                                         .delayed_choose_list(
                                             Term::var("self"),
                                             Term::var("tail_2")
                                                 .choose_list(
                                                     Term::var("clause_guard")
-                                                        .if_else(
+                                                        .if_then_else(
                                                             Term::mk_cons()
                                                                 .apply(
                                                                     Term::i_data()
@@ -4797,7 +4803,7 @@ fn list_clause_with_assign2() {
                         .apply(
                             Term::var("self")
                                 .delayed_choose_list(
-                                    Term::Error.trace(Term::string("unreachable")),
+                                    Term::Error.delayed_trace(Term::string("unreachable")),
                                     Term::var("tail_1")
                                         .delayed_choose_list(
                                             Term::var("self"),
@@ -4809,7 +4815,7 @@ fn list_clause_with_assign2() {
                                                             Term::var(CONSTR_INDEX_EXPOSER)
                                                                 .apply(Term::var("n")),
                                                         )
-                                                        .if_else(
+                                                        .if_then_else(
                                                             Term::mk_cons()
                                                                 .apply(Term::var("n"))
                                                                 .apply(Term::empty_list())
@@ -4942,7 +4948,7 @@ fn opaque_value_in_datum() {
                     .apply(
                         Term::unmap_data().apply(Term::snd_pair().apply(Term::var("tuple_item_0"))),
                     ),
-                Term::Error.trace(Term::var(TOO_MANY_ITEMS)),
+                Term::Error.delayed_trace(Term::var(TOO_MANY_ITEMS)),
             )
             .lambda("tuple_item_0")
             .apply(Term::head_list().apply(Term::var("val")))
@@ -4955,18 +4961,18 @@ fn opaque_value_in_datum() {
                         .apply(Term::var(CONSTR_FIELDS_EXPOSER).apply(Term::var("dat"))),
                 ),
             )
-            .delayed_if_else(
+            .delayed_if_then_else(
                 Term::unit(),
                 Term::Error
                     .apply(Term::Error.force())
-                    .trace(Term::string("Validator returned false")),
+                    .delayed_trace(Term::string("Validator returned false")),
             )
             .lambda("_")
             .apply(
                 Term::equals_integer()
                     .apply(Term::integer(0.into()))
                     .apply(Term::var("subject"))
-                    .delayed_if_else(
+                    .delayed_if_then_else(
                         Term::tail_list()
                             .apply(Term::var("tail_1"))
                             .delayed_choose_list(
@@ -4996,7 +5002,7 @@ fn opaque_value_in_datum() {
                                             .lambda("pair_outer"),
                                     ),
                                 ),
-                                Term::Error.trace(Term::var(TOO_MANY_ITEMS)),
+                                Term::Error.delayed_trace(Term::var(TOO_MANY_ITEMS)),
                             )
                             .lambda("a")
                             .apply(
@@ -5012,7 +5018,9 @@ fn opaque_value_in_datum() {
                             )
                             .lambda("dat_fields")
                             .apply(Term::var(CONSTR_FIELDS_EXPOSER).apply(Term::var("param_0"))),
-                        Term::Error.trace(Term::string("Constr index didn't match a type variant")),
+                        Term::Error.delayed_trace(Term::string(
+                            "Constr index didn't match a type variant",
+                        )),
                     )
                     .lambda("subject")
                     .apply(Term::var(CONSTR_INDEX_EXPOSER).apply(Term::var("param_0")))
@@ -5115,7 +5123,7 @@ fn opaque_value_in_test() {
                     .apply(
                         Term::unmap_data().apply(Term::snd_pair().apply(Term::var("tuple_item_0"))),
                     ),
-                Term::Error.trace(Term::string(
+                Term::Error.delayed_trace(Term::string(
                     "List/Tuple/Constr contains more items than expected",
                 )),
             )
@@ -5171,9 +5179,9 @@ fn expect_none() {
         Term::equals_integer()
             .apply(Term::integer(1.into()))
             .apply(Term::var(CONSTR_INDEX_EXPOSER).apply(Term::var("x")))
-            .delayed_if_else(
+            .delayed_if_then_else(
                 Term::bool(true),
-                Term::Error.trace(Term::string("Expected on incorrect Constr variant")),
+                Term::Error.delayed_trace(Term::string("Expected on incorrect Constr variant")),
             )
             .lambda("x")
             .apply(Term::Constant(
@@ -5223,24 +5231,24 @@ fn tuple_2_match() {
                 Term::equals_integer()
                     .apply(Term::integer(0.into()))
                     .apply(Term::var(CONSTR_INDEX_EXPOSER).apply(Term::var("tuple_index_0")))
-                    .if_else(
+                    .if_then_else(
                         Term::equals_integer()
                             .apply(Term::integer(0.into()))
                             .apply(
                                 Term::var(CONSTR_INDEX_EXPOSER).apply(Term::var("tuple_index_1")),
                             )
-                            .if_else(
+                            .if_then_else(
                                 Term::equals_integer()
                                     .apply(
-                                        Term::sub_integer()
+                                        Term::subtract_integer()
                                             .apply(Term::var("x2"))
                                             .apply(Term::var("x1")),
                                     )
                                     .apply(Term::integer(0.into()))
-                                    .delayed_if_else(
+                                    .delayed_if_then_else(
                                         Term::equals_integer()
                                             .apply(
-                                                Term::sub_integer()
+                                                Term::subtract_integer()
                                                     .apply(Term::var("y2"))
                                                     .apply(Term::var("y1")),
                                             )
@@ -5324,14 +5332,17 @@ fn tuple_2_match() {
                             .apply(
                                 Term::var(CONSTR_INDEX_EXPOSER).apply(Term::var("tuple_index_0")),
                             )
-                            .if_else(
+                            .if_then_else(
                                 Term::equals_integer()
                                     .apply(Term::integer(1.into()))
                                     .apply(
                                         Term::var(CONSTR_INDEX_EXPOSER)
                                             .apply(Term::var("tuple_index_1")),
                                     )
-                                    .if_else(Term::bool(true).delay(), Term::var("clauses_delayed"))
+                                    .if_then_else(
+                                        Term::bool(true).delay(),
+                                        Term::var("clauses_delayed"),
+                                    )
                                     .force()
                                     .delay(),
                                 Term::var("clauses_delayed"),
@@ -5345,14 +5356,14 @@ fn tuple_2_match() {
                                         Term::var(CONSTR_INDEX_EXPOSER)
                                             .apply(Term::var("tuple_index_0")),
                                     )
-                                    .if_else(
+                                    .if_then_else(
                                         Term::equals_integer()
                                             .apply(Term::integer(0.into()))
                                             .apply(
                                                 Term::var(CONSTR_INDEX_EXPOSER)
                                                     .apply(Term::var("tuple_index_1")),
                                             )
-                                            .if_else(
+                                            .if_then_else(
                                                 Term::bool(false).delay(),
                                                 Term::var("clauses_delayed"),
                                             )
@@ -5382,9 +5393,9 @@ fn tuple_2_match() {
             )
             .apply(Term::data(Data::constr(1, vec![])))
             .apply(Term::data(Data::constr(1, vec![])))
-            .delayed_if_else(
+            .delayed_if_then_else(
                 Term::bool(true),
-                Term::bool(true).if_else(Term::bool(false), Term::bool(true)),
+                Term::bool(true).if_then_else(Term::bool(false), Term::bool(true)),
             )
             .constr_index_exposer()
             .constr_fields_exposer(),

--- a/crates/uplc/src/builder.rs
+++ b/crates/uplc/src/builder.rs
@@ -80,8 +80,6 @@ impl<T> Term<T> {
     // Theses are in _alphabetical order_
     // The naming convention almost follows PascalCase -> snake_case
     // Exceptions include the use of `un`.
-    // FIXME: All cases of `bytearray` are "wrong" and should be `byte_string`
-    // FIXME: All missing cases are to be added as needed
 
     pub fn add_integer() -> Self {
         Term::Builtin(DefaultFunction::AddInteger)
@@ -101,6 +99,24 @@ impl<T> Term<T> {
 
     pub fn blake2b_256() -> Self {
         Term::Builtin(DefaultFunction::Blake2b_256)
+    }
+
+    pub fn choose_data(
+        self,
+        constr_case: Self,
+        map_case: Self,
+        array_case: Self,
+        int_case: Self,
+        bytes_case: Self,
+    ) -> Self {
+        Term::Builtin(DefaultFunction::ChooseData)
+            .force()
+            .apply(self)
+            .apply(constr_case)
+            .apply(map_case)
+            .apply(array_case)
+            .apply(int_case)
+            .apply(bytes_case)
     }
 
     pub fn choose_list(self, then_term: Self, else_term: Self) -> Self {
@@ -171,8 +187,7 @@ impl<T> Term<T> {
         Term::Builtin(DefaultFunction::IData)
     }
 
-    pub fn if_else(self, then_term: Self, else_term: Self) -> Self {
-        // FIXME : rename if_then_else
+    pub fn if_then_else(self, then_term: Self, else_term: Self) -> Self {
         Term::Builtin(DefaultFunction::IfThenElse)
             .force()
             .apply(self)
@@ -252,8 +267,7 @@ impl<T> Term<T> {
         Term::Builtin(DefaultFunction::SndPair).force().force()
     }
 
-    pub fn sub_integer() -> Self {
-        // FIXME :: rename subtract_integer
+    pub fn subtract_integer() -> Self {
         Term::Builtin(DefaultFunction::SubtractInteger)
     }
 
@@ -292,52 +306,22 @@ impl<T> Term<T> {
         Term::Builtin(DefaultFunction::VerifySchnorrSecp256k1Signature)
     }
 
-    // FIXME : The following builders are missing
-    // pub fn null_list() -> Self {
-    //     Term::Builtin(DefaultFunction::NullList)
-    // }
-    // pub fn choose_data() -> Self {
-    //     Term::Builtin(DefaultFunction::ChooseData)
-    // }
-    // pub fn serialise_data() -> Self {
-    //     Term::Builtin(DefaultFunction::SerialiseData)
-    // }
-    // pub fn mk_nil_data() -> Self {
-    //     Term::Builtin(DefaultFunction::MkNilData)
-    // }
-    // pub fn mk_nil_pair_data() -> Self {
-    //     Term::Builtin(DefaultFunction::MkNilPairData)
-    // }
+    // Unused bultins
+    pub fn mk_nil_data() -> Self {
+        Term::Builtin(DefaultFunction::MkNilData)
+    }
+    pub fn mk_nil_pair_data() -> Self {
+        Term::Builtin(DefaultFunction::MkNilPairData)
+    }
+    pub fn null_list() -> Self {
+        Term::Builtin(DefaultFunction::NullList)
+    }
+    pub fn serialise_data() -> Self {
+        Term::Builtin(DefaultFunction::SerialiseData)
+    }
 }
 
 impl<T> Term<T> {
-    pub fn delayed_choose_list(self, then_term: Self, else_term: Self) -> Self {
-        Term::Builtin(DefaultFunction::ChooseList)
-            .force()
-            .force()
-            .apply(self)
-            .apply(then_term.delay())
-            .apply(else_term.delay())
-            .force()
-    }
-
-    pub fn delayed_choose_unit(self, then_term: Self) -> Self {
-        Term::Builtin(DefaultFunction::ChooseUnit)
-            .force()
-            .apply(self)
-            .apply(then_term.delay())
-            .force()
-    }
-
-    pub fn delayed_if_else(self, then_term: Self, else_term: Self) -> Self {
-        Term::Builtin(DefaultFunction::IfThenElse)
-            .force()
-            .apply(self)
-            .apply(then_term.delay())
-            .apply(else_term.delay())
-            .force()
-    }
-
     pub fn delayed_choose_data(
         self,
         constr_case: Self,
@@ -357,7 +341,34 @@ impl<T> Term<T> {
             .force()
     }
 
-    pub fn trace(self, msg_term: Self) -> Self {
+    pub fn delayed_choose_list(self, then_term: Self, else_term: Self) -> Self {
+        Term::Builtin(DefaultFunction::ChooseList)
+            .force()
+            .force()
+            .apply(self)
+            .apply(then_term.delay())
+            .apply(else_term.delay())
+            .force()
+    }
+
+    pub fn delayed_choose_unit(self, then_term: Self) -> Self {
+        Term::Builtin(DefaultFunction::ChooseUnit)
+            .force()
+            .apply(self)
+            .apply(then_term.delay())
+            .force()
+    }
+
+    pub fn delayed_if_then_else(self, then_term: Self, else_term: Self) -> Self {
+        Term::Builtin(DefaultFunction::IfThenElse)
+            .force()
+            .apply(self)
+            .apply(then_term.delay())
+            .apply(else_term.delay())
+            .force()
+    }
+
+    pub fn delayed_trace(self, msg_term: Self) -> Self {
         Term::Builtin(DefaultFunction::Trace)
             .force()
             .apply(msg_term)
@@ -365,6 +376,7 @@ impl<T> Term<T> {
             .force()
     }
 
+    // Misc.
     pub fn repeat_tail_list(self, repeat: usize) -> Self {
         let mut term = self;
 
@@ -388,6 +400,7 @@ impl Term<Name> {
         Term::Var(Name::text(name).into())
     }
 
+    // Misc.
     pub fn constr_fields_exposer(self) -> Self {
         self.lambda(CONSTR_FIELDS_EXPOSER).apply(
             Term::snd_pair()

--- a/crates/uplc/src/builder.rs
+++ b/crates/uplc/src/builder.rs
@@ -76,181 +76,31 @@ impl<T> Term<T> {
         )
     }
 
-    // Builtins
-    pub fn constr_data() -> Self {
-        Term::Builtin(DefaultFunction::ConstrData)
-    }
-
-    pub fn map_data() -> Self {
-        Term::Builtin(DefaultFunction::MapData)
-    }
-
-    pub fn list_data() -> Self {
-        Term::Builtin(DefaultFunction::ListData)
-    }
-
-    pub fn b_data() -> Self {
-        Term::Builtin(DefaultFunction::BData)
-    }
-
-    pub fn i_data() -> Self {
-        Term::Builtin(DefaultFunction::IData)
-    }
-
-    pub fn unconstr_data() -> Self {
-        Term::Builtin(DefaultFunction::UnConstrData)
-    }
-
-    pub fn un_i_data() -> Self {
-        Term::Builtin(DefaultFunction::UnIData)
-    }
-
-    pub fn un_b_data() -> Self {
-        Term::Builtin(DefaultFunction::UnBData)
-    }
-
-    pub fn unmap_data() -> Self {
-        Term::Builtin(DefaultFunction::UnMapData)
-    }
-
-    pub fn unlist_data() -> Self {
-        Term::Builtin(DefaultFunction::UnListData)
-    }
-
-    pub fn equals_integer() -> Self {
-        Term::Builtin(DefaultFunction::EqualsInteger)
-    }
-
-    pub fn less_than_integer() -> Self {
-        Term::Builtin(DefaultFunction::LessThanInteger)
-    }
-
-    pub fn less_than_equals_integer() -> Self {
-        Term::Builtin(DefaultFunction::LessThanEqualsInteger)
-    }
-
-    pub fn equals_string() -> Self {
-        Term::Builtin(DefaultFunction::EqualsString)
-    }
-
-    pub fn equals_bytestring() -> Self {
-        Term::Builtin(DefaultFunction::EqualsByteString)
-    }
-
-    pub fn less_than_bytearray() -> Self {
-        Term::Builtin(DefaultFunction::LessThanByteString)
-    }
-
-    pub fn less_than_equals_bytearray() -> Self {
-        Term::Builtin(DefaultFunction::LessThanEqualsByteString)
-    }
-
-    pub fn equals_data() -> Self {
-        Term::Builtin(DefaultFunction::EqualsData)
-    }
+    // This section contains builders for builtins from default functions
+    // Theses are in _alphabetical order_
+    // The naming convention almost follows PascalCase -> snake_case
+    // Exceptions include the use of `un`.
+    // FIXME: All cases of `bytearray` are "wrong" and should be `byte_string`
+    // FIXME: All missing cases are to be added as needed
 
     pub fn add_integer() -> Self {
         Term::Builtin(DefaultFunction::AddInteger)
-    }
-
-    pub fn sub_integer() -> Self {
-        Term::Builtin(DefaultFunction::SubtractInteger)
-    }
-
-    pub fn div_integer() -> Self {
-        Term::Builtin(DefaultFunction::DivideInteger)
-    }
-
-    pub fn mod_integer() -> Self {
-        Term::Builtin(DefaultFunction::ModInteger)
-    }
-
-    pub fn length_of_bytearray() -> Self {
-        Term::Builtin(DefaultFunction::LengthOfByteString)
-    }
-
-    pub fn cons_bytearray() -> Self {
-        Term::Builtin(DefaultFunction::ConsByteString)
-    }
-
-    pub fn slice_bytearray() -> Self {
-        Term::Builtin(DefaultFunction::SliceByteString)
     }
 
     pub fn append_bytearray() -> Self {
         Term::Builtin(DefaultFunction::AppendByteString)
     }
 
-    pub fn index_bytearray() -> Self {
-        Term::Builtin(DefaultFunction::IndexByteString)
-    }
-
-    pub fn sha2_256() -> Self {
-        Term::Builtin(DefaultFunction::Sha2_256)
-    }
-
-    pub fn sha3_256() -> Self {
-        Term::Builtin(DefaultFunction::Sha3_256)
-    }
-
-    pub fn blake2b_256() -> Self {
-        Term::Builtin(DefaultFunction::Blake2b_256)
-    }
-
-    pub fn verify_ed25519_signature() -> Self {
-        Term::Builtin(DefaultFunction::VerifyEd25519Signature)
-    }
-
-    pub fn verify_ecdsa_secp256k1_signature() -> Self {
-        Term::Builtin(DefaultFunction::VerifyEcdsaSecp256k1Signature)
-    }
-
-    pub fn verify_schnorr_secp256k1_signature() -> Self {
-        Term::Builtin(DefaultFunction::VerifySchnorrSecp256k1Signature)
-    }
-
-    pub fn decode_utf8() -> Self {
-        Term::Builtin(DefaultFunction::DecodeUtf8)
-    }
-
     pub fn append_string() -> Self {
         Term::Builtin(DefaultFunction::AppendString)
     }
 
-    pub fn encode_utf8() -> Self {
-        Term::Builtin(DefaultFunction::EncodeUtf8)
+    pub fn b_data() -> Self {
+        Term::Builtin(DefaultFunction::BData)
     }
 
-    pub fn head_list() -> Self {
-        Term::Builtin(DefaultFunction::HeadList).force()
-    }
-
-    pub fn tail_list() -> Self {
-        Term::Builtin(DefaultFunction::TailList).force()
-    }
-
-    pub fn mk_cons() -> Self {
-        Term::Builtin(DefaultFunction::MkCons).force()
-    }
-
-    pub fn fst_pair() -> Self {
-        Term::Builtin(DefaultFunction::FstPair).force().force()
-    }
-
-    pub fn snd_pair() -> Self {
-        Term::Builtin(DefaultFunction::SndPair).force().force()
-    }
-
-    pub fn mk_pair_data() -> Self {
-        Term::Builtin(DefaultFunction::MkPairData)
-    }
-
-    pub fn if_else(self, then_term: Self, else_term: Self) -> Self {
-        Term::Builtin(DefaultFunction::IfThenElse)
-            .force()
-            .apply(self)
-            .apply(then_term)
-            .apply(else_term)
+    pub fn blake2b_256() -> Self {
+        Term::Builtin(DefaultFunction::Blake2b_256)
     }
 
     pub fn choose_list(self, then_term: Self, else_term: Self) -> Self {
@@ -269,6 +119,208 @@ impl<T> Term<T> {
             .apply(then_term)
     }
 
+    pub fn cons_bytearray() -> Self {
+        Term::Builtin(DefaultFunction::ConsByteString)
+    }
+
+    pub fn constr_data() -> Self {
+        Term::Builtin(DefaultFunction::ConstrData)
+    }
+
+    pub fn decode_utf8() -> Self {
+        Term::Builtin(DefaultFunction::DecodeUtf8)
+    }
+
+    pub fn div_integer() -> Self {
+        Term::Builtin(DefaultFunction::DivideInteger)
+    }
+
+    pub fn divide_integer() -> Self {
+        Term::Builtin(DefaultFunction::DivideInteger)
+    }
+
+    pub fn encode_utf8() -> Self {
+        Term::Builtin(DefaultFunction::EncodeUtf8)
+    }
+
+    pub fn equals_bytestring() -> Self {
+        Term::Builtin(DefaultFunction::EqualsByteString)
+    }
+
+    pub fn equals_data() -> Self {
+        Term::Builtin(DefaultFunction::EqualsData)
+    }
+
+    pub fn equals_integer() -> Self {
+        Term::Builtin(DefaultFunction::EqualsInteger)
+    }
+
+    pub fn equals_string() -> Self {
+        Term::Builtin(DefaultFunction::EqualsString)
+    }
+
+    pub fn fst_pair() -> Self {
+        Term::Builtin(DefaultFunction::FstPair).force().force()
+    }
+
+    pub fn head_list() -> Self {
+        Term::Builtin(DefaultFunction::HeadList).force()
+    }
+
+    pub fn i_data() -> Self {
+        Term::Builtin(DefaultFunction::IData)
+    }
+
+    pub fn if_else(self, then_term: Self, else_term: Self) -> Self {
+        // FIXME : rename if_then_else
+        Term::Builtin(DefaultFunction::IfThenElse)
+            .force()
+            .apply(self)
+            .apply(then_term)
+            .apply(else_term)
+    }
+
+    pub fn index_bytearray() -> Self {
+        Term::Builtin(DefaultFunction::IndexByteString)
+    }
+
+    pub fn length_of_bytearray() -> Self {
+        Term::Builtin(DefaultFunction::LengthOfByteString)
+    }
+
+    pub fn less_than_bytearray() -> Self {
+        Term::Builtin(DefaultFunction::LessThanByteString)
+    }
+
+    pub fn less_than_equals_bytearray() -> Self {
+        Term::Builtin(DefaultFunction::LessThanEqualsByteString)
+    }
+
+    pub fn less_than_equals_integer() -> Self {
+        Term::Builtin(DefaultFunction::LessThanEqualsInteger)
+    }
+
+    pub fn less_than_integer() -> Self {
+        Term::Builtin(DefaultFunction::LessThanInteger)
+    }
+
+    pub fn list_data() -> Self {
+        Term::Builtin(DefaultFunction::ListData)
+    }
+
+    pub fn map_data() -> Self {
+        Term::Builtin(DefaultFunction::MapData)
+    }
+
+    pub fn mk_cons() -> Self {
+        Term::Builtin(DefaultFunction::MkCons).force()
+    }
+
+    pub fn mk_pair_data() -> Self {
+        Term::Builtin(DefaultFunction::MkPairData)
+    }
+
+    pub fn mod_integer() -> Self {
+        Term::Builtin(DefaultFunction::ModInteger)
+    }
+
+    pub fn multiply_integer() -> Self {
+        Term::Builtin(DefaultFunction::MultiplyInteger)
+    }
+
+    pub fn quotient_integer() -> Self {
+        Term::Builtin(DefaultFunction::QuotientInteger)
+    }
+
+    pub fn remainder_integer() -> Self {
+        Term::Builtin(DefaultFunction::RemainderInteger)
+    }
+
+    pub fn sha2_256() -> Self {
+        Term::Builtin(DefaultFunction::Sha2_256)
+    }
+
+    pub fn sha3_256() -> Self {
+        Term::Builtin(DefaultFunction::Sha3_256)
+    }
+
+    pub fn slice_bytearray() -> Self {
+        Term::Builtin(DefaultFunction::SliceByteString)
+    }
+
+    pub fn snd_pair() -> Self {
+        Term::Builtin(DefaultFunction::SndPair).force().force()
+    }
+
+    pub fn sub_integer() -> Self {
+        // FIXME :: rename subtract_integer
+        Term::Builtin(DefaultFunction::SubtractInteger)
+    }
+
+    pub fn tail_list() -> Self {
+        Term::Builtin(DefaultFunction::TailList).force()
+    }
+
+    pub fn un_b_data() -> Self {
+        Term::Builtin(DefaultFunction::UnBData)
+    }
+
+    pub fn un_i_data() -> Self {
+        Term::Builtin(DefaultFunction::UnIData)
+    }
+
+    pub fn unconstr_data() -> Self {
+        Term::Builtin(DefaultFunction::UnConstrData)
+    }
+
+    pub fn unlist_data() -> Self {
+        Term::Builtin(DefaultFunction::UnListData)
+    }
+    pub fn unmap_data() -> Self {
+        Term::Builtin(DefaultFunction::UnMapData)
+    }
+
+    pub fn verify_ecdsa_secp256k1_signature() -> Self {
+        Term::Builtin(DefaultFunction::VerifyEcdsaSecp256k1Signature)
+    }
+
+    pub fn verify_ed25519_signature() -> Self {
+        Term::Builtin(DefaultFunction::VerifyEd25519Signature)
+    }
+
+    pub fn verify_schnorr_secp256k1_signature() -> Self {
+        Term::Builtin(DefaultFunction::VerifySchnorrSecp256k1Signature)
+    }
+
+    // FIXME : The following builders are missing
+    // pub fn null_list() -> Self {
+    //     Term::Builtin(DefaultFunction::NullList)
+    // }
+    // pub fn choose_data() -> Self {
+    //     Term::Builtin(DefaultFunction::ChooseData)
+    // }
+    // pub fn serialise_data() -> Self {
+    //     Term::Builtin(DefaultFunction::SerialiseData)
+    // }
+    // pub fn mk_nil_data() -> Self {
+    //     Term::Builtin(DefaultFunction::MkNilData)
+    // }
+    // pub fn mk_nil_pair_data() -> Self {
+    //     Term::Builtin(DefaultFunction::MkNilPairData)
+    // }
+}
+
+impl<T> Term<T> {
+    pub fn delayed_choose_list(self, then_term: Self, else_term: Self) -> Self {
+        Term::Builtin(DefaultFunction::ChooseList)
+            .force()
+            .force()
+            .apply(self)
+            .apply(then_term.delay())
+            .apply(else_term.delay())
+            .force()
+    }
+
     pub fn delayed_choose_unit(self, then_term: Self) -> Self {
         Term::Builtin(DefaultFunction::ChooseUnit)
             .force()
@@ -279,16 +331,6 @@ impl<T> Term<T> {
 
     pub fn delayed_if_else(self, then_term: Self, else_term: Self) -> Self {
         Term::Builtin(DefaultFunction::IfThenElse)
-            .force()
-            .apply(self)
-            .apply(then_term.delay())
-            .apply(else_term.delay())
-            .force()
-    }
-
-    pub fn delayed_choose_list(self, then_term: Self, else_term: Self) -> Self {
-        Term::Builtin(DefaultFunction::ChooseList)
-            .force()
             .force()
             .apply(self)
             .apply(then_term.delay())

--- a/crates/uplc/src/machine.rs
+++ b/crates/uplc/src/machine.rs
@@ -495,7 +495,7 @@ mod tests {
                         ],
                     }
                     .into(),
-                    branches: vec![Term::Builtin(fun), Term::sub_integer()],
+                    branches: vec![Term::Builtin(fun), Term::subtract_integer()],
                 },
             };
 

--- a/crates/uplc/src/optimize/shrinker.rs
+++ b/crates/uplc/src/optimize/shrinker.rs
@@ -935,7 +935,7 @@ mod tests {
                         .apply(Term::integer(2.into()))
                         .apply(Term::var("y")),
                 )
-                .delayed_if_else(
+                .delayed_if_then_else(
                     Term::length_of_bytearray().apply(Term::byte_string(vec![])),
                     Term::Error,
                 )


### PR DESCRIPTION
- sort alphabetically
- add some of the missing builtins used for ints
- renames some of the builtins and the functions that use them