### PR TITLE
Generics mini overhaul

### DIFF
--- a/crates/aiken-lang/src/gen_uplc/builder.rs
+++ b/crates/aiken-lang/src/gen_uplc/builder.rs
@@ -589,7 +589,7 @@ pub fn handle_clause_guard(clause_guard: &TypedClauseGuard) -> AirTree {
     }
 }
 
-pub fn get_variant_name(t: &Rc<Type>) -> String {
+pub fn get_generic_variant_name(t: &Rc<Type>) -> String {
     if t.is_string() {
         "_string".to_string()
     } else if t.is_int() {
@@ -605,27 +605,13 @@ pub fn get_variant_name(t: &Rc<Type>) -> String {
     } else if t.is_ml_result() {
         "_ml_result".to_string()
     } else if t.is_map() {
-        let mut full_type = vec!["_map".to_string()];
-        let pair_type = &t.get_inner_types()[0];
-        let fst_type = &pair_type.get_inner_types()[0];
-        let snd_type = &pair_type.get_inner_types()[1];
-        full_type.push(get_variant_name(fst_type));
-        full_type.push(get_variant_name(snd_type));
-        full_type.join("")
+        "_map".to_string()
+    } else if t.is_2_tuple() {
+        "_pair".to_string()
     } else if t.is_list() {
-        let full_type = "_list".to_string();
-        let list_type = &t.get_inner_types()[0];
-
-        format!("{}{}", full_type, get_variant_name(list_type))
+        "_list".to_string()
     } else if t.is_tuple() {
-        let mut full_type = vec!["_tuple".to_string()];
-
-        let inner_types = t.get_inner_types();
-
-        for arg_type in inner_types {
-            full_type.push(get_variant_name(&arg_type));
-        }
-        full_type.join("")
+        "_tuple".to_string()
     } else if t.is_unbound() {
         "_unbound".to_string()
     } else {

--- a/crates/aiken-lang/src/tipo.rs
+++ b/crates/aiken-lang/src/tipo.rs
@@ -186,15 +186,10 @@ impl Type {
         match self {
             Self::App {
                 module, name, args, ..
-            } if "List" == name && module.is_empty() => {
-                if let Type::Tuple { elems } = &*args[0] {
-                    elems.len() == 2
-                } else if let Type::Var { tipo } = &*args[0] {
-                    matches!(tipo.borrow().get_uplc_type(), Some(UplcType::Pair(_, _)))
-                } else {
-                    false
-                }
-            }
+            } if "List" == name && module.is_empty() => args
+                .first()
+                .expect("unreachable: List should have an inner type")
+                .is_2_tuple(),
             Self::Var { tipo } => tipo.borrow().is_map(),
             _ => false,
         }
@@ -322,6 +317,12 @@ impl Type {
                 Self::Var { tipo } => tipo.borrow().get_uplc_type().unwrap(),
                 _ => unreachable!(),
             }
+        } else if self.is_bls381_12_g1() {
+            UplcType::Bls12_381G1Element
+        } else if self.is_bls381_12_g2() {
+            UplcType::Bls12_381G2Element
+        } else if self.is_ml_result() {
+            UplcType::Bls12_381MlResult
         } else {
             UplcType::Data
         }

--- a/examples/acceptance_tests/036/aiken.lock
+++ b/examples/acceptance_tests/036/aiken.lock
@@ -13,4 +13,4 @@ requirements = []
 source = "github"
 
 [etags]
-"aiken-lang/stdlib@main" = [{ secs_since_epoch = 1704340543, nanos_since_epoch = 17966000 }, "cf946239d3dd481ed41f20e56bf24910b5229ea35aa171a708edc2a47fc20a7b"]
+"aiken-lang/stdlib@main" = [{ secs_since_epoch = 1705181051, nanos_since_epoch = 270212000 }, "cf946239d3dd481ed41f20e56bf24910b5229ea35aa171a708edc2a47fc20a7b"]

--- a/examples/acceptance_tests/036/plutus.json
+++ b/examples/acceptance_tests/036/plutus.json
@@ -5,7 +5,7 @@
     "plutusVersion": "v2",
     "compiler": {
       "name": "Aiken",
-      "version": "v1.0.21-alpha+631757e"
+      "version": "v1.0.21-alpha+0161cf6"
     }
   },
   "validators": [

--- a/examples/acceptance_tests/047/plutus.json
+++ b/examples/acceptance_tests/047/plutus.json
@@ -5,7 +5,7 @@
     "plutusVersion": "v2",
     "compiler": {
       "name": "Aiken",
-      "version": "v1.0.21-alpha+631757e"
+      "version": "v1.0.21-alpha+0161cf6"
     }
   },
   "validators": [

--- a/examples/acceptance_tests/054/aiken.lock
+++ b/examples/acceptance_tests/054/aiken.lock
@@ -13,4 +13,4 @@ requirements = []
 source = "github"
 
 [etags]
-"aiken-lang/stdlib@main" = [{ secs_since_epoch = 1704340540, nanos_since_epoch = 434572000 }, "cf946239d3dd481ed41f20e56bf24910b5229ea35aa171a708edc2a47fc20a7b"]
+"aiken-lang/stdlib@main" = [{ secs_since_epoch = 1705181048, nanos_since_epoch = 152219000 }, "cf946239d3dd481ed41f20e56bf24910b5229ea35aa171a708edc2a47fc20a7b"]

--- a/examples/acceptance_tests/055/aiken.lock
+++ b/examples/acceptance_tests/055/aiken.lock
@@ -13,4 +13,4 @@ requirements = []
 source = "github"
 
 [etags]
-"aiken-lang/stdlib@main" = [{ secs_since_epoch = 1704340543, nanos_since_epoch = 225382000 }, "cf946239d3dd481ed41f20e56bf24910b5229ea35aa171a708edc2a47fc20a7b"]
+"aiken-lang/stdlib@main" = [{ secs_since_epoch = 1705181051, nanos_since_epoch = 995566000 }, "cf946239d3dd481ed41f20e56bf24910b5229ea35aa171a708edc2a47fc20a7b"]

--- a/examples/acceptance_tests/061/aiken.lock
+++ b/examples/acceptance_tests/061/aiken.lock
@@ -13,4 +13,4 @@ requirements = []
 source = "github"
 
 [etags]
-"aiken-lang/stdlib@main" = [{ secs_since_epoch = 1704340554, nanos_since_epoch = 369598000 }, "cf946239d3dd481ed41f20e56bf24910b5229ea35aa171a708edc2a47fc20a7b"]
+"aiken-lang/stdlib@main" = [{ secs_since_epoch = 1705181064, nanos_since_epoch = 69739000 }, "cf946239d3dd481ed41f20e56bf24910b5229ea35aa171a708edc2a47fc20a7b"]

--- a/examples/acceptance_tests/063/aiken.lock
+++ b/examples/acceptance_tests/063/aiken.lock
@@ -13,4 +13,4 @@ requirements = []
 source = "github"
 
 [etags]
-"aiken-lang/stdlib@main" = [{ secs_since_epoch = 1704340543, nanos_since_epoch = 584877000 }, "cf946239d3dd481ed41f20e56bf24910b5229ea35aa171a708edc2a47fc20a7b"]
+"aiken-lang/stdlib@main" = [{ secs_since_epoch = 1705181052, nanos_since_epoch = 418642000 }, "cf946239d3dd481ed41f20e56bf24910b5229ea35aa171a708edc2a47fc20a7b"]

--- a/examples/acceptance_tests/067/aiken.lock
+++ b/examples/acceptance_tests/067/aiken.lock
@@ -13,4 +13,4 @@ requirements = []
 source = "github"
 
 [etags]
-"aiken-lang/stdlib@main" = [{ secs_since_epoch = 1704340557, nanos_since_epoch = 10227000 }, "cf946239d3dd481ed41f20e56bf24910b5229ea35aa171a708edc2a47fc20a7b"]
+"aiken-lang/stdlib@main" = [{ secs_since_epoch = 1705181066, nanos_since_epoch = 607926000 }, "cf946239d3dd481ed41f20e56bf24910b5229ea35aa171a708edc2a47fc20a7b"]

--- a/examples/acceptance_tests/068/aiken.lock
+++ b/examples/acceptance_tests/068/aiken.lock
@@ -13,4 +13,4 @@ requirements = []
 source = "github"
 
 [etags]
-"aiken-lang/stdlib@main" = [{ secs_since_epoch = 1704340555, nanos_since_epoch = 229103000 }, "cf946239d3dd481ed41f20e56bf24910b5229ea35aa171a708edc2a47fc20a7b"]
+"aiken-lang/stdlib@main" = [{ secs_since_epoch = 1705181064, nanos_since_epoch = 977089000 }, "cf946239d3dd481ed41f20e56bf24910b5229ea35aa171a708edc2a47fc20a7b"]

--- a/examples/acceptance_tests/069/aiken.lock
+++ b/examples/acceptance_tests/069/aiken.lock
@@ -13,4 +13,4 @@ requirements = []
 source = "github"
 
 [etags]
-"aiken-lang/stdlib@main" = [{ secs_since_epoch = 1705181054, nanos_since_epoch = 373675000 }, "cf946239d3dd481ed41f20e56bf24910b5229ea35aa171a708edc2a47fc20a7b"]
+"aiken-lang/stdlib@main" = [{ secs_since_epoch = 1705179899, nanos_since_epoch = 505049000 }, "cf946239d3dd481ed41f20e56bf24910b5229ea35aa171a708edc2a47fc20a7b"]

--- a/examples/acceptance_tests/069/aiken.toml
+++ b/examples/acceptance_tests/069/aiken.toml
@@ -1,0 +1,8 @@
+name = "aiken-lang/acceptance_test_069"
+version = '0.0.0'
+description = ''
+
+[[dependencies]]
+name = 'aiken-lang/stdlib'
+version = 'main'
+source = 'github'

--- a/examples/acceptance_tests/069/lib/tests.ak
+++ b/examples/acceptance_tests/069/lib/tests.ak
@@ -1,0 +1,97 @@
+pub fn generic_wrap(x: a) -> Option<a> {
+  Some(x)
+}
+
+pub fn generic_in_list(x: a) -> List<a> {
+  [x]
+}
+
+test multiple_wraps() {
+  let a = 1
+  let b = ""
+  let c =
+    [0]
+  let d =
+    [""]
+  let e =
+    []
+  let f = (1, "")
+  let g = ("", 1)
+  let h = (1, 2, "")
+  let i = None
+  let j = Some("")
+  let k =
+    [(1, "")]
+  let l =
+    [(2, 3, "")]
+
+  and {
+    generic_wrap(a) == Some(a),
+    generic_wrap(b) == Some(b),
+    generic_wrap(c) == Some(c),
+    generic_wrap(d) == Some(d),
+    generic_wrap(e) == Some(e),
+    generic_wrap(f) == Some(f),
+    generic_wrap(g) == Some(g),
+    generic_wrap(h) == Some(h),
+    generic_wrap(i) == Some(i),
+    generic_wrap(j) == Some(j),
+    generic_wrap(k) == Some(k),
+    generic_wrap(l) == Some(l),
+  }
+}
+
+test multiple_in_list() {
+  let a = 1
+  let b = ""
+  let c =
+    [0]
+  let d =
+    [""]
+  let e =
+    []
+  let f = (1, "")
+  let g = ("", 1)
+  let h = (1, 2, "")
+  let i = None
+  let j = Some("")
+  let k =
+    [(1, "")]
+  let l =
+    [(2, 3, "")]
+
+  and {
+    generic_in_list(a) == [a],
+    generic_in_list(b) == [b],
+    generic_in_list(c) == [c],
+    generic_in_list(d) == [d],
+    generic_in_list(e) == [e],
+    generic_in_list(f) == [f],
+    generic_in_list(g) == [g],
+    generic_in_list(h) == [h],
+    generic_in_list(i) == [i],
+    generic_in_list(j) == [j],
+    generic_in_list(k) == [k],
+    generic_in_list(l) == [l],
+  }
+}
+
+test edge_case_wrap() {
+  let a = (1, (1, 1, 1))
+  let b = (1, (1, 1), 1)
+
+  and {
+    generic_wrap(a) == Some(a),
+    generic_wrap(b) == Some(b),
+  }
+}
+
+test edge_case_in_list() {
+  let a = (1, (1, 1, 1))
+  let b = (1, (1, 1), 1)
+
+  and {
+    generic_in_list(a) == [a],
+    generic_in_list(b) == [b],
+  }
+}

--- a/examples/acceptance_tests/071/aiken.lock
+++ b/examples/acceptance_tests/071/aiken.lock
@@ -13,4 +13,4 @@ requirements = []
 source = "github"
 
 [etags]
-"aiken-lang/stdlib@main" = [{ secs_since_epoch = 1704340537, nanos_since_epoch = 228257000 }, "cf946239d3dd481ed41f20e56bf24910b5229ea35aa171a708edc2a47fc20a7b"]
+"aiken-lang/stdlib@main" = [{ secs_since_epoch = 1705181045, nanos_since_epoch = 255817000 }, "cf946239d3dd481ed41f20e56bf24910b5229ea35aa171a708edc2a47fc20a7b"]

--- a/examples/acceptance_tests/071/plutus.json
+++ b/examples/acceptance_tests/071/plutus.json
@@ -5,7 +5,7 @@
     "plutusVersion": "v2",
     "compiler": {
       "name": "Aiken",
-      "version": "v1.0.21-alpha+631757e"
+      "version": "v1.0.21-alpha+0161cf6"
     }
   },
   "validators": [

--- a/examples/acceptance_tests/072/aiken.lock
+++ b/examples/acceptance_tests/072/aiken.lock
@@ -13,4 +13,4 @@ requirements = []
 source = "github"
 
 [etags]
-"aiken-lang/stdlib@main" = [{ secs_since_epoch = 1704340550, nanos_since_epoch = 584623000 }, "cf946239d3dd481ed41f20e56bf24910b5229ea35aa171a708edc2a47fc20a7b"]
+"aiken-lang/stdlib@main" = [{ secs_since_epoch = 1705181059, nanos_since_epoch = 86246000 }, "cf946239d3dd481ed41f20e56bf24910b5229ea35aa171a708edc2a47fc20a7b"]

--- a/examples/acceptance_tests/074/aiken.lock
+++ b/examples/acceptance_tests/074/aiken.lock
@@ -13,4 +13,4 @@ requirements = []
 source = "github"
 
 [etags]
-"aiken-lang/stdlib@main" = [{ secs_since_epoch = 1704340547, nanos_since_epoch = 394912000 }, "cf946239d3dd481ed41f20e56bf24910b5229ea35aa171a708edc2a47fc20a7b"]
+"aiken-lang/stdlib@main" = [{ secs_since_epoch = 1705181056, nanos_since_epoch = 151986000 }, "cf946239d3dd481ed41f20e56bf24910b5229ea35aa171a708edc2a47fc20a7b"]

--- a/examples/acceptance_tests/077/aiken.lock
+++ b/examples/acceptance_tests/077/aiken.lock
@@ -13,4 +13,4 @@ requirements = []
 source = "github"
 
 [etags]
-"aiken-lang/stdlib@main" = [{ secs_since_epoch = 1704340535, nanos_since_epoch = 549750000 }, "cf946239d3dd481ed41f20e56bf24910b5229ea35aa171a708edc2a47fc20a7b"]
+"aiken-lang/stdlib@main" = [{ secs_since_epoch = 1705181044, nanos_since_epoch = 445717000 }, "cf946239d3dd481ed41f20e56bf24910b5229ea35aa171a708edc2a47fc20a7b"]

--- a/examples/acceptance_tests/077/plutus.json
+++ b/examples/acceptance_tests/077/plutus.json
@@ -5,7 +5,7 @@
     "plutusVersion": "v2",
     "compiler": {
       "name": "Aiken",
-      "version": "v1.0.21-alpha+631757e"
+      "version": "v1.0.21-alpha+0161cf6"
     }
   },
   "validators": [

--- a/examples/acceptance_tests/079/plutus.json
+++ b/examples/acceptance_tests/079/plutus.json
@@ -5,7 +5,7 @@
     "plutusVersion": "v2",
     "compiler": {
       "name": "Aiken",
-      "version": "v1.0.21-alpha+631757e"
+      "version": "v1.0.21-alpha+0161cf6"
     }
   },
   "validators": [

--- a/examples/acceptance_tests/082/aiken.lock
+++ b/examples/acceptance_tests/082/aiken.lock
@@ -13,4 +13,4 @@ requirements = []
 source = "github"
 
 [etags]
-"aiken-lang/stdlib@main" = [{ secs_since_epoch = 1704340537, nanos_since_epoch = 243457000 }, "cf946239d3dd481ed41f20e56bf24910b5229ea35aa171a708edc2a47fc20a7b"]
+"aiken-lang/stdlib@main" = [{ secs_since_epoch = 1705181045, nanos_since_epoch = 361146000 }, "cf946239d3dd481ed41f20e56bf24910b5229ea35aa171a708edc2a47fc20a7b"]

--- a/examples/acceptance_tests/083/aiken.lock
+++ b/examples/acceptance_tests/083/aiken.lock
@@ -13,4 +13,4 @@ requirements = []
 source = "github"
 
 [etags]
-"aiken-lang/stdlib@main" = [{ secs_since_epoch = 1704340535, nanos_since_epoch = 540401000 }, "cf946239d3dd481ed41f20e56bf24910b5229ea35aa171a708edc2a47fc20a7b"]
+"aiken-lang/stdlib@main" = [{ secs_since_epoch = 1705181044, nanos_since_epoch = 445541000 }, "cf946239d3dd481ed41f20e56bf24910b5229ea35aa171a708edc2a47fc20a7b"]

--- a/examples/acceptance_tests/084/aiken.lock
+++ b/examples/acceptance_tests/084/aiken.lock
@@ -13,4 +13,4 @@ requirements = []
 source = "github"
 
 [etags]
-"aiken-lang/stdlib@main" = [{ secs_since_epoch = 1704340536, nanos_since_epoch = 374601000 }, "cf946239d3dd481ed41f20e56bf24910b5229ea35aa171a708edc2a47fc20a7b"]
+"aiken-lang/stdlib@main" = [{ secs_since_epoch = 1705181045, nanos_since_epoch = 301366000 }, "cf946239d3dd481ed41f20e56bf24910b5229ea35aa171a708edc2a47fc20a7b"]

--- a/examples/acceptance_tests/085/aiken.lock
+++ b/examples/acceptance_tests/085/aiken.lock
@@ -13,4 +13,4 @@ requirements = []
 source = "github"
 
 [etags]
-"aiken-lang/stdlib@main" = [{ secs_since_epoch = 1704340537, nanos_since_epoch = 11039000 }, "cf946239d3dd481ed41f20e56bf24910b5229ea35aa171a708edc2a47fc20a7b"]
+"aiken-lang/stdlib@main" = [{ secs_since_epoch = 1705181045, nanos_since_epoch = 320068000 }, "cf946239d3dd481ed41f20e56bf24910b5229ea35aa171a708edc2a47fc20a7b"]

--- a/examples/acceptance_tests/086/aiken.lock
+++ b/examples/acceptance_tests/086/aiken.lock
@@ -13,4 +13,4 @@ requirements = []
 source = "github"
 
 [etags]
-"aiken-lang/stdlib@main" = [{ secs_since_epoch = 1704340550, nanos_since_epoch = 288401000 }, "cf946239d3dd481ed41f20e56bf24910b5229ea35aa171a708edc2a47fc20a7b"]
+"aiken-lang/stdlib@main" = [{ secs_since_epoch = 1705181059, nanos_since_epoch = 76573000 }, "cf946239d3dd481ed41f20e56bf24910b5229ea35aa171a708edc2a47fc20a7b"]

--- a/examples/acceptance_tests/086/plutus.json
+++ b/examples/acceptance_tests/086/plutus.json
@@ -5,7 +5,7 @@
     "plutusVersion": "v2",
     "compiler": {
       "name": "Aiken",
-      "version": "v1.0.21-alpha+631757e"
+      "version": "v1.0.21-alpha+0161cf6"
     }
   },
   "validators": [

--- a/examples/acceptance_tests/087/aiken.lock
+++ b/examples/acceptance_tests/087/aiken.lock
@@ -13,4 +13,4 @@ requirements = []
 source = "github"
 
 [etags]
-"aiken-lang/stdlib@main" = [{ secs_since_epoch = 1704340546, nanos_since_epoch = 592776000 }, "cf946239d3dd481ed41f20e56bf24910b5229ea35aa171a708edc2a47fc20a7b"]
+"aiken-lang/stdlib@main" = [{ secs_since_epoch = 1705181055, nanos_since_epoch = 546831000 }, "cf946239d3dd481ed41f20e56bf24910b5229ea35aa171a708edc2a47fc20a7b"]

--- a/examples/acceptance_tests/088/aiken.lock
+++ b/examples/acceptance_tests/088/aiken.lock
@@ -13,4 +13,4 @@ requirements = []
 source = "github"
 
 [etags]
-"aiken-lang/stdlib@main" = [{ secs_since_epoch = 1704340551, nanos_since_epoch = 543964000 }, "cf946239d3dd481ed41f20e56bf24910b5229ea35aa171a708edc2a47fc20a7b"]
+"aiken-lang/stdlib@main" = [{ secs_since_epoch = 1705181060, nanos_since_epoch = 328311000 }, "cf946239d3dd481ed41f20e56bf24910b5229ea35aa171a708edc2a47fc20a7b"]

--- a/examples/acceptance_tests/script_context/aiken.lock
+++ b/examples/acceptance_tests/script_context/aiken.lock
@@ -13,4 +13,4 @@ requirements = []
 source = "github"
 
 [etags]
-"aiken-lang/stdlib@main" = [{ secs_since_epoch = 1704341807, nanos_since_epoch = 247364000 }, "cf946239d3dd481ed41f20e56bf24910b5229ea35aa171a708edc2a47fc20a7b"]
+"aiken-lang/stdlib@main" = [{ secs_since_epoch = 1705181303, nanos_since_epoch = 777227000 }, "cf946239d3dd481ed41f20e56bf24910b5229ea35aa171a708edc2a47fc20a7b"]

--- a/examples/acceptance_tests/script_context/plutus.json
+++ b/examples/acceptance_tests/script_context/plutus.json
@@ -5,7 +5,7 @@
     "plutusVersion": "v2",
     "compiler": {
       "name": "Aiken",
-      "version": "v1.0.21-alpha+631757e"
+      "version": "v1.0.21-alpha+0161cf6"
     }
   },
   "validators": [


### PR DESCRIPTION
fix: generic edge case with tuples that allowed 2 tuples and 3 tuples to use the same monomorphized function.

Also massively reduced the space taken up by generics in scripts when using generics with list and tuples. The difference is that before using a generic with a tuple or list would create a unique variant based on the lists inner types. In practice list and tuples are opaque when used as generics so only a single list or tuple or pair variant is needed.

Add test 69 for showing an edge case that failed under the previous generic system.

Minor fix for bls types where in generics they were incorrectly assumed to be data.