### PR TITLE
backpassing multiple patterns

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 .idea
 _site/
 temp/
+scratch/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
 - **aiken**: The `check` command now accept an extra (optional) option `--max-success` to control the number of property-test iterations to perform. @KtorZ
 - **aiken**: The `docs` command now accept an optional flag `--include-dependencies` to include all dependencies in the generated documentation. @KtorZ
 - **aiken-lang**: Implement [function backpassing](https://www.roc-lang.org/tutorial#backpassing) as a syntactic sugar. @KtorZ
+- **aiken-lang**: Extend backpassing to support multiple patterns/arguments. @rvcas
 
 ### Fixed
 

--- a/crates/aiken-lang/src/ast.rs
+++ b/crates/aiken-lang/src/ast.rs
@@ -1782,6 +1782,47 @@ impl Span {
         }
     }
 
+    /// Map the current start and end of the Span to new values.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use aiken_lang::ast::Span;
+    ///
+    /// let span = Span { start: 0, end: 1 };
+    ///
+    /// let other = span.map(|start, end| (start + 2, end + 4));
+    ///
+    /// assert_eq!(other.start, 2);
+    /// assert_eq!(other.end, 5);
+    /// ```
+    pub fn map<F: FnOnce(usize, usize) -> (usize, usize)>(&self, f: F) -> Self {
+        let (start, end) = f(self.start, self.end);
+
+        Self { start, end }
+    }
+
+    /// Map the current end of the Span to a new value.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use aiken_lang::ast::Span;
+    ///
+    /// let span = Span { start: 0, end: 1 };
+    ///
+    /// let other = span.map_end(|end| end + 1);
+    ///
+    /// assert_eq!(other.start, 0);
+    /// assert_eq!(other.end, 2);
+    /// ```
+    pub fn map_end<F: FnOnce(usize) -> usize>(&self, f: F) -> Self {
+        Self {
+            start: self.start,
+            end: f(self.end),
+        }
+    }
+
     pub fn contains(&self, byte_index: usize) -> bool {
         byte_index >= self.start && byte_index < self.end
     }

--- a/crates/aiken-lang/src/ast.rs
+++ b/crates/aiken-lang/src/ast.rs
@@ -1436,6 +1436,27 @@ impl Default for Bls12_381Point {
     }
 }
 
+#[derive(Debug, Clone, PartialEq)]
+pub struct AssignmentPattern {
+    pub pattern: UntypedPattern,
+    pub annotation: Option<Annotation>,
+}
+
+impl AssignmentPattern {
+    pub fn new(pattern: UntypedPattern, annotation: Option<Annotation>) -> AssignmentPattern {
+        Self {
+            pattern,
+            annotation,
+        }
+    }
+}
+
+impl From<AssignmentPattern> for Vec1<AssignmentPattern> {
+    fn from(value: AssignmentPattern) -> Self {
+        Vec1::new(value)
+    }
+}
+
 pub type UntypedAssignmentKind = AssignmentKind<bool>;
 pub type TypedAssignmentKind = AssignmentKind<()>;
 

--- a/crates/aiken-lang/src/expr.rs
+++ b/crates/aiken-lang/src/expr.rs
@@ -1,10 +1,10 @@
 use crate::{
     ast::{
-        self, Annotation, Arg, ArgName, BinOp, Bls12_381Point, ByteArrayFormatPreference, CallArg,
-        Curve, DataType, DataTypeKey, DefinitionLocation, IfBranch, Located, LogicalOpChainKind,
-        ParsedCallArg, Pattern, RecordConstructorArg, RecordUpdateSpread, Span, TraceKind,
-        TypedAssignmentKind, TypedClause, TypedDataType, TypedRecordUpdateArg, UnOp,
-        UntypedAssignmentKind, UntypedClause, UntypedPattern, UntypedRecordUpdateArg,
+        self, Annotation, Arg, ArgName, AssignmentPattern, BinOp, Bls12_381Point,
+        ByteArrayFormatPreference, CallArg, Curve, DataType, DataTypeKey, DefinitionLocation,
+        IfBranch, Located, LogicalOpChainKind, ParsedCallArg, Pattern, RecordConstructorArg,
+        RecordUpdateSpread, Span, TraceKind, TypedAssignmentKind, TypedClause, TypedDataType,
+        TypedRecordUpdateArg, UnOp, UntypedAssignmentKind, UntypedClause, UntypedRecordUpdateArg,
     },
     builtins::void,
     parser::token::Base,
@@ -518,7 +518,7 @@ pub enum UntypedExpr {
     Assignment {
         location: Span,
         value: Box<Self>,
-        patterns: Vec1<(UntypedPattern, Option<Annotation>)>,
+        patterns: Vec1<AssignmentPattern>,
         kind: UntypedAssignmentKind,
     },
 

--- a/crates/aiken-lang/src/format.rs
+++ b/crates/aiken-lang/src/format.rs
@@ -727,8 +727,7 @@ impl<'comments> Formatter<'comments> {
                     .append(break_("", " "))
                     .append(join(patterns, break_(",", ", ")))
                     .nest(INDENT)
-                    .append(break_(",", ""))
-                    .append(break_("", " "))
+                    .append(break_(",", " "))
                     .append(symbol)
                     .append(self.case_clause_value(value))
             }

--- a/crates/aiken-lang/src/parser/definition/snapshots/def_test_fail.snap
+++ b/crates/aiken-lang/src/parser/definition/snapshots/def_test_fail.snap
@@ -15,8 +15,8 @@ Test(
                         name: "False",
                     },
                     patterns: [
-                        (
-                            Constructor {
+                        AssignmentPattern {
+                            pattern: Constructor {
                                 is_record: false,
                                 location: 38..42,
                                 name: "True",
@@ -26,8 +26,8 @@ Test(
                                 with_spread: false,
                                 tipo: (),
                             },
-                            None,
-                        ),
+                            annotation: None,
+                        },
                     ],
                     kind: Expect {
                         backpassing: false,

--- a/crates/aiken-lang/src/parser/definition/snapshots/def_test_fail.snap
+++ b/crates/aiken-lang/src/parser/definition/snapshots/def_test_fail.snap
@@ -14,20 +14,24 @@ Test(
                         location: 45..50,
                         name: "False",
                     },
-                    pattern: Constructor {
-                        is_record: false,
-                        location: 38..42,
-                        name: "True",
-                        arguments: [],
-                        module: None,
-                        constructor: (),
-                        with_spread: false,
-                        tipo: (),
-                    },
+                    patterns: [
+                        (
+                            Constructor {
+                                is_record: false,
+                                location: 38..42,
+                                name: "True",
+                                arguments: [],
+                                module: None,
+                                constructor: (),
+                                with_spread: false,
+                                tipo: (),
+                            },
+                            None,
+                        ),
+                    ],
                     kind: Expect {
                         backpassing: false,
                     },
-                    annotation: None,
                 },
                 Var {
                     location: 54..59,

--- a/crates/aiken-lang/src/parser/definition/snapshots/function_assignment_only.snap
+++ b/crates/aiken-lang/src/parser/definition/snapshots/function_assignment_only.snap
@@ -26,13 +26,13 @@ Fn(
                 },
             },
             patterns: [
-                (
-                    Var {
+                AssignmentPattern {
+                    pattern: Var {
                         location: 17..18,
                         name: "x",
                     },
-                    None,
-                ),
+                    annotation: None,
+                },
             ],
             kind: Let {
                 backpassing: false,

--- a/crates/aiken-lang/src/parser/definition/snapshots/function_assignment_only.snap
+++ b/crates/aiken-lang/src/parser/definition/snapshots/function_assignment_only.snap
@@ -25,14 +25,18 @@ Fn(
                     },
                 },
             },
-            pattern: Var {
-                location: 17..18,
-                name: "x",
-            },
+            patterns: [
+                (
+                    Var {
+                        location: 17..18,
+                        name: "x",
+                    },
+                    None,
+                ),
+            ],
             kind: Let {
                 backpassing: false,
             },
-            annotation: None,
         },
         doc: None,
         location: 0..8,

--- a/crates/aiken-lang/src/parser/expr/assignment.rs
+++ b/crates/aiken-lang/src/parser/expr/assignment.rs
@@ -12,6 +12,10 @@ pub fn let_(
         .ignore_then(
             pattern()
                 .then(just(Token::Colon).ignore_then(annotation()).or_not())
+                .map(|(pattern, annotation)| ast::AssignmentPattern {
+                    pattern,
+                    annotation,
+                })
                 .separated_by(just(Token::Comma))
                 .at_least(1),
         )
@@ -44,6 +48,10 @@ pub fn expect(
         .ignore_then(
             pattern()
                 .then(just(Token::Colon).ignore_then(annotation()).or_not())
+                .map(|(pattern, annotation)| ast::AssignmentPattern {
+                    pattern,
+                    annotation,
+                })
                 .separated_by(just(Token::Comma))
                 .at_least(1)
                 .then(choice((just(Token::Equal), just(Token::LArrow))))
@@ -57,8 +65,8 @@ pub fn expect(
 
             let (patterns, kind) = opt_pattern.unwrap_or_else(|| {
                 (
-                    vec![(
-                        ast::UntypedPattern::Constructor {
+                    vec![ast::AssignmentPattern {
+                        pattern: ast::UntypedPattern::Constructor {
                             is_record: false,
                             location: span,
                             name: "True".to_string(),
@@ -68,8 +76,8 @@ pub fn expect(
                             with_spread: false,
                             tipo: (),
                         },
-                        None,
-                    )],
+                        annotation: None,
+                    }],
                     Token::Equal,
                 )
             });

--- a/crates/aiken-lang/src/parser/expr/assignment.rs
+++ b/crates/aiken-lang/src/parser/expr/assignment.rs
@@ -17,6 +17,7 @@ pub fn let_(
                     annotation,
                 })
                 .separated_by(just(Token::Comma))
+                .allow_trailing()
                 .at_least(1),
         )
         .then(choice((just(Token::Equal), just(Token::LArrow))))
@@ -53,6 +54,7 @@ pub fn expect(
                     annotation,
                 })
                 .separated_by(just(Token::Comma))
+                .allow_trailing()
                 .at_least(1)
                 .then(choice((just(Token::Equal), just(Token::LArrow))))
                 .or_not(),

--- a/crates/aiken-lang/src/parser/expr/snapshots/block_let.snap
+++ b/crates/aiken-lang/src/parser/expr/snapshots/block_let.snap
@@ -16,14 +16,18 @@ Assignment {
                         numeric_underscore: false,
                     },
                 },
-                pattern: Var {
-                    location: 16..17,
-                    name: "x",
-                },
+                patterns: [
+                    (
+                        Var {
+                            location: 16..17,
+                            name: "x",
+                        },
+                        None,
+                    ),
+                ],
                 kind: Let {
                     backpassing: false,
                 },
-                annotation: None,
             },
             BinOp {
                 location: 24..29,
@@ -42,12 +46,16 @@ Assignment {
             },
         ],
     },
-    pattern: Var {
-        location: 4..5,
-        name: "b",
-    },
+    patterns: [
+        (
+            Var {
+                location: 4..5,
+                name: "b",
+            },
+            None,
+        ),
+    ],
     kind: Let {
         backpassing: false,
     },
-    annotation: None,
 }

--- a/crates/aiken-lang/src/parser/expr/snapshots/block_let.snap
+++ b/crates/aiken-lang/src/parser/expr/snapshots/block_let.snap
@@ -17,13 +17,13 @@ Assignment {
                     },
                 },
                 patterns: [
-                    (
-                        Var {
+                    AssignmentPattern {
+                        pattern: Var {
                             location: 16..17,
                             name: "x",
                         },
-                        None,
-                    ),
+                        annotation: None,
+                    },
                 ],
                 kind: Let {
                     backpassing: false,
@@ -47,13 +47,13 @@ Assignment {
         ],
     },
     patterns: [
-        (
-            Var {
+        AssignmentPattern {
+            pattern: Var {
                 location: 4..5,
                 name: "b",
             },
-            None,
-        ),
+            annotation: None,
+        },
     ],
     kind: Let {
         backpassing: false,

--- a/crates/aiken-lang/src/parser/expr/snapshots/expect.snap
+++ b/crates/aiken-lang/src/parser/expr/snapshots/expect.snap
@@ -12,27 +12,31 @@ Assignment {
             name: "something",
         },
     },
-    pattern: Constructor {
-        is_record: false,
-        location: 7..14,
-        name: "Some",
-        arguments: [
-            CallArg {
-                label: None,
-                location: 12..13,
-                value: Var {
-                    location: 12..13,
-                    name: "x",
-                },
+    patterns: [
+        (
+            Constructor {
+                is_record: false,
+                location: 7..14,
+                name: "Some",
+                arguments: [
+                    CallArg {
+                        label: None,
+                        location: 12..13,
+                        value: Var {
+                            location: 12..13,
+                            name: "x",
+                        },
+                    },
+                ],
+                module: None,
+                constructor: (),
+                with_spread: false,
+                tipo: (),
             },
-        ],
-        module: None,
-        constructor: (),
-        with_spread: false,
-        tipo: (),
-    },
+            None,
+        ),
+    ],
     kind: Expect {
         backpassing: false,
     },
-    annotation: None,
 }

--- a/crates/aiken-lang/src/parser/expr/snapshots/expect.snap
+++ b/crates/aiken-lang/src/parser/expr/snapshots/expect.snap
@@ -13,8 +13,8 @@ Assignment {
         },
     },
     patterns: [
-        (
-            Constructor {
+        AssignmentPattern {
+            pattern: Constructor {
                 is_record: false,
                 location: 7..14,
                 name: "Some",
@@ -33,8 +33,8 @@ Assignment {
                 with_spread: false,
                 tipo: (),
             },
-            None,
-        ),
+            annotation: None,
+        },
     ],
     kind: Expect {
         backpassing: false,

--- a/crates/aiken-lang/src/parser/expr/snapshots/expect_bool_sugar.snap
+++ b/crates/aiken-lang/src/parser/expr/snapshots/expect_bool_sugar.snap
@@ -21,8 +21,8 @@ Assignment {
         },
     },
     patterns: [
-        (
-            Constructor {
+        AssignmentPattern {
+            pattern: Constructor {
                 is_record: false,
                 location: 0..29,
                 name: "True",
@@ -32,8 +32,8 @@ Assignment {
                 with_spread: false,
                 tipo: (),
             },
-            None,
-        ),
+            annotation: None,
+        },
     ],
     kind: Expect {
         backpassing: false,

--- a/crates/aiken-lang/src/parser/expr/snapshots/expect_bool_sugar.snap
+++ b/crates/aiken-lang/src/parser/expr/snapshots/expect_bool_sugar.snap
@@ -20,18 +20,22 @@ Assignment {
             name: "wow",
         },
     },
-    pattern: Constructor {
-        is_record: false,
-        location: 0..29,
-        name: "True",
-        arguments: [],
-        module: None,
-        constructor: (),
-        with_spread: false,
-        tipo: (),
-    },
+    patterns: [
+        (
+            Constructor {
+                is_record: false,
+                location: 0..29,
+                name: "True",
+                arguments: [],
+                module: None,
+                constructor: (),
+                with_spread: false,
+                tipo: (),
+            },
+            None,
+        ),
+    ],
     kind: Expect {
         backpassing: false,
     },
-    annotation: None,
 }

--- a/crates/aiken-lang/src/parser/expr/snapshots/expect_expect_let.snap
+++ b/crates/aiken-lang/src/parser/expr/snapshots/expect_expect_let.snap
@@ -17,13 +17,13 @@ Assignment {
                     },
                 },
                 patterns: [
-                    (
-                        Var {
+                    AssignmentPattern {
+                        pattern: Var {
                             location: 13..14,
                             name: "a",
                         },
-                        None,
-                    ),
+                        annotation: None,
+                    },
                 ],
                 kind: Let {
                     backpassing: false,
@@ -32,8 +32,8 @@ Assignment {
         ],
     },
     patterns: [
-        (
-            Constructor {
+        AssignmentPattern {
+            pattern: Constructor {
                 is_record: false,
                 location: 0..21,
                 name: "True",
@@ -43,8 +43,8 @@ Assignment {
                 with_spread: false,
                 tipo: (),
             },
-            None,
-        ),
+            annotation: None,
+        },
     ],
     kind: Expect {
         backpassing: false,

--- a/crates/aiken-lang/src/parser/expr/snapshots/expect_expect_let.snap
+++ b/crates/aiken-lang/src/parser/expr/snapshots/expect_expect_let.snap
@@ -16,29 +16,37 @@ Assignment {
                         numeric_underscore: false,
                     },
                 },
-                pattern: Var {
-                    location: 13..14,
-                    name: "a",
-                },
+                patterns: [
+                    (
+                        Var {
+                            location: 13..14,
+                            name: "a",
+                        },
+                        None,
+                    ),
+                ],
                 kind: Let {
                     backpassing: false,
                 },
-                annotation: None,
             },
         ],
     },
-    pattern: Constructor {
-        is_record: false,
-        location: 0..21,
-        name: "True",
-        arguments: [],
-        module: None,
-        constructor: (),
-        with_spread: false,
-        tipo: (),
-    },
+    patterns: [
+        (
+            Constructor {
+                is_record: false,
+                location: 0..21,
+                name: "True",
+                arguments: [],
+                module: None,
+                constructor: (),
+                with_spread: false,
+                tipo: (),
+            },
+            None,
+        ),
+    ],
     kind: Expect {
         backpassing: false,
     },
-    annotation: None,
 }

--- a/crates/aiken-lang/src/parser/expr/snapshots/expect_let_in_let.snap
+++ b/crates/aiken-lang/src/parser/expr/snapshots/expect_let_in_let.snap
@@ -16,23 +16,31 @@ Assignment {
                         numeric_underscore: false,
                     },
                 },
-                pattern: Var {
-                    location: 14..15,
-                    name: "b",
-                },
+                patterns: [
+                    (
+                        Var {
+                            location: 14..15,
+                            name: "b",
+                        },
+                        None,
+                    ),
+                ],
                 kind: Let {
                     backpassing: false,
                 },
-                annotation: None,
             },
         ],
     },
-    pattern: Var {
-        location: 4..5,
-        name: "a",
-    },
+    patterns: [
+        (
+            Var {
+                location: 4..5,
+                name: "a",
+            },
+            None,
+        ),
+    ],
     kind: Let {
         backpassing: false,
     },
-    annotation: None,
 }

--- a/crates/aiken-lang/src/parser/expr/snapshots/expect_let_in_let.snap
+++ b/crates/aiken-lang/src/parser/expr/snapshots/expect_let_in_let.snap
@@ -17,13 +17,13 @@ Assignment {
                     },
                 },
                 patterns: [
-                    (
-                        Var {
+                    AssignmentPattern {
+                        pattern: Var {
                             location: 14..15,
                             name: "b",
                         },
-                        None,
-                    ),
+                        annotation: None,
+                    },
                 ],
                 kind: Let {
                     backpassing: false,
@@ -32,13 +32,13 @@ Assignment {
         ],
     },
     patterns: [
-        (
-            Var {
+        AssignmentPattern {
+            pattern: Var {
                 location: 4..5,
                 name: "a",
             },
-            None,
-        ),
+            annotation: None,
+        },
     ],
     kind: Let {
         backpassing: false,

--- a/crates/aiken-lang/src/parser/expr/snapshots/expect_let_in_let_parens.snap
+++ b/crates/aiken-lang/src/parser/expr/snapshots/expect_let_in_let_parens.snap
@@ -16,23 +16,31 @@ Assignment {
                         numeric_underscore: false,
                     },
                 },
-                pattern: Var {
-                    location: 14..15,
-                    name: "b",
-                },
+                patterns: [
+                    (
+                        Var {
+                            location: 14..15,
+                            name: "b",
+                        },
+                        None,
+                    ),
+                ],
                 kind: Let {
                     backpassing: false,
                 },
-                annotation: None,
             },
         ],
     },
-    pattern: Var {
-        location: 4..5,
-        name: "a",
-    },
+    patterns: [
+        (
+            Var {
+                location: 4..5,
+                name: "a",
+            },
+            None,
+        ),
+    ],
     kind: Let {
         backpassing: false,
     },
-    annotation: None,
 }

--- a/crates/aiken-lang/src/parser/expr/snapshots/expect_let_in_let_parens.snap
+++ b/crates/aiken-lang/src/parser/expr/snapshots/expect_let_in_let_parens.snap
@@ -17,13 +17,13 @@ Assignment {
                     },
                 },
                 patterns: [
-                    (
-                        Var {
+                    AssignmentPattern {
+                        pattern: Var {
                             location: 14..15,
                             name: "b",
                         },
-                        None,
-                    ),
+                        annotation: None,
+                    },
                 ],
                 kind: Let {
                     backpassing: false,
@@ -32,13 +32,13 @@ Assignment {
         ],
     },
     patterns: [
-        (
-            Var {
+        AssignmentPattern {
+            pattern: Var {
                 location: 4..5,
                 name: "a",
             },
-            None,
-        ),
+            annotation: None,
+        },
     ],
     kind: Let {
         backpassing: false,

--- a/crates/aiken-lang/src/parser/expr/snapshots/expect_let_in_let_return.snap
+++ b/crates/aiken-lang/src/parser/expr/snapshots/expect_let_in_let_return.snap
@@ -17,13 +17,13 @@ Assignment {
                     },
                 },
                 patterns: [
-                    (
-                        Var {
+                    AssignmentPattern {
+                        pattern: Var {
                             location: 16..17,
                             name: "b",
                         },
-                        None,
-                    ),
+                        annotation: None,
+                    },
                 ],
                 kind: Let {
                     backpassing: false,
@@ -36,13 +36,13 @@ Assignment {
         ],
     },
     patterns: [
-        (
-            Var {
+        AssignmentPattern {
+            pattern: Var {
                 location: 4..5,
                 name: "a",
             },
-            None,
-        ),
+            annotation: None,
+        },
     ],
     kind: Let {
         backpassing: false,

--- a/crates/aiken-lang/src/parser/expr/snapshots/expect_let_in_let_return.snap
+++ b/crates/aiken-lang/src/parser/expr/snapshots/expect_let_in_let_return.snap
@@ -16,14 +16,18 @@ Assignment {
                         numeric_underscore: false,
                     },
                 },
-                pattern: Var {
-                    location: 16..17,
-                    name: "b",
-                },
+                patterns: [
+                    (
+                        Var {
+                            location: 16..17,
+                            name: "b",
+                        },
+                        None,
+                    ),
+                ],
                 kind: Let {
                     backpassing: false,
                 },
-                annotation: None,
             },
             Var {
                 location: 25..26,
@@ -31,12 +35,16 @@ Assignment {
             },
         ],
     },
-    pattern: Var {
-        location: 4..5,
-        name: "a",
-    },
+    patterns: [
+        (
+            Var {
+                location: 4..5,
+                name: "a",
+            },
+            None,
+        ),
+    ],
     kind: Let {
         backpassing: false,
     },
-    annotation: None,
 }

--- a/crates/aiken-lang/src/parser/expr/snapshots/expect_trace_if_false.snap
+++ b/crates/aiken-lang/src/parser/expr/snapshots/expect_trace_if_false.snap
@@ -12,8 +12,8 @@ Assignment {
         },
     },
     patterns: [
-        (
-            Constructor {
+        AssignmentPattern {
+            pattern: Constructor {
                 is_record: false,
                 location: 0..11,
                 name: "True",
@@ -23,8 +23,8 @@ Assignment {
                 with_spread: false,
                 tipo: (),
             },
-            None,
-        ),
+            annotation: None,
+        },
     ],
     kind: Expect {
         backpassing: false,

--- a/crates/aiken-lang/src/parser/expr/snapshots/expect_trace_if_false.snap
+++ b/crates/aiken-lang/src/parser/expr/snapshots/expect_trace_if_false.snap
@@ -11,18 +11,22 @@ Assignment {
             name: "foo",
         },
     },
-    pattern: Constructor {
-        is_record: false,
-        location: 0..11,
-        name: "True",
-        arguments: [],
-        module: None,
-        constructor: (),
-        with_spread: false,
-        tipo: (),
-    },
+    patterns: [
+        (
+            Constructor {
+                is_record: false,
+                location: 0..11,
+                name: "True",
+                arguments: [],
+                module: None,
+                constructor: (),
+                with_spread: false,
+                tipo: (),
+            },
+            None,
+        ),
+    ],
     kind: Expect {
         backpassing: false,
     },
-    annotation: None,
 }

--- a/crates/aiken-lang/src/parser/expr/snapshots/function_invoke.snap
+++ b/crates/aiken-lang/src/parser/expr/snapshots/function_invoke.snap
@@ -28,13 +28,13 @@ Sequence {
                 location: 8..18,
             },
             patterns: [
-                (
-                    Var {
+                AssignmentPattern {
+                    pattern: Var {
                         location: 4..5,
                         name: "x",
                     },
-                    None,
-                ),
+                    annotation: None,
+                },
             ],
             kind: Let {
                 backpassing: false,
@@ -118,13 +118,13 @@ Sequence {
                 return_annotation: None,
             },
             patterns: [
-                (
-                    Var {
+                AssignmentPattern {
+                    pattern: Var {
                         location: 24..33,
                         name: "map_add_x",
                     },
-                    None,
-                ),
+                    annotation: None,
+                },
             ],
             kind: Let {
                 backpassing: false,

--- a/crates/aiken-lang/src/parser/expr/snapshots/function_invoke.snap
+++ b/crates/aiken-lang/src/parser/expr/snapshots/function_invoke.snap
@@ -27,14 +27,18 @@ Sequence {
                 },
                 location: 8..18,
             },
-            pattern: Var {
-                location: 4..5,
-                name: "x",
-            },
+            patterns: [
+                (
+                    Var {
+                        location: 4..5,
+                        name: "x",
+                    },
+                    None,
+                ),
+            ],
             kind: Let {
                 backpassing: false,
             },
-            annotation: None,
         },
         Assignment {
             location: 20..65,
@@ -113,14 +117,18 @@ Sequence {
                 },
                 return_annotation: None,
             },
-            pattern: Var {
-                location: 24..33,
-                name: "map_add_x",
-            },
+            patterns: [
+                (
+                    Var {
+                        location: 24..33,
+                        name: "map_add_x",
+                    },
+                    None,
+                ),
+            ],
             kind: Let {
                 backpassing: false,
             },
-            annotation: None,
         },
         Call {
             arguments: [

--- a/crates/aiken-lang/src/parser/expr/snapshots/int_numeric_underscore.snap
+++ b/crates/aiken-lang/src/parser/expr/snapshots/int_numeric_underscore.snap
@@ -14,14 +14,18 @@ Sequence {
                     numeric_underscore: true,
                 },
             },
-            pattern: Var {
-                location: 8..9,
-                name: "i",
-            },
+            patterns: [
+                (
+                    Var {
+                        location: 8..9,
+                        name: "i",
+                    },
+                    None,
+                ),
+            ],
             kind: Let {
                 backpassing: false,
             },
-            annotation: None,
         },
         Assignment {
             location: 24..41,
@@ -32,14 +36,18 @@ Sequence {
                     numeric_underscore: true,
                 },
             },
-            pattern: Var {
-                location: 28..29,
-                name: "j",
-            },
+            patterns: [
+                (
+                    Var {
+                        location: 28..29,
+                        name: "j",
+                    },
+                    None,
+                ),
+            ],
             kind: Let {
                 backpassing: false,
             },
-            annotation: None,
         },
         Assignment {
             location: 44..59,
@@ -54,14 +62,18 @@ Sequence {
                     },
                 },
             },
-            pattern: Var {
-                location: 48..49,
-                name: "k",
-            },
+            patterns: [
+                (
+                    Var {
+                        location: 48..49,
+                        name: "k",
+                    },
+                    None,
+                ),
+            ],
             kind: Let {
                 backpassing: false,
             },
-            annotation: None,
         },
     ],
 }

--- a/crates/aiken-lang/src/parser/expr/snapshots/int_numeric_underscore.snap
+++ b/crates/aiken-lang/src/parser/expr/snapshots/int_numeric_underscore.snap
@@ -15,13 +15,13 @@ Sequence {
                 },
             },
             patterns: [
-                (
-                    Var {
+                AssignmentPattern {
+                    pattern: Var {
                         location: 8..9,
                         name: "i",
                     },
-                    None,
-                ),
+                    annotation: None,
+                },
             ],
             kind: Let {
                 backpassing: false,
@@ -37,13 +37,13 @@ Sequence {
                 },
             },
             patterns: [
-                (
-                    Var {
+                AssignmentPattern {
+                    pattern: Var {
                         location: 28..29,
                         name: "j",
                     },
-                    None,
-                ),
+                    annotation: None,
+                },
             ],
             kind: Let {
                 backpassing: false,
@@ -63,13 +63,13 @@ Sequence {
                 },
             },
             patterns: [
-                (
-                    Var {
+                AssignmentPattern {
+                    pattern: Var {
                         location: 48..49,
                         name: "k",
                     },
-                    None,
-                ),
+                    annotation: None,
+                },
             ],
             kind: Let {
                 backpassing: false,

--- a/crates/aiken-lang/src/parser/expr/snapshots/let_bindings.snap
+++ b/crates/aiken-lang/src/parser/expr/snapshots/let_bindings.snap
@@ -29,13 +29,13 @@ Assignment {
         tail: None,
     },
     patterns: [
-        (
-            Var {
+        AssignmentPattern {
+            pattern: Var {
                 location: 4..9,
                 name: "thing",
             },
-            None,
-        ),
+            annotation: None,
+        },
     ],
     kind: Let {
         backpassing: false,

--- a/crates/aiken-lang/src/parser/expr/snapshots/let_bindings.snap
+++ b/crates/aiken-lang/src/parser/expr/snapshots/let_bindings.snap
@@ -28,12 +28,16 @@ Assignment {
         ],
         tail: None,
     },
-    pattern: Var {
-        location: 4..9,
-        name: "thing",
-    },
+    patterns: [
+        (
+            Var {
+                location: 4..9,
+                name: "thing",
+            },
+            None,
+        ),
+    ],
     kind: Let {
         backpassing: false,
     },
-    annotation: None,
 }

--- a/crates/aiken-lang/src/parser/expr/snapshots/parse_tuple.snap
+++ b/crates/aiken-lang/src/parser/expr/snapshots/parse_tuple.snap
@@ -41,13 +41,13 @@ Sequence {
                 ],
             },
             patterns: [
-                (
-                    Var {
+                AssignmentPattern {
+                    pattern: Var {
                         location: 4..9,
                         name: "tuple",
                     },
-                    None,
-                ),
+                    annotation: None,
+                },
             ],
             kind: Let {
                 backpassing: false,

--- a/crates/aiken-lang/src/parser/expr/snapshots/parse_tuple.snap
+++ b/crates/aiken-lang/src/parser/expr/snapshots/parse_tuple.snap
@@ -40,14 +40,18 @@ Sequence {
                     },
                 ],
             },
-            pattern: Var {
-                location: 4..9,
-                name: "tuple",
-            },
+            patterns: [
+                (
+                    Var {
+                        location: 4..9,
+                        name: "tuple",
+                    },
+                    None,
+                ),
+            ],
             kind: Let {
                 backpassing: false,
             },
-            annotation: None,
         },
         BinOp {
             location: 25..70,

--- a/crates/aiken-lang/src/parser/expr/snapshots/parse_tuple2.snap
+++ b/crates/aiken-lang/src/parser/expr/snapshots/parse_tuple2.snap
@@ -27,14 +27,18 @@ Sequence {
                 },
                 location: 8..15,
             },
-            pattern: Var {
-                location: 4..5,
-                name: "a",
-            },
+            patterns: [
+                (
+                    Var {
+                        location: 4..5,
+                        name: "a",
+                    },
+                    None,
+                ),
+            ],
             kind: Let {
                 backpassing: false,
             },
-            annotation: None,
         },
         Tuple {
             location: 16..23,

--- a/crates/aiken-lang/src/parser/expr/snapshots/parse_tuple2.snap
+++ b/crates/aiken-lang/src/parser/expr/snapshots/parse_tuple2.snap
@@ -28,13 +28,13 @@ Sequence {
                 location: 8..15,
             },
             patterns: [
-                (
-                    Var {
+                AssignmentPattern {
+                    pattern: Var {
                         location: 4..5,
                         name: "a",
                     },
-                    None,
-                ),
+                    annotation: None,
+                },
             ],
             kind: Let {
                 backpassing: false,

--- a/crates/aiken-lang/src/parser/expr/when/snapshots/when_basic.snap
+++ b/crates/aiken-lang/src/parser/expr/when/snapshots/when_basic.snap
@@ -86,13 +86,13 @@ When {
                             },
                         },
                         patterns: [
-                            (
-                                Var {
+                            AssignmentPattern {
+                                pattern: Var {
                                     location: 55..62,
                                     name: "amazing",
                                 },
-                                None,
-                            ),
+                                annotation: None,
+                            },
                         ],
                         kind: Let {
                             backpassing: false,

--- a/crates/aiken-lang/src/parser/expr/when/snapshots/when_basic.snap
+++ b/crates/aiken-lang/src/parser/expr/when/snapshots/when_basic.snap
@@ -85,14 +85,18 @@ When {
                                 numeric_underscore: false,
                             },
                         },
-                        pattern: Var {
-                            location: 55..62,
-                            name: "amazing",
-                        },
+                        patterns: [
+                            (
+                                Var {
+                                    location: 55..62,
+                                    name: "amazing",
+                                },
+                                None,
+                            ),
+                        ],
                         kind: Let {
                             backpassing: false,
                         },
-                        annotation: None,
                     },
                     Var {
                         location: 71..78,

--- a/crates/aiken-lang/src/snapshots/function_ambiguous_sequence.snap
+++ b/crates/aiken-lang/src/snapshots/function_ambiguous_sequence.snap
@@ -20,13 +20,13 @@ Module {
                                 name: "bar",
                             },
                             patterns: [
-                                (
-                                    Var {
+                                AssignmentPattern {
+                                    pattern: Var {
                                         location: 19..20,
                                         name: "a",
                                     },
-                                    None,
-                                ),
+                                    annotation: None,
+                                },
                             ],
                             kind: Let {
                                 backpassing: false,
@@ -64,13 +64,13 @@ Module {
                                 name: "bar",
                             },
                             patterns: [
-                                (
-                                    Var {
+                                AssignmentPattern {
+                                    pattern: Var {
                                         location: 56..57,
                                         name: "a",
                                     },
-                                    None,
-                                ),
+                                    annotation: None,
+                                },
                             ],
                             kind: Let {
                                 backpassing: false,
@@ -119,13 +119,13 @@ Module {
                         },
                     },
                     patterns: [
-                        (
-                            Var {
+                        AssignmentPattern {
+                            pattern: Var {
                                 location: 93..94,
                                 name: "a",
                             },
-                            None,
-                        ),
+                            annotation: None,
+                        },
                     ],
                     kind: Let {
                         backpassing: false,
@@ -170,13 +170,13 @@ Module {
                                 location: 130..137,
                             },
                             patterns: [
-                                (
-                                    Var {
+                                AssignmentPattern {
+                                    pattern: Var {
                                         location: 126..127,
                                         name: "a",
                                     },
-                                    None,
-                                ),
+                                    annotation: None,
+                                },
                             ],
                             kind: Let {
                                 backpassing: false,

--- a/crates/aiken-lang/src/snapshots/function_ambiguous_sequence.snap
+++ b/crates/aiken-lang/src/snapshots/function_ambiguous_sequence.snap
@@ -19,14 +19,18 @@ Module {
                                 location: 23..26,
                                 name: "bar",
                             },
-                            pattern: Var {
-                                location: 19..20,
-                                name: "a",
-                            },
+                            patterns: [
+                                (
+                                    Var {
+                                        location: 19..20,
+                                        name: "a",
+                                    },
+                                    None,
+                                ),
+                            ],
                             kind: Let {
                                 backpassing: false,
                             },
-                            annotation: None,
                         },
                         UInt {
                             location: 30..32,
@@ -59,14 +63,18 @@ Module {
                                 location: 60..63,
                                 name: "bar",
                             },
-                            pattern: Var {
-                                location: 56..57,
-                                name: "a",
-                            },
+                            patterns: [
+                                (
+                                    Var {
+                                        location: 56..57,
+                                        name: "a",
+                                    },
+                                    None,
+                                ),
+                            ],
                             kind: Let {
                                 backpassing: false,
                             },
-                            annotation: None,
                         },
                         UInt {
                             location: 67..69,
@@ -110,14 +118,18 @@ Module {
                             },
                         },
                     },
-                    pattern: Var {
-                        location: 93..94,
-                        name: "a",
-                    },
+                    patterns: [
+                        (
+                            Var {
+                                location: 93..94,
+                                name: "a",
+                            },
+                            None,
+                        ),
+                    ],
                     kind: Let {
                         backpassing: false,
                     },
-                    annotation: None,
                 },
                 doc: None,
                 location: 74..84,
@@ -157,14 +169,18 @@ Module {
                                 },
                                 location: 130..137,
                             },
-                            pattern: Var {
-                                location: 126..127,
-                                name: "a",
-                            },
+                            patterns: [
+                                (
+                                    Var {
+                                        location: 126..127,
+                                        name: "a",
+                                    },
+                                    None,
+                                ),
+                            ],
                             kind: Let {
                                 backpassing: false,
                             },
-                            annotation: None,
                         },
                         BinOp {
                             location: 141..153,

--- a/crates/aiken-lang/src/snapshots/parse_unicode_offset_1.snap
+++ b/crates/aiken-lang/src/snapshots/parse_unicode_offset_1.snap
@@ -24,14 +24,18 @@ Module {
                                 ],
                                 preferred_format: Utf8String,
                             },
-                            pattern: Var {
-                                location: 17..18,
-                                name: "x",
-                            },
+                            patterns: [
+                                (
+                                    Var {
+                                        location: 17..18,
+                                        name: "x",
+                                    },
+                                    None,
+                                ),
+                            ],
                             kind: Let {
                                 backpassing: false,
                             },
-                            annotation: None,
                         },
                         Var {
                             location: 29..30,

--- a/crates/aiken-lang/src/snapshots/parse_unicode_offset_1.snap
+++ b/crates/aiken-lang/src/snapshots/parse_unicode_offset_1.snap
@@ -25,13 +25,13 @@ Module {
                                 preferred_format: Utf8String,
                             },
                             patterns: [
-                                (
-                                    Var {
+                                AssignmentPattern {
+                                    pattern: Var {
                                         location: 17..18,
                                         name: "x",
                                     },
-                                    None,
-                                ),
+                                    annotation: None,
+                                },
                             ],
                             kind: Let {
                                 backpassing: false,

--- a/crates/aiken-lang/src/snapshots/parse_unicode_offset_2.snap
+++ b/crates/aiken-lang/src/snapshots/parse_unicode_offset_2.snap
@@ -23,13 +23,13 @@ Module {
                                 preferred_format: Utf8String,
                             },
                             patterns: [
-                                (
-                                    Var {
+                                AssignmentPattern {
+                                    pattern: Var {
                                         location: 17..18,
                                         name: "x",
                                     },
-                                    None,
-                                ),
+                                    annotation: None,
+                                },
                             ],
                             kind: Let {
                                 backpassing: false,

--- a/crates/aiken-lang/src/snapshots/parse_unicode_offset_2.snap
+++ b/crates/aiken-lang/src/snapshots/parse_unicode_offset_2.snap
@@ -22,14 +22,18 @@ Module {
                                 ],
                                 preferred_format: Utf8String,
                             },
-                            pattern: Var {
-                                location: 17..18,
-                                name: "x",
-                            },
+                            patterns: [
+                                (
+                                    Var {
+                                        location: 17..18,
+                                        name: "x",
+                                    },
+                                    None,
+                                ),
+                            ],
                             kind: Let {
                                 backpassing: false,
                             },
-                            annotation: None,
                         },
                         Var {
                             location: 27..28,

--- a/crates/aiken-lang/src/tests/format.rs
+++ b/crates/aiken-lang/src/tests/format.rs
@@ -474,6 +474,34 @@ fn format_newline_module_comments() {
 }
 
 #[test]
+fn format_many_assignment_patterns() {
+    assert_format!(
+        r#"
+        fn backpassing() -> Int {
+        
+          let
+            elem, accumulator, wow,
+            who,
+            thing,
+            what,
+            idk,
+            wee,
+            will,
+            it,
+            break,
+
+
+
+          <- fold([1, 2, 3],
+          0)
+
+          elem + accumulator
+        }
+        "#
+    );
+}
+
+#[test]
 fn format_bytearray_literals() {
     assert_format!(
         r#"

--- a/crates/aiken-lang/src/tests/snapshots/format_many_assignment_patterns.snap
+++ b/crates/aiken-lang/src/tests/snapshots/format_many_assignment_patterns.snap
@@ -1,0 +1,21 @@
+---
+source: crates/aiken-lang/src/tests/format.rs
+description: "Code:\n\nfn backpassing() -> Int {\n\n  let\n    elem, accumulator, wow,\n    who,\n    thing,\n    what,\n    idk,\n    wee,\n    will,\n    it,\n    break,\n\n\n\n  <- fold([1, 2, 3],\n  0)\n\n  elem + accumulator\n}\n"
+---
+fn backpassing() -> Int {
+  let
+    elem,
+    accumulator,
+    wow,
+    who,
+    thing,
+    what,
+    idk,
+    wee,
+    will,
+    it,
+    break,
+  <- fold([1, 2, 3], 0)
+
+  elem + accumulator
+}

--- a/crates/aiken-lang/src/tipo/error.rs
+++ b/crates/aiken-lang/src/tipo/error.rs
@@ -707,6 +707,19 @@ Perhaps, try the following:
         with_spread: bool,
     },
 
+    #[error("I discovered a regular let assignment with multiple patterns.\n")]
+    #[diagnostic(code("unexpected::multi_pattern_assignment"))]
+    #[diagnostic(help(
+        "Did you mean to use backpassing syntax with {}?",
+        "<-".if_supports_color(Stdout, |s| s.purple())
+    ))]
+    UnexpectedMultiPatternAssignment {
+        #[label("unexpected")]
+        location: Span,
+        #[label("<-")]
+        arrow: Span,
+    },
+
     #[error("I tripped over some unknown labels in a pattern or function.\n")]
     #[diagnostic(code("unknown::labels"))]
     UnknownLabels(#[related] Vec<UnknownLabels>),
@@ -1031,6 +1044,7 @@ impl ExtraData for Error {
             | Error::ValidatorImported { .. }
             | Error::IncorrectTestArity { .. }
             | Error::GenericLeftAtBoundary { .. }
+            | Error::UnexpectedMultiPatternAssignment { .. }
             | Error::ValidatorMustReturnBool { .. } => None,
 
             Error::UnknownType { name, .. }

--- a/crates/aiken-lang/src/tipo/expr.rs
+++ b/crates/aiken-lang/src/tipo/expr.rs
@@ -1894,8 +1894,7 @@ impl<'a, 'b> ExprTyper<'a, 'b> {
                                 .iter()
                                 .map(|ap| ap.pattern.location())
                                 .reduce(|acc, loc| acc.union(loc))
-                                .unwrap_or(location)
-                                .map_end(|current| current - 1),
+                                .unwrap_or(location),
                         });
                     }
                     _ => prefix.push(expression),


### PR DESCRIPTION
The main trick here was transforming Assignment to contain `Vec<UntypedPattern, Option<Annotation>>` in a field called patterns. This then meant that I could remove the `pattern` and `annotation` field from `Assignment`. The parser handles `=` and `<-` just fine because in the future `=` with multi patterns will mean some kind of optimization on tuples. But, since we don't have that optimization yet, when someone uses multi patterns with an `=` there will be an error returned from the type checker right where `infer_seq` looks for `backpassing`. From there the rest of the work was in `Project::backpassing` where I only needed to rework some things to work with a list of patterns instead of just one.

This is what the new error looks like
![CleanShot 2024-03-11 at 19 02 07@2x](https://github.com/aiken-lang/aiken/assets/12070598/d99835c3-f83c-40f8-b93d-15491ed748c4)


This is what is looks like formatted with many args
![CleanShot 2024-03-11 at 18 59 26@2x](https://github.com/aiken-lang/aiken/assets/12070598/74a6bfdd-bfa1-49fb-a412-87e6e18946e8)
