### PR TITLE
Forbid non-serializable inhabitants in compound data-types.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@
 - **aiken-lang**: allow zero arg mutually recursive functions. @Microproofs
 - **aiken-lang**: function aliases now resolved to the module and function name in codegen. @Microproofs
 - **aiken-lang**: fix indentation of pipelines to remain a multiple of the base indent increment. @KtorZ
+- **aiken-lang**: forbid presence of non-serialisable data-types in compound structures like List and Tuple. @KtorZ
 
 ### Changed
 

--- a/crates/aiken-lang/src/tests/check.rs
+++ b/crates/aiken-lang/src/tests/check.rs
@@ -123,6 +123,70 @@ fn validator_illegal_arity() {
 }
 
 #[test]
+fn list_illegal_inhabitants() {
+    let source_code = r#"
+        fn main() {
+          [identity]
+        }
+    "#;
+
+    assert!(matches!(
+        check_validator(parse(source_code)),
+        Err((_, Error::IllegalTypeInData { .. }))
+    ))
+}
+
+#[test]
+fn tuple_illegal_inhabitants() {
+    let source_code = r#"
+        fn main() {
+          (identity, always)
+        }
+    "#;
+
+    assert!(matches!(
+        check_validator(parse(source_code)),
+        Err((_, Error::IllegalTypeInData { .. }))
+    ))
+}
+
+#[test]
+fn illegal_inhabitants_nested() {
+    let source_code = r#"
+        fn main() {
+          [(identity, always)]
+        }
+    "#;
+
+    assert!(matches!(
+        check_validator(parse(source_code)),
+        Err((_, Error::IllegalTypeInData { .. }))
+    ))
+}
+
+#[test]
+fn illegal_inhabitants_returned() {
+    let source_code = r#"
+        type Fuzzer<a> = fn(PRNG) -> (a, PRNG)
+
+        fn constant(a: a) -> Fuzzer<a> {
+          fn (prng) {
+            (a, prng)
+          }
+        }
+
+        fn main() -> Fuzzer<Fuzzer<Int>> {
+          constant(constant(42))
+        }
+    "#;
+
+    assert!(matches!(
+        check_validator(parse(source_code)),
+        Err((_, Error::IllegalTypeInData { .. }))
+    ))
+}
+
+#[test]
 fn mark_constructors_as_used_via_field_access() {
     let source_code = r#"
       type Datum {

--- a/crates/aiken-lang/src/tipo/error.rs
+++ b/crates/aiken-lang/src/tipo/error.rs
@@ -269,11 +269,14 @@ You can use '{discard}' and numbers to distinguish between similar names.
         location: Span,
     },
 
-    #[error("I found a type definition that has an unsupported type in it.\n")]
+    #[error("I found a type definition that has unsupported inhabitants.\n")]
     #[diagnostic(code("illegal::type_in_data"))]
     #[diagnostic(help(
-        r#"Data-types can't contain type {type_info} because it isn't serializable into a Plutus Data. Yet, this is a strong requirement for types found in compound structures such as List or Tuples."#,
-        type_info = tipo.to_pretty(0).if_supports_color(Stdout, |s| s.red())
+        r#"Data-types cannot contain values of type {type_info} because they aren't serialisable into a Plutus Data. Yet this is necessary for inhabitants of compound structures like {List}, {Tuple} or {Fuzzer}."#,
+        type_info = tipo.to_pretty(0).if_supports_color(Stdout, |s| s.red()),
+        List = "List".if_supports_color(Stdout, |s| s.cyan()),
+        Tuple = "Tuple".if_supports_color(Stdout, |s| s.cyan()),
+        Fuzzer = "Fuzzer".if_supports_color(Stdout, |s| s.cyan()),
     ))]
     IllegalTypeInData {
         #[label]


### PR DESCRIPTION
Note: the stdlib still compiles, type-check and succeed on all tests.

Closes #827.