### PR TITLE
Initial pass at watch filtering

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -70,6 +70,7 @@ dependencies = [
  "rand",
  "regex",
  "serde_json",
+ "termion",
  "thiserror",
  "uplc",
 ]
@@ -1644,6 +1645,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "libredox"
+version = "0.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3af92c55d7d839293953fcd0fda5ecfe93297cfde6ffbdec13b41d99c0ba6607"
+dependencies = [
+ "bitflags 2.4.2",
+ "libc",
+ "redox_syscall",
+]
+
+[[package]]
 name = "libz-sys"
 version = "1.1.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1923,6 +1935,12 @@ dependencies = [
  "hermit-abi 0.3.9",
  "libc",
 ]
+
+[[package]]
+name = "numtoa"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8f8bdf33df195859076e54ab11ee78a1b208382d3a26ec40d142ffc1ecc49ef"
 
 [[package]]
 name = "object"
@@ -2573,13 +2591,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "redox_termios"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "20145670ba436b55d91fc92d25e71160fbfbdd57831631c8d7d36377a476f1cb"
+
+[[package]]
 name = "redox_users"
 version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a18479200779601e498ada4e8c1e1f50e3ee19deb0259c25825a98b5603b2cb4"
 dependencies = [
  "getrandom",
- "libredox",
+ "libredox 0.0.1",
  "thiserror",
 ]
 
@@ -3146,6 +3170,18 @@ checksum = "21bebf2b7c9e0a515f6e0f8c51dc0f8e4696391e6f1ff30379559f8365fb0df7"
 dependencies = [
  "rustix",
  "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "termion"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "417813675a504dfbbf21bfde32c03e5bf9f2413999962b479023c02848c1c7a5"
+dependencies = [
+ "libc",
+ "libredox 0.0.2",
+ "numtoa",
+ "redox_termios",
 ]
 
 [[package]]

--- a/crates/aiken/Cargo.toml
+++ b/crates/aiken/Cargo.toml
@@ -30,6 +30,8 @@ regex = "1.7.1"
 serde_json = "1.0.94"
 thiserror = "1.0.39"
 
+termion = "3.0.0"
+
 aiken-lang = { path = "../aiken-lang", version = "1.0.24-alpha" }
 aiken-lsp = { path = "../aiken-lsp", version = "1.0.24-alpha" }
 aiken-project = { path = '../aiken-project', version = "1.0.24-alpha" }

--- a/crates/aiken/src/cmd/build.rs
+++ b/crates/aiken/src/cmd/build.rs
@@ -51,7 +51,7 @@ pub fn exec(
     }: Args,
 ) -> miette::Result<()> {
     let result = if watch {
-        watch_project(directory.as_deref(), watch::default_filter, 500, |p| {
+        watch_project(directory.as_deref(), None, watch::default_filter, 500, |p| {
             p.build(
                 uplc,
                 match filter_traces {

--- a/crates/aiken/src/cmd/docs.rs
+++ b/crates/aiken/src/cmd/docs.rs
@@ -34,7 +34,7 @@ pub fn exec(
     }: Args,
 ) -> miette::Result<()> {
     let result = if watch {
-        watch_project(directory.as_deref(), watch::default_filter, 500, |p| {
+        watch_project(directory.as_deref(), None, watch::default_filter, 500, |p| {
             p.docs(destination.clone(), include_dependencies)
         })
     } else {


### PR DESCRIPTION
This allows you to type and hit enter while running check --watch, which will update the -m setting, basically.

This can be super useful for filtering down to just one test to run and iterate on, before pressing enter again to clear it out and go back to running everything again.

I'm sure this deserves some cleanup, but I wanted to get this out there for feedback.

Related to a discussion I started here: https://github.com/aiken-lang/aiken/discussions/865