### PR TITLE
Fix pretty printing of bigint

### DIFF
--- a/crates/uplc/src/pretty.rs
+++ b/crates/uplc/src/pretty.rs
@@ -3,10 +3,10 @@ use crate::{
     flat::Binder,
     machine::runtime::Compressable,
 };
-use pallas_primitives::babbage::{Constr, PlutusData};
-use pretty::RcDoc;
 use num_bigint::BigInt;
 use num_bigint::Sign;
+use pallas_primitives::babbage::{Constr, PlutusData};
+use pretty::RcDoc;
 use std::ascii::escape_default;
 
 impl<'a, T> Program<T>
@@ -340,8 +340,12 @@ impl Constant {
                 .append(RcDoc::text("]")),
             PlutusData::BigInt(bi) => RcDoc::text("I").append(RcDoc::space()).append(match bi {
                 pallas_primitives::babbage::BigInt::Int(v) => RcDoc::text(v.to_string()),
-                pallas_primitives::babbage::BigInt::BigUInt(v) => RcDoc::text(BigInt::from_bytes_be(Sign::Plus, v).to_string()),
-                pallas_primitives::babbage::BigInt::BigNInt(v) => RcDoc::text(BigInt::from_bytes_be(Sign::Minus, v).to_string()),
+                pallas_primitives::babbage::BigInt::BigUInt(v) => {
+                    RcDoc::text(BigInt::from_bytes_be(Sign::Plus, v).to_string())
+                }
+                pallas_primitives::babbage::BigInt::BigNInt(v) => {
+                    RcDoc::text(BigInt::from_bytes_be(Sign::Minus, v).to_string())
+                }
             }),
             PlutusData::BoundedBytes(bs) => RcDoc::text("B")
                 .append(RcDoc::space())

--- a/crates/uplc/src/pretty.rs
+++ b/crates/uplc/src/pretty.rs
@@ -5,6 +5,8 @@ use crate::{
 };
 use pallas_primitives::babbage::{Constr, PlutusData};
 use pretty::RcDoc;
+use num_bigint::BigInt;
+use num_bigint::Sign;
 use std::ascii::escape_default;
 
 impl<'a, T> Program<T>
@@ -338,8 +340,8 @@ impl Constant {
                 .append(RcDoc::text("]")),
             PlutusData::BigInt(bi) => RcDoc::text("I").append(RcDoc::space()).append(match bi {
                 pallas_primitives::babbage::BigInt::Int(v) => RcDoc::text(v.to_string()),
-                pallas_primitives::babbage::BigInt::BigUInt(v) => RcDoc::text(v.to_string()),
-                pallas_primitives::babbage::BigInt::BigNInt(v) => RcDoc::text(v.to_string()),
+                pallas_primitives::babbage::BigInt::BigUInt(v) => RcDoc::text(BigInt::from_bytes_be(Sign::Plus, v).to_string()),
+                pallas_primitives::babbage::BigInt::BigNInt(v) => RcDoc::text(BigInt::from_bytes_be(Sign::Minus, v).to_string()),
             }),
             PlutusData::BoundedBytes(bs) => RcDoc::text("B")
                 .append(RcDoc::space())

--- a/crates/uplc/tests/pretty_tests.rs
+++ b/crates/uplc/tests/pretty_tests.rs
@@ -172,6 +172,10 @@ fn constant_data_int() {
     ).into());
     assert_eq!(term.to_pretty(), "(con data (I 131844))");
     let term = Term::<Name>::Constant(Constant::Data(
+        PlutusData::BigInt(pallas_primitives::alonzo::BigInt::BigUInt(vec![0].into())),
+    ).into());
+    assert_eq!(term.to_pretty(), "(con data (I 0))");
+    let term = Term::<Name>::Constant(Constant::Data(
         PlutusData::BigInt(pallas_primitives::alonzo::BigInt::BigNInt(vec![2,3,4].into())),
     ).into());
     assert_eq!(term.to_pretty(), "(con data (I -131844))");

--- a/crates/uplc/tests/pretty_tests.rs
+++ b/crates/uplc/tests/pretty_tests.rs
@@ -167,17 +167,26 @@ fn constant_data_int() {
         "(con data (I 2))",
     );
 
-    let term = Term::<Name>::Constant(Constant::Data(
-        PlutusData::BigInt(pallas_primitives::alonzo::BigInt::BigUInt(vec![2,3,4].into())),
-    ).into());
+    let term = Term::<Name>::Constant(
+        Constant::Data(PlutusData::BigInt(
+            pallas_primitives::alonzo::BigInt::BigUInt(vec![2, 3, 4].into()),
+        ))
+        .into(),
+    );
     assert_eq!(term.to_pretty(), "(con data (I 131844))");
-    let term = Term::<Name>::Constant(Constant::Data(
-        PlutusData::BigInt(pallas_primitives::alonzo::BigInt::BigUInt(vec![0].into())),
-    ).into());
+    let term = Term::<Name>::Constant(
+        Constant::Data(PlutusData::BigInt(
+            pallas_primitives::alonzo::BigInt::BigUInt(vec![0].into()),
+        ))
+        .into(),
+    );
     assert_eq!(term.to_pretty(), "(con data (I 0))");
-    let term = Term::<Name>::Constant(Constant::Data(
-        PlutusData::BigInt(pallas_primitives::alonzo::BigInt::BigNInt(vec![2,3,4].into())),
-    ).into());
+    let term = Term::<Name>::Constant(
+        Constant::Data(PlutusData::BigInt(
+            pallas_primitives::alonzo::BigInt::BigNInt(vec![2, 3, 4].into()),
+        ))
+        .into(),
+    );
     assert_eq!(term.to_pretty(), "(con data (I -131844))");
 }
 

--- a/crates/uplc/tests/pretty_tests.rs
+++ b/crates/uplc/tests/pretty_tests.rs
@@ -167,17 +167,14 @@ fn constant_data_int() {
         "(con data (I 2))",
     );
 
-    // TODO: large integers currently encode as bytestrings, which isn't great
-    /*
-    let term = Term::<DeBruijn>::Constant(Constant::Data(
+    let term = Term::<Name>::Constant(Constant::Data(
         PlutusData::BigInt(pallas_primitives::alonzo::BigInt::BigUInt(vec![2,3,4].into())),
     ).into());
     assert_eq!(term.to_pretty(), "(con data (I 131844))");
-    let term = Term::<DeBruijn>::Constant(Constant::Data(
-        PlutusData::BigInt(pallas_primitives::alonzo::BigInt::BigNInt(vec![FF,FD,FC,FC].into())),
+    let term = Term::<Name>::Constant(Constant::Data(
+        PlutusData::BigInt(pallas_primitives::alonzo::BigInt::BigNInt(vec![2,3,4].into())),
     ).into());
     assert_eq!(term.to_pretty(), "(con data (I -131844))");
-    */
 }
 
 #[test]


### PR DESCRIPTION
This fixes #782 (which seems to have been known for longer) and re-enables tests that check correct pretty printing.

The remaining open question is whether pallas stores BigNInt in two's complement (which seems superfluous since the type already points out that the bytes are of a negative integer).