### PR TITLE
Introduces cli aliases for `aiken check` and `aiken build` subcommands

### DIFF
--- a/crates/aiken/src/cmd/mod.rs
+++ b/crates/aiken/src/cmd/mod.rs
@@ -20,8 +20,12 @@ pub mod uplc;
 pub enum Cmd {
     New(new::Args),
     Fmt(fmt::Args),
+
+    #[clap(visible_alias("b"))]
     Build(build::Args),
     Address(blueprint::address::Args),
+
+    #[clap(visible_alias("c"))]
     Check(check::Args),
     Docs(docs::Args),
     Add(packages::add::Args),


### PR DESCRIPTION
Improves the cli by adding aliases for the `build` and `check` commands, ensuring compatibility with Cargo's functionality.