### PR TITLE
chore: use updated theme method

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,9 @@
 <div align="center">
-  <img src="https://raw.githubusercontent.com/aiken-lang/branding/main/assets/logo-light.png?sanitize=true#gh-dark-mode-only" alt="Aiken" height="150" />
-  <img src="https://raw.githubusercontent.com/aiken-lang/branding/main/assets/logo-dark.png?sanitize=true#gh-light-mode-only" alt="Aiken" height="150" />
+  <picture>
+    <source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/aiken-lang/branding/main/assets/logo-light.png">
+    <source media="(prefers-color-scheme: light)" srcset="https://raw.githubusercontent.com/aiken-lang/branding/main/assets/logo-dark.png">
+    <img alt="Aiken" src="https://raw.githubusercontent.com/aiken-lang/branding/main/assets/logo-dark.png" height="150">
+  </picture>
   <hr />
     <h2 align="center" style="border-bottom: none">A modern smart contract platform for Cardano</h2>
 


### PR DESCRIPTION
Per Github docs (https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax#specifying-the-theme-an-image-is-shown-to)

```
The old method of specifying images based on the theme, by using a fragment appended to the URL (#gh-dark-mode-only or #gh-light-mode-only), is deprecated and will be removed in favor of the new method described above.
```

There is a bug with Github if the theme settings are set to sync with system (xref: https://github.com/github/markup/issues/1583)