### PR TITLE
Backpassing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 - **aiken-lang**: Strings can contain a nul byte using the escape sequence `\0`. @KtorZ
 - **aiken**: The `check` command now accept an extra (optional) option `--max-success` to control the number of property-test iterations to perform. @KtorZ
 - **aiken**: The `docs` command now accept an optional flag `--include-dependencies` to include all dependencies in the generated documentation. @KtorZ
+- **aiken-lang**: Implement [function backpassing](https://www.roc-lang.org/tutorial#backpassing) as a syntactic sugar. @KtorZ
 
 ### Fixed
 

--- a/crates/aiken-lang/src/ast.rs
+++ b/crates/aiken-lang/src/ast.rs
@@ -16,6 +16,7 @@ use std::{
 use uplc::machine::runtime::Compressable;
 use vec1::Vec1;
 
+pub const BACKPASS_VARIABLE: &str = "_backpass";
 pub const CAPTURE_VARIABLE: &str = "_capture";
 pub const PIPE_VARIABLE: &str = "_pipe";
 
@@ -790,6 +791,19 @@ impl<A> Arg<A> {
 
     pub fn get_variable_name(&self) -> Option<&str> {
         self.arg_name.get_variable_name()
+    }
+
+    pub fn is_capture(&self) -> bool {
+        if let ArgName::Named {
+            ref name, location, ..
+        } = self.arg_name
+        {
+            return name.starts_with(CAPTURE_VARIABLE)
+                && location == Span::empty()
+                && self.location == Span::empty();
+        }
+
+        false
     }
 
     pub fn put_doc(&mut self, new_doc: String) {

--- a/crates/aiken-lang/src/ast.rs
+++ b/crates/aiken-lang/src/ast.rs
@@ -1479,13 +1479,17 @@ impl AssignmentKind<bool> {
     }
 }
 
-impl AssignmentKind<()> {
+impl<T: Default> AssignmentKind<T> {
     pub fn let_() -> Self {
-        AssignmentKind::Let { backpassing: () }
+        AssignmentKind::Let {
+            backpassing: Default::default(),
+        }
     }
 
     pub fn expect() -> Self {
-        AssignmentKind::Expect { backpassing: () }
+        AssignmentKind::Expect {
+            backpassing: Default::default(),
+        }
     }
 }
 

--- a/crates/aiken-lang/src/ast.rs
+++ b/crates/aiken-lang/src/ast.rs
@@ -1425,6 +1425,7 @@ impl Default for Bls12_381Point {
 #[derive(Debug, Clone, PartialEq, Eq, Copy, serde::Serialize, serde::Deserialize)]
 pub enum AssignmentKind {
     Let,
+    Bind,
     Expect,
 }
 
@@ -1440,6 +1441,7 @@ impl AssignmentKind {
     pub fn location_offset(&self) -> usize {
         match self {
             AssignmentKind::Let => 3,
+            AssignmentKind::Bind => 3,
             AssignmentKind::Expect => 6,
         }
     }

--- a/crates/aiken-lang/src/expr.rs
+++ b/crates/aiken-lang/src/expr.rs
@@ -1,10 +1,10 @@
 use crate::{
     ast::{
-        self, Annotation, Arg, AssignmentKind, BinOp, Bls12_381Point, ByteArrayFormatPreference,
-        CallArg, Curve, DataType, DataTypeKey, DefinitionLocation, IfBranch, Located,
-        LogicalOpChainKind, ParsedCallArg, Pattern, RecordConstructorArg, RecordUpdateSpread, Span,
-        TraceKind, TypedClause, TypedDataType, TypedRecordUpdateArg, UnOp, UntypedClause,
-        UntypedRecordUpdateArg,
+        self, Annotation, Arg, ArgName, AssignmentKind, BinOp, Bls12_381Point,
+        ByteArrayFormatPreference, CallArg, Curve, DataType, DataTypeKey, DefinitionLocation,
+        IfBranch, Located, LogicalOpChainKind, ParsedCallArg, Pattern, RecordConstructorArg,
+        RecordUpdateSpread, Span, TraceKind, TypedClause, TypedDataType, TypedRecordUpdateArg,
+        UnOp, UntypedClause, UntypedRecordUpdateArg,
     },
     builtins::void,
     parser::token::Base,
@@ -1298,5 +1298,30 @@ impl UntypedExpr {
             self,
             Self::String { .. } | Self::UInt { .. } | Self::ByteArray { .. }
         )
+    }
+
+    pub fn lambda(name: String, expressions: Vec<UntypedExpr>, location: Span) -> Self {
+        Self::Fn {
+            location,
+            fn_style: FnStyle::Plain,
+            arguments: vec![Arg {
+                location,
+                doc: None,
+                annotation: None,
+                tipo: (),
+                arg_name: ArgName::Named {
+                    label: name.clone(),
+                    name,
+                    location,
+                    is_validator_param: false,
+                },
+            }],
+            body: Self::Sequence {
+                location,
+                expressions,
+            }
+            .into(),
+            return_annotation: None,
+        }
     }
 }

--- a/crates/aiken-lang/src/expr.rs
+++ b/crates/aiken-lang/src/expr.rs
@@ -1,10 +1,10 @@
 use crate::{
     ast::{
-        self, Annotation, Arg, ArgName, AssignmentKind, BinOp, Bls12_381Point,
-        ByteArrayFormatPreference, CallArg, Curve, DataType, DataTypeKey, DefinitionLocation,
-        IfBranch, Located, LogicalOpChainKind, ParsedCallArg, Pattern, RecordConstructorArg,
-        RecordUpdateSpread, Span, TraceKind, TypedClause, TypedDataType, TypedRecordUpdateArg,
-        UnOp, UntypedClause, UntypedRecordUpdateArg,
+        self, Annotation, Arg, ArgName, BinOp, Bls12_381Point, ByteArrayFormatPreference, CallArg,
+        Curve, DataType, DataTypeKey, DefinitionLocation, IfBranch, Located, LogicalOpChainKind,
+        ParsedCallArg, Pattern, RecordConstructorArg, RecordUpdateSpread, Span, TraceKind,
+        TypedAssignmentKind, TypedClause, TypedDataType, TypedRecordUpdateArg, UnOp,
+        UntypedAssignmentKind, UntypedClause, UntypedRecordUpdateArg,
     },
     builtins::void,
     parser::token::Base,
@@ -106,7 +106,7 @@ pub enum TypedExpr {
         tipo: Rc<Type>,
         value: Box<Self>,
         pattern: Pattern<PatternConstructor, Rc<Type>>,
-        kind: AssignmentKind,
+        kind: TypedAssignmentKind,
     },
 
     Trace {
@@ -519,7 +519,7 @@ pub enum UntypedExpr {
         location: Span,
         value: Box<Self>,
         pattern: Pattern<(), ()>,
-        kind: AssignmentKind,
+        kind: UntypedAssignmentKind,
         annotation: Option<Annotation>,
     },
 

--- a/crates/aiken-lang/src/format.rs
+++ b/crates/aiken-lang/src/format.rs
@@ -684,9 +684,10 @@ impl<'comments> Formatter<'comments> {
         kind: AssignmentKind,
         annotation: &'a Option<Annotation>,
     ) -> Document<'a> {
-        let keyword = match kind {
-            AssignmentKind::Let => "let",
-            AssignmentKind::Expect => "expect",
+        let (keyword, equal) = match kind {
+            AssignmentKind::Let => ("let", "="),
+            AssignmentKind::Bind => ("let", "<-"),
+            AssignmentKind::Expect => ("expect", "="),
         };
 
         match pattern {
@@ -708,7 +709,8 @@ impl<'comments> Formatter<'comments> {
                     .to_doc()
                     .append(" ")
                     .append(pattern.append(annotation).group())
-                    .append(" =")
+                    .append(" ")
+                    .append(equal)
                     .append(self.case_clause_value(value))
             }
         }
@@ -1842,11 +1844,7 @@ impl<'a> Documentable<'a> for &'a ArgName {
 }
 
 fn pub_(public: bool) -> Document<'static> {
-    if public {
-        "pub ".to_doc()
-    } else {
-        nil()
-    }
+    if public { "pub ".to_doc() } else { nil() }
 }
 
 impl<'a> Documentable<'a> for &'a UnqualifiedImport {

--- a/crates/aiken-lang/src/format.rs
+++ b/crates/aiken-lang/src/format.rs
@@ -1844,7 +1844,11 @@ impl<'a> Documentable<'a> for &'a ArgName {
 }
 
 fn pub_(public: bool) -> Document<'static> {
-    if public { "pub ".to_doc() } else { nil() }
+    if public {
+        "pub ".to_doc()
+    } else {
+        nil()
+    }
 }
 
 impl<'a> Documentable<'a> for &'a UnqualifiedImport {

--- a/crates/aiken-lang/src/format.rs
+++ b/crates/aiken-lang/src/format.rs
@@ -4,9 +4,9 @@ use crate::{
         CallArg, ClauseGuard, Constant, CurveType, DataType, Definition, Function, IfBranch,
         LogicalOpChainKind, ModuleConstant, Pattern, RecordConstructor, RecordConstructorArg,
         RecordUpdateSpread, Span, TraceKind, TypeAlias, TypedArg, UnOp, UnqualifiedImport,
-        UntypedArg, UntypedArgVia, UntypedClause, UntypedClauseGuard, UntypedDefinition,
-        UntypedFunction, UntypedModule, UntypedPattern, UntypedRecordUpdateArg, Use, Validator,
-        CAPTURE_VARIABLE,
+        UntypedArg, UntypedArgVia, UntypedAssignmentKind, UntypedClause, UntypedClauseGuard,
+        UntypedDefinition, UntypedFunction, UntypedModule, UntypedPattern, UntypedRecordUpdateArg,
+        Use, Validator, CAPTURE_VARIABLE,
     },
     docvec,
     expr::{FnStyle, UntypedExpr, DEFAULT_ERROR_STR, DEFAULT_TODO_STR},
@@ -681,14 +681,15 @@ impl<'comments> Formatter<'comments> {
         &mut self,
         pattern: &'a UntypedPattern,
         value: &'a UntypedExpr,
-        kind: AssignmentKind,
+        kind: UntypedAssignmentKind,
         annotation: &'a Option<Annotation>,
     ) -> Document<'a> {
-        let (keyword, equal) = match kind {
-            AssignmentKind::Let => ("let", "="),
-            AssignmentKind::Bind => ("let", "<-"),
-            AssignmentKind::Expect => ("expect", "="),
+        let keyword = match kind {
+            AssignmentKind::Let { .. } => "let",
+            AssignmentKind::Expect { .. } => "expect",
         };
+
+        let symbol = if kind.is_backpassing() { "<-" } else { "=" };
 
         match pattern {
             UntypedPattern::Constructor {
@@ -710,7 +711,7 @@ impl<'comments> Formatter<'comments> {
                     .append(" ")
                     .append(pattern.append(annotation).group())
                     .append(" ")
-                    .append(equal)
+                    .append(symbol)
                     .append(self.case_clause_value(value))
             }
         }

--- a/crates/aiken-lang/src/gen_uplc.rs
+++ b/crates/aiken-lang/src/gen_uplc.rs
@@ -559,7 +559,7 @@ impl<'a> CodeGenerator<'a> {
                             &subject_type,
                             AssignmentProperties {
                                 value_type: subject.tipo(),
-                                kind: AssignmentKind::Let,
+                                kind: AssignmentKind::let_(),
                                 remove_unused: false,
                                 full_check: false,
                                 msg_func: None,
@@ -843,7 +843,7 @@ impl<'a> CodeGenerator<'a> {
     ) -> AirTree {
         assert!(
             match &value {
-                AirTree::Var { name, .. } if props.kind == AssignmentKind::Let => {
+                AirTree::Var { name, .. } if props.kind.is_let() => {
                     name != "_"
                 }
                 _ => true,
@@ -2812,7 +2812,7 @@ impl<'a> CodeGenerator<'a> {
                         &actual_type,
                         AssignmentProperties {
                             value_type: data(),
-                            kind: AssignmentKind::Expect,
+                            kind: AssignmentKind::expect(),
                             remove_unused: false,
                             full_check: true,
                             msg_func,

--- a/crates/aiken-lang/src/gen_uplc/builder.rs
+++ b/crates/aiken-lang/src/gen_uplc/builder.rs
@@ -4,8 +4,8 @@ use super::{
 };
 use crate::{
     ast::{
-        AssignmentKind, BinOp, ClauseGuard, Constant, DataTypeKey, FunctionAccessKey, Pattern,
-        Span, TraceLevel, TypedArg, TypedClause, TypedClauseGuard, TypedDataType, TypedPattern,
+        BinOp, ClauseGuard, Constant, DataTypeKey, FunctionAccessKey, Pattern, Span, TraceLevel,
+        TypedArg, TypedAssignmentKind, TypedClause, TypedClauseGuard, TypedDataType, TypedPattern,
         UnOp,
     },
     builtins::{bool, data, function, int, list, void},
@@ -68,7 +68,7 @@ pub enum HoistableFunction {
 #[derive(Clone, Debug)]
 pub struct AssignmentProperties {
     pub value_type: Rc<Type>,
-    pub kind: AssignmentKind,
+    pub kind: TypedAssignmentKind,
     pub remove_unused: bool,
     pub full_check: bool,
     pub msg_func: Option<AirMsg>,

--- a/crates/aiken-lang/src/parser/definition/snapshots/def_test_fail.snap
+++ b/crates/aiken-lang/src/parser/definition/snapshots/def_test_fail.snap
@@ -24,7 +24,9 @@ Test(
                         with_spread: false,
                         tipo: (),
                     },
-                    kind: Expect,
+                    kind: Expect {
+                        backpassing: false,
+                    },
                     annotation: None,
                 },
                 Var {

--- a/crates/aiken-lang/src/parser/definition/snapshots/function_assignment_only.snap
+++ b/crates/aiken-lang/src/parser/definition/snapshots/function_assignment_only.snap
@@ -29,7 +29,9 @@ Fn(
                 location: 17..18,
                 name: "x",
             },
-            kind: Let,
+            kind: Let {
+                backpassing: false,
+            },
             annotation: None,
         },
         doc: None,

--- a/crates/aiken-lang/src/parser/expr/snapshots/block_let.snap
+++ b/crates/aiken-lang/src/parser/expr/snapshots/block_let.snap
@@ -20,7 +20,9 @@ Assignment {
                     location: 16..17,
                     name: "x",
                 },
-                kind: Let,
+                kind: Let {
+                    backpassing: false,
+                },
                 annotation: None,
             },
             BinOp {
@@ -44,6 +46,8 @@ Assignment {
         location: 4..5,
         name: "b",
     },
-    kind: Let,
+    kind: Let {
+        backpassing: false,
+    },
     annotation: None,
 }

--- a/crates/aiken-lang/src/parser/expr/snapshots/expect.snap
+++ b/crates/aiken-lang/src/parser/expr/snapshots/expect.snap
@@ -31,6 +31,8 @@ Assignment {
         with_spread: false,
         tipo: (),
     },
-    kind: Expect,
+    kind: Expect {
+        backpassing: false,
+    },
     annotation: None,
 }

--- a/crates/aiken-lang/src/parser/expr/snapshots/expect_bool_sugar.snap
+++ b/crates/aiken-lang/src/parser/expr/snapshots/expect_bool_sugar.snap
@@ -30,6 +30,8 @@ Assignment {
         with_spread: false,
         tipo: (),
     },
-    kind: Expect,
+    kind: Expect {
+        backpassing: false,
+    },
     annotation: None,
 }

--- a/crates/aiken-lang/src/parser/expr/snapshots/expect_expect_let.snap
+++ b/crates/aiken-lang/src/parser/expr/snapshots/expect_expect_let.snap
@@ -20,7 +20,9 @@ Assignment {
                     location: 13..14,
                     name: "a",
                 },
-                kind: Let,
+                kind: Let {
+                    backpassing: false,
+                },
                 annotation: None,
             },
         ],
@@ -35,6 +37,8 @@ Assignment {
         with_spread: false,
         tipo: (),
     },
-    kind: Expect,
+    kind: Expect {
+        backpassing: false,
+    },
     annotation: None,
 }

--- a/crates/aiken-lang/src/parser/expr/snapshots/expect_let_in_let.snap
+++ b/crates/aiken-lang/src/parser/expr/snapshots/expect_let_in_let.snap
@@ -20,7 +20,9 @@ Assignment {
                     location: 14..15,
                     name: "b",
                 },
-                kind: Let,
+                kind: Let {
+                    backpassing: false,
+                },
                 annotation: None,
             },
         ],
@@ -29,6 +31,8 @@ Assignment {
         location: 4..5,
         name: "a",
     },
-    kind: Let,
+    kind: Let {
+        backpassing: false,
+    },
     annotation: None,
 }

--- a/crates/aiken-lang/src/parser/expr/snapshots/expect_let_in_let_parens.snap
+++ b/crates/aiken-lang/src/parser/expr/snapshots/expect_let_in_let_parens.snap
@@ -20,7 +20,9 @@ Assignment {
                     location: 14..15,
                     name: "b",
                 },
-                kind: Let,
+                kind: Let {
+                    backpassing: false,
+                },
                 annotation: None,
             },
         ],
@@ -29,6 +31,8 @@ Assignment {
         location: 4..5,
         name: "a",
     },
-    kind: Let,
+    kind: Let {
+        backpassing: false,
+    },
     annotation: None,
 }

--- a/crates/aiken-lang/src/parser/expr/snapshots/expect_let_in_let_return.snap
+++ b/crates/aiken-lang/src/parser/expr/snapshots/expect_let_in_let_return.snap
@@ -20,7 +20,9 @@ Assignment {
                     location: 16..17,
                     name: "b",
                 },
-                kind: Let,
+                kind: Let {
+                    backpassing: false,
+                },
                 annotation: None,
             },
             Var {
@@ -33,6 +35,8 @@ Assignment {
         location: 4..5,
         name: "a",
     },
-    kind: Let,
+    kind: Let {
+        backpassing: false,
+    },
     annotation: None,
 }

--- a/crates/aiken-lang/src/parser/expr/snapshots/expect_trace_if_false.snap
+++ b/crates/aiken-lang/src/parser/expr/snapshots/expect_trace_if_false.snap
@@ -21,6 +21,8 @@ Assignment {
         with_spread: false,
         tipo: (),
     },
-    kind: Expect,
+    kind: Expect {
+        backpassing: false,
+    },
     annotation: None,
 }

--- a/crates/aiken-lang/src/parser/expr/snapshots/function_invoke.snap
+++ b/crates/aiken-lang/src/parser/expr/snapshots/function_invoke.snap
@@ -31,7 +31,9 @@ Sequence {
                 location: 4..5,
                 name: "x",
             },
-            kind: Let,
+            kind: Let {
+                backpassing: false,
+            },
             annotation: None,
         },
         Assignment {
@@ -115,7 +117,9 @@ Sequence {
                 location: 24..33,
                 name: "map_add_x",
             },
-            kind: Let,
+            kind: Let {
+                backpassing: false,
+            },
             annotation: None,
         },
         Call {

--- a/crates/aiken-lang/src/parser/expr/snapshots/int_numeric_underscore.snap
+++ b/crates/aiken-lang/src/parser/expr/snapshots/int_numeric_underscore.snap
@@ -18,7 +18,9 @@ Sequence {
                 location: 8..9,
                 name: "i",
             },
-            kind: Let,
+            kind: Let {
+                backpassing: false,
+            },
             annotation: None,
         },
         Assignment {
@@ -34,7 +36,9 @@ Sequence {
                 location: 28..29,
                 name: "j",
             },
-            kind: Let,
+            kind: Let {
+                backpassing: false,
+            },
             annotation: None,
         },
         Assignment {
@@ -54,7 +58,9 @@ Sequence {
                 location: 48..49,
                 name: "k",
             },
-            kind: Let,
+            kind: Let {
+                backpassing: false,
+            },
             annotation: None,
         },
     ],

--- a/crates/aiken-lang/src/parser/expr/snapshots/let_bindings.snap
+++ b/crates/aiken-lang/src/parser/expr/snapshots/let_bindings.snap
@@ -32,6 +32,8 @@ Assignment {
         location: 4..9,
         name: "thing",
     },
-    kind: Let,
+    kind: Let {
+        backpassing: false,
+    },
     annotation: None,
 }

--- a/crates/aiken-lang/src/parser/expr/snapshots/parse_tuple.snap
+++ b/crates/aiken-lang/src/parser/expr/snapshots/parse_tuple.snap
@@ -44,7 +44,9 @@ Sequence {
                 location: 4..9,
                 name: "tuple",
             },
-            kind: Let,
+            kind: Let {
+                backpassing: false,
+            },
             annotation: None,
         },
         BinOp {

--- a/crates/aiken-lang/src/parser/expr/snapshots/parse_tuple2.snap
+++ b/crates/aiken-lang/src/parser/expr/snapshots/parse_tuple2.snap
@@ -31,7 +31,9 @@ Sequence {
                 location: 4..5,
                 name: "a",
             },
-            kind: Let,
+            kind: Let {
+                backpassing: false,
+            },
             annotation: None,
         },
         Tuple {

--- a/crates/aiken-lang/src/parser/expr/when/snapshots/when_basic.snap
+++ b/crates/aiken-lang/src/parser/expr/when/snapshots/when_basic.snap
@@ -89,7 +89,9 @@ When {
                             location: 55..62,
                             name: "amazing",
                         },
-                        kind: Let,
+                        kind: Let {
+                            backpassing: false,
+                        },
                         annotation: None,
                     },
                     Var {

--- a/crates/aiken-lang/src/parser/lexer.rs
+++ b/crates/aiken-lang/src/parser/lexer.rs
@@ -163,6 +163,8 @@ pub fn lexer() -> impl Parser<char, Vec<(Token, Span)>, Error = ParseError> {
         just("!=").to(Token::NotEqual),
         just('!').to(Token::Bang),
         just('?').to(Token::Question),
+        just("<-").to(Token::LArrow),
+        just("->").to(Token::RArrow),
         choice((
             just("<=").to(Token::LessEqual),
             just('<').to(Token::Less),
@@ -170,7 +172,6 @@ pub fn lexer() -> impl Parser<char, Vec<(Token, Span)>, Error = ParseError> {
             just('>').to(Token::Greater),
         )),
         just('+').to(Token::Plus),
-        just("->").to(Token::RArrow),
         just('-').to(Token::Minus),
         just('*').to(Token::Star),
         just('/').to(Token::Slash),

--- a/crates/aiken-lang/src/parser/token.rs
+++ b/crates/aiken-lang/src/parser/token.rs
@@ -62,6 +62,7 @@ pub enum Token {
     Pipe,        // '|>'
     Dot,         // '.'
     RArrow,      // '->'
+    LArrow,      // '<-'
     DotDot,      // '..'
     EndOfFile,
     // Docs/Extra
@@ -152,6 +153,7 @@ impl fmt::Display for Token {
             Token::Pipe => "|>",
             Token::Dot => ".",
             Token::RArrow => "->",
+            Token::LArrow => "<-",
             Token::DotDot => "..",
             Token::EndOfFile => "EOF",
             Token::Comment => "//",

--- a/crates/aiken-lang/src/snapshots/function_ambiguous_sequence.snap
+++ b/crates/aiken-lang/src/snapshots/function_ambiguous_sequence.snap
@@ -23,7 +23,9 @@ Module {
                                 location: 19..20,
                                 name: "a",
                             },
-                            kind: Let,
+                            kind: Let {
+                                backpassing: false,
+                            },
                             annotation: None,
                         },
                         UInt {
@@ -61,7 +63,9 @@ Module {
                                 location: 56..57,
                                 name: "a",
                             },
-                            kind: Let,
+                            kind: Let {
+                                backpassing: false,
+                            },
                             annotation: None,
                         },
                         UInt {
@@ -110,7 +114,9 @@ Module {
                         location: 93..94,
                         name: "a",
                     },
-                    kind: Let,
+                    kind: Let {
+                        backpassing: false,
+                    },
                     annotation: None,
                 },
                 doc: None,
@@ -155,7 +161,9 @@ Module {
                                 location: 126..127,
                                 name: "a",
                             },
-                            kind: Let,
+                            kind: Let {
+                                backpassing: false,
+                            },
                             annotation: None,
                         },
                         BinOp {

--- a/crates/aiken-lang/src/snapshots/parse_unicode_offset_1.snap
+++ b/crates/aiken-lang/src/snapshots/parse_unicode_offset_1.snap
@@ -28,7 +28,9 @@ Module {
                                 location: 17..18,
                                 name: "x",
                             },
-                            kind: Let,
+                            kind: Let {
+                                backpassing: false,
+                            },
                             annotation: None,
                         },
                         Var {

--- a/crates/aiken-lang/src/snapshots/parse_unicode_offset_2.snap
+++ b/crates/aiken-lang/src/snapshots/parse_unicode_offset_2.snap
@@ -26,7 +26,9 @@ Module {
                                 location: 17..18,
                                 name: "x",
                             },
-                            kind: Let,
+                            kind: Let {
+                                backpassing: false,
+                            },
                             annotation: None,
                         },
                         Var {

--- a/crates/aiken-lang/src/tipo/expr.rs
+++ b/crates/aiken-lang/src/tipo/expr.rs
@@ -8,12 +8,12 @@ use super::{
 };
 use crate::{
     ast::{
-        Annotation, Arg, ArgName, AssignmentKind, BinOp, Bls12_381Point, ByteArrayFormatPreference,
-        CallArg, ClauseGuard, Constant, Curve, IfBranch, LogicalOpChainKind, Pattern,
-        RecordUpdateSpread, Span, TraceKind, TraceLevel, Tracing, TypedArg, TypedCallArg,
-        TypedClause, TypedClauseGuard, TypedIfBranch, TypedPattern, TypedRecordUpdateArg, UnOp,
-        UntypedArg, UntypedClause, UntypedClauseGuard, UntypedIfBranch, UntypedPattern,
-        UntypedRecordUpdateArg,
+        self, Annotation, Arg, ArgName, AssignmentKind, BinOp, Bls12_381Point,
+        ByteArrayFormatPreference, CallArg, ClauseGuard, Constant, Curve, IfBranch,
+        LogicalOpChainKind, Pattern, RecordUpdateSpread, Span, TraceKind, TraceLevel, Tracing,
+        TypedArg, TypedCallArg, TypedClause, TypedClauseGuard, TypedIfBranch, TypedPattern,
+        TypedRecordUpdateArg, UnOp, UntypedArg, UntypedClause, UntypedClauseGuard, UntypedIfBranch,
+        UntypedPattern, UntypedRecordUpdateArg,
     },
     builtins::{
         bool, byte_array, function, g1_element, g2_element, int, list, string, tuple, void,
@@ -24,7 +24,7 @@ use crate::{
     tipo::{fields::FieldMap, PatternConstructor, TypeVar},
 };
 use std::{cmp::Ordering, collections::HashMap, ops::Deref, rc::Rc};
-use vec1::{vec1, Vec1};
+use vec1::Vec1;
 
 #[derive(Debug)]
 pub(crate) struct ExprTyper<'a, 'b> {
@@ -1711,27 +1711,150 @@ impl<'a, 'b> ExprTyper<'a, 'b> {
         PipeTyper::infer(self, expressions)
     }
 
-    fn infer_seq(&mut self, location: Span, untyped: Vec<UntypedExpr>) -> Result<TypedExpr, Error> {
-        let mut breakpoint = None;
+    fn backpass(&mut self, breakpoint: UntypedExpr, continuation: Vec<UntypedExpr>) -> UntypedExpr {
+        let (assign_location, value, pattern, annotation) = match breakpoint {
+            UntypedExpr::Assignment {
+                location,
+                value,
+                pattern,
+                annotation,
+                ..
+            } => (location, value, pattern, annotation),
+            _ => unreachable!("backpass misuse: breakpoint isn't an Assignment ?!"),
+        };
 
-        let mut sequence = self.in_new_scope(|scope| {
-            let count = untyped.len();
+        // In case where we have a Pattern that isn't simply a let-binding to a name, we do insert an extra let-binding
+        // in front of the continuation sequence. This is because we do not support patterns in function argument
+        // (which is perhaps something we should support?).
+        let (name, continuation) = match pattern {
+            Pattern::Var { name, .. } | Pattern::Discard { name, .. } => {
+                (name.clone(), continuation)
+            }
+            _ => {
+                let mut with_assignment = vec![UntypedExpr::Assignment {
+                    location: assign_location,
+                    value: UntypedExpr::Var {
+                        location: assign_location,
+                        name: ast::BACKPASS_VARIABLE.to_string(),
+                    }
+                    .into(),
+                    pattern,
+                    kind: AssignmentKind::Let,
+                    annotation,
+                }];
+                with_assignment.extend(continuation);
+                (ast::BACKPASS_VARIABLE.to_string(), with_assignment)
+            }
+        };
+
+        match *value {
+            UntypedExpr::Call {
+                location: call_location,
+                fun,
+                arguments,
+            } => {
+                let mut new_arguments = Vec::new();
+                new_arguments.extend(arguments);
+                new_arguments.push(CallArg {
+                    location: assign_location,
+                    label: None,
+                    value: UntypedExpr::lambda(name, continuation, call_location),
+                });
+
+                UntypedExpr::Call {
+                    location: call_location,
+                    fun,
+                    arguments: new_arguments,
+                }
+            }
+
+            // This typically occurs on function captures. We do not try to assert anything on the
+            // length of the arguments here. We defer that to the rest of the type-checker. The
+            // only thing we have to do is rewrite the AST as-if someone had passed a callback.
+            //
+            // Now, whether this leads to an invalid call usage, that's not *our* immediate
+            // problem.
+            UntypedExpr::Fn {
+                location: call_location,
+                fn_style,
+                ref arguments,
+                ref return_annotation,
+                ..
+            } => {
+                let return_annotation = return_annotation.clone();
+
+                let arguments = arguments.iter().skip(1).cloned().collect::<Vec<_>>();
+
+                let call = UntypedExpr::Call {
+                    location: call_location,
+                    fun: value,
+                    arguments: vec![CallArg {
+                        location: assign_location,
+                        label: None,
+                        value: UntypedExpr::lambda(name, continuation, call_location),
+                    }],
+                };
+
+                if arguments.is_empty() {
+                    call
+                } else {
+                    UntypedExpr::Fn {
+                        location: call_location,
+                        fn_style,
+                        arguments,
+                        body: call.into(),
+                        return_annotation,
+                    }
+                }
+            }
+
+            // Similarly to function captures, if we have any other expression we simply call it
+            // with our continuation. If the expression isn't callable? No problem, the
+            // type-checker will catch that eventually in exactly the same way as if the code was
+            // written like that to begin with.
+            _ => UntypedExpr::Call {
+                location: assign_location,
+                fun: value,
+                arguments: vec![CallArg {
+                    location: assign_location,
+                    label: None,
+                    value: UntypedExpr::lambda(name, continuation, assign_location),
+                }],
+            },
+        }
+    }
+
+    fn infer_seq(&mut self, location: Span, untyped: Vec<UntypedExpr>) -> Result<TypedExpr, Error> {
+        // Search for backpassing.
+        let mut breakpoint = None;
+        let mut prefix = Vec::with_capacity(untyped.len());
+        let mut suffix = Vec::with_capacity(untyped.len());
+        for expression in untyped.into_iter() {
+            match expression {
+                _ if breakpoint.is_some() => suffix.push(expression),
+                UntypedExpr::Assignment {
+                    kind: AssignmentKind::Bind,
+                    ..
+                } => {
+                    breakpoint = Some(expression);
+                }
+                _ => prefix.push(expression),
+            }
+        }
+        if let Some(breakpoint) = breakpoint {
+            prefix.push(self.backpass(breakpoint, suffix));
+            return self.infer_seq(location, prefix);
+        }
+
+        let sequence = self.in_new_scope(|scope| {
+            let count = prefix.len();
 
             let mut expressions = Vec::with_capacity(count);
 
-            for (i, expression) in untyped.iter().enumerate() {
-                let no_assignment = assert_no_assignment(expression);
+            for (i, expression) in prefix.into_iter().enumerate() {
+                let no_assignment = assert_no_assignment(&expression);
 
-                let typed_expression = match expression {
-                    UntypedExpr::Assignment {
-                        kind: AssignmentKind::Bind,
-                        ..
-                    } => {
-                        breakpoint = Some((i, expression.clone()));
-                        return Ok(expressions);
-                    }
-                    _ => scope.infer(expression.to_owned())?,
-                };
+                let typed_expression = scope.infer(expression)?;
 
                 expressions.push(match i.cmp(&(count - 1)) {
                     // When the expression is the last in a sequence, we enforce it is NOT
@@ -1752,74 +1875,6 @@ impl<'a, 'b> ExprTyper<'a, 'b> {
 
             Ok(expressions)
         })?;
-
-        if let Some((
-            i,
-            UntypedExpr::Assignment {
-                location,
-                value,
-                pattern,
-                ..
-            },
-        )) = breakpoint
-        {
-            let then = UntypedExpr::Sequence {
-                location,
-                expressions: untyped.into_iter().skip(i + 1).collect::<Vec<_>>(),
-            };
-
-            // TODO: This must be constructed based on the inferred type of *value*.
-            //
-            //     let tipo = self.infer(untyped_value.clone())?.tipo();
-            //
-            // The following is the `and_then` for Option. The one for Fuzzer is a bit
-            // different.
-            let desugar = UntypedExpr::When {
-                location,
-                subject: value.clone(),
-                clauses: vec![
-                    UntypedClause {
-                        location,
-                        guard: None,
-                        patterns: vec1![Pattern::Constructor {
-                            location,
-                            is_record: false,
-                            with_spread: false,
-                            name: "None".to_string(),
-                            module: None,
-                            constructor: (),
-                            tipo: (),
-                            arguments: vec![],
-                        }],
-                        then: UntypedExpr::Var {
-                            location,
-                            name: "None".to_string(),
-                        },
-                    },
-                    UntypedClause {
-                        location,
-                        guard: None,
-                        patterns: vec1![Pattern::Constructor {
-                            location,
-                            is_record: false,
-                            with_spread: false,
-                            name: "Some".to_string(),
-                            module: None,
-                            constructor: (),
-                            tipo: (),
-                            arguments: vec![CallArg {
-                                location,
-                                label: None,
-                                value: pattern.clone(),
-                            }],
-                        }],
-                        then,
-                    },
-                ],
-            };
-
-            sequence.push(self.infer(desugar)?);
-        };
 
         let unused = self
             .environment

--- a/crates/aiken-lang/src/tipo/pipe.rs
+++ b/crates/aiken-lang/src/tipo/pipe.rs
@@ -1,18 +1,15 @@
-use std::{ops::Deref, rc::Rc};
-
-use vec1::Vec1;
-
-use crate::{
-    ast::{AssignmentKind, CallArg, Pattern, Span, PIPE_VARIABLE},
-    builtins::function,
-    expr::{TypedExpr, UntypedExpr},
-};
-
 use super::{
     error::{Error, UnifyErrorSituation},
     expr::ExprTyper,
     Type, ValueConstructor, ValueConstructorVariant,
 };
+use crate::{
+    ast::{AssignmentKind, CallArg, Pattern, Span, PIPE_VARIABLE},
+    builtins::function,
+    expr::{TypedExpr, UntypedExpr},
+};
+use std::{ops::Deref, rc::Rc};
+use vec1::Vec1;
 
 #[derive(Debug)]
 pub(crate) struct PipeTyper<'a, 'b, 'c> {
@@ -184,7 +181,7 @@ impl<'a, 'b, 'c> PipeTyper<'a, 'b, 'c> {
         let assignment = TypedExpr::Assignment {
             location,
             tipo: expression.tipo(),
-            kind: AssignmentKind::Let,
+            kind: AssignmentKind::let_(),
             value: Box::new(expression),
             pattern: Pattern::Var {
                 location,


### PR DESCRIPTION
| <img width="360" alt="image" src="https://github.com/aiken-lang/aiken/assets/5680256/f8ff628c-d9f8-4dfe-9569-972a08f24d48"> | <img width="360" alt="Screenshot 2024-03-11 at 00 12 37" src="https://github.com/aiken-lang/aiken/assets/5680256/384af358-573d-4ae3-a7f5-528ccf2316fb"> |
| --- | --- |
| <img width="360" alt="Screenshot 2024-03-11 at 00 06 18" src="https://github.com/aiken-lang/aiken/assets/5680256/dab874f9-3eb5-4362-9faa-a179feeb9efa"> | <img width="360" alt="Screenshot 2024-03-11 at 00 05 59" src="https://github.com/aiken-lang/aiken/assets/5680256/094fee9c-c946-4b95-b712-ace9733165d5"> |

- :round_pushpin: **Experiment with monadic bind.**
  
- :round_pushpin: **Rework monadic-bind into function backpassing.**
    This is more holistic and less awkward than having monadic bind working only with some pre-defined type. Backpassing work with _any_ function, and can be implemented relatively easily by rewriting the AST on-the-fly.

  Also, it is far easier to explain than trying to explain what a monadic bind is, how its behavior differs from type to type and why it isn't generally available for any monadic type.

- :round_pushpin: **Refactor AssignmentKind to allow backpassing on both let and expect.**
    The 3rd kind of assignment kind (Bind) is gone and now reflected through a boolean parameter. Note that this parameter is completely erased by the type-checker so that the rest of the pipeline (i.e. code-generation) doesn't have to make any assumption. They simply can't see a backpassing let or expect.

- :round_pushpin: **Allow backpassing with expect.**
  
- :round_pushpin: **Fix spans and error reporting for backpassing.**
  
