### PR TITLE
Forbid opaque types in the application binary interface.

### DIFF
--- a/crates/aiken-project/src/blueprint/snapshots/aiken_project__blueprint__validator__tests__opaque_singleton_multi_variants.snap
+++ b/crates/aiken-project/src/blueprint/snapshots/aiken_project__blueprint__validator__tests__opaque_singleton_multi_variants.snap
@@ -1,0 +1,22 @@
+---
+source: crates/aiken-project/src/blueprint/validator.rs
+description: "Code:\n\npub opaque type Rational {\n  numerator: Int,\n  denominator: Int,\n}\n\nvalidator {\n  fn opaque_singleton_multi_variants(redeemer: Rational, ctx: Void) {\n    True\n  }\n}\n"
+---
+Schema {
+    error: Error {
+        context: IllegalOpaqueType,
+        breadcrumbs: [
+            App {
+                public: true,
+                module: "test_module",
+                name: "Rational",
+                args: [],
+            },
+        ],
+    },
+    location: 117..135,
+    source_code: NamedSource {
+        name: "",
+        source: "<redacted>",
+    ,
+}

--- a/crates/aiken-project/src/blueprint/snapshots/aiken_project__blueprint__validator__tests__opaque_singleton_variants.snap
+++ b/crates/aiken-project/src/blueprint/snapshots/aiken_project__blueprint__validator__tests__opaque_singleton_variants.snap
@@ -2,32 +2,46 @@
 source: crates/aiken-project/src/blueprint/validator.rs
 description: "Code:\n\npub opaque type Dict<key, value> {\n    inner: List<(ByteArray, value)>\n}\n\ntype UUID { UUID }\n\nvalidator {\n  fn opaque_singleton_variants(redeemer: Dict<UUID, Int>, ctx: Void) {\n    True\n  }\n}\n"
 ---
-{
-  "title": "test_module.opaque_singleton_variants",
-  "redeemer": {
-    "title": "redeemer",
-    "schema": {
-      "$ref": "#/definitions/test_module~1Dict$test_module~1UUID_Int"
-    }
-  },
-  "compiledCode": "58f201000032323232323232323223232253330064a22930a99803a4811856616c696461746f722072657475726e65642066616c73650013656323300100100222533300a00114984c8cc00c00cc034008c8c8c94cccccc04000454cc0280205854cc0280205854cc028020584dd68008a998050040b18058011929999998078008a998048038b0a998048038b0a998048038b0a998048038b09bae0013009001300b001533333300a001153300400216137560022a660080042c2a660080042c2a660080042c9211972656465656d65723a20446963743c555549442c20496e743e005734ae7155ceaab9e5573eae855d12ba41",
-  "hash": "c3f68ad7fb4d6c26e1f19799fe0ded6c9904bf04b924835ddad2abf0",
-  "definitions": {
-    "ByteArray": {
-      "dataType": "bytes"
+Schema {
+    error: Error {
+        context: IllegalOpaqueType,
+        breadcrumbs: [
+            App {
+                public: true,
+                module: "test_module",
+                name: "Dict",
+                args: [
+                    Var {
+                        tipo: RefCell {
+                            value: Link {
+                                tipo: App {
+                                    public: false,
+                                    module: "test_module",
+                                    name: "UUID",
+                                    args: [],
+                                },
+                            },
+                        },
+                    },
+                    Var {
+                        tipo: RefCell {
+                            value: Link {
+                                tipo: App {
+                                    public: true,
+                                    module: "",
+                                    name: "Int",
+                                    args: [],
+                                },
+                            },
+                        },
+                    },
+                ],
+            },
+        ],
     },
-    "Int": {
-      "dataType": "integer"
-    },
-    "test_module/Dict$test_module/UUID_Int": {
-      "title": "Dict",
-      "dataType": "map",
-      "keys": {
-        "$ref": "#/definitions/ByteArray"
-      },
-      "values": {
-        "$ref": "#/definitions/Int"
-      }
-    }
-  }
+    location: 137..162,
+    source_code: NamedSource {
+        name: "",
+        source: "<redacted>",
+    ,
 }


### PR DESCRIPTION
This was a long overdue... 

<img width="908" alt="image" src="https://github.com/aiken-lang/aiken/assets/5680256/e95eac70-4ef8-487d-812a-a3fb6f9f03a0">