### PR TITLE
Include the number of tests / checks run as part of the summary

### DIFF
--- a/crates/aiken-project/src/lib.rs
+++ b/crates/aiken-project/src/lib.rs
@@ -89,6 +89,7 @@ where
     root: PathBuf,
     sources: Vec<Source>,
     warnings: Vec<Warning>,
+    checks_count: Option<usize>,
     event_listener: T,
     functions: IndexMap<FunctionAccessKey, TypedFunction>,
     data_types: IndexMap<DataTypeKey, TypedDataType>,
@@ -128,6 +129,7 @@ where
             root,
             sources: vec![],
             warnings: vec![],
+            checks_count: None,
             event_listener,
             functions,
             data_types,
@@ -335,6 +337,15 @@ where
                 }
 
                 let tests = self.run_tests(tests, seed);
+
+                self.checks_count = if tests.is_empty() { None } else {
+                    Some(tests.iter().fold(0, |acc, test| {
+                        acc + match test {
+                            TestResult::PropertyTestResult(r) => r.iterations,
+                            _ => 1,
+                        }
+                    }))
+                };
 
                 let errors: Vec<Error> = tests
                     .iter()

--- a/crates/aiken-project/src/watch.rs
+++ b/crates/aiken-project/src/watch.rs
@@ -120,7 +120,7 @@ where
         eprintln!(
             "{}",
             Summary {
-                check_count: None,
+                check_count: project.checks_count,
                 warning_count,
                 error_count: errs.len(),
             }
@@ -132,7 +132,7 @@ where
     eprintln!(
         "{}",
         Summary {
-            check_count: Some(41),
+            check_count: project.checks_count,
             error_count: 0,
             warning_count
         }

--- a/crates/aiken-project/src/watch.rs
+++ b/crates/aiken-project/src/watch.rs
@@ -24,6 +24,7 @@ impl ExitFailure {
 }
 
 struct Summary {
+    check_count: Option<usize>,
     warning_count: usize,
     error_count: usize,
 }
@@ -31,10 +32,18 @@ struct Summary {
 impl Display for Summary {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         f.write_str(&format!(
-            "      {} {} {}, {} {}",
+            "      {} {}{}{} {}, {} {}",
             "Summary"
                 .if_supports_color(Stderr, |s| s.purple())
                 .if_supports_color(Stderr, |s| s.bold()),
+            if let Some(c) = self.check_count { format!("{} ", c) } else { "".to_string() },
+            match self.check_count {
+                Some(1) => "check, ",
+                Some(_) => "checks, ",
+                None => ""
+            }
+            .if_supports_color(Stderr, |s| s.green())
+            .if_supports_color(Stderr, |s| s.bold()),
             self.error_count,
             if self.error_count == 1 {
                 "error"
@@ -111,6 +120,7 @@ where
         eprintln!(
             "{}",
             Summary {
+                check_count: None,
                 warning_count,
                 error_count: errs.len(),
             }
@@ -122,6 +132,7 @@ where
     eprintln!(
         "{}",
         Summary {
+            check_count: Some(41),
             error_count: 0,
             warning_count
         }


### PR DESCRIPTION
I got annoyed adding up each of the test counts for each module, so I asked @KtorZ if I could add it to the final summary.

![image](https://github.com/aiken-lang/aiken/assets/49870/096c0d08-de2b-40b6-b4b6-187b9b701bd7)

We talked a bit about how best to fit it into the code. In theory, a more comprehensive refactor would be possible, whereby the action can return `Summary`, and summary is extended to include everything. Then, the output format could change, a la [this discussion](https://github.com/aiken-lang/aiken/discussions/822).