### PR TITLE
block expects on opaque types

### DIFF
--- a/crates/aiken-lang/src/ast.rs
+++ b/crates/aiken-lang/src/ast.rs
@@ -1225,6 +1225,7 @@ impl TypedPattern {
     }
 
     pub fn tipo(&self, value: &TypedExpr) -> Option<Rc<Type>> {
+        // expect thing: Wow = thing
         match self {
             Pattern::Int { .. } => Some(builtins::int()),
             Pattern::Constructor { tipo, .. } => Some(tipo.clone()),

--- a/crates/aiken-lang/src/ast.rs
+++ b/crates/aiken-lang/src/ast.rs
@@ -1225,7 +1225,6 @@ impl TypedPattern {
     }
 
     pub fn tipo(&self, value: &TypedExpr) -> Option<Rc<Type>> {
-        // expect thing: Wow = thing
         match self {
             Pattern::Int { .. } => Some(builtins::int()),
             Pattern::Constructor { tipo, .. } => Some(tipo.clone()),

--- a/crates/aiken-lang/src/builtins.rs
+++ b/crates/aiken-lang/src/builtins.rs
@@ -1267,7 +1267,7 @@ pub fn prelude_data_types(id_gen: &IdGenerator) -> IndexMap<DataTypeKey, TypedDa
 pub fn int() -> Rc<Type> {
     Rc::new(Type::App {
         public: true,
-        opaque: false,
+        contains_opaque: false,
         name: INT.to_string(),
         module: "".to_string(),
         args: vec![],
@@ -1278,7 +1278,7 @@ pub fn int() -> Rc<Type> {
 pub fn data() -> Rc<Type> {
     Rc::new(Type::App {
         public: true,
-        opaque: false,
+        contains_opaque: false,
         name: DATA.to_string(),
         module: "".to_string(),
         args: vec![],
@@ -1290,7 +1290,7 @@ pub fn byte_array() -> Rc<Type> {
     Rc::new(Type::App {
         args: vec![],
         public: true,
-        opaque: false,
+        contains_opaque: false,
         name: BYTE_ARRAY.to_string(),
         module: "".to_string(),
         alias: None,
@@ -1300,7 +1300,7 @@ pub fn byte_array() -> Rc<Type> {
 pub fn g1_element() -> Rc<Type> {
     Rc::new(Type::App {
         public: true,
-        opaque: false,
+        contains_opaque: false,
         module: "".to_string(),
         name: G1_ELEMENT.to_string(),
         args: vec![],
@@ -1311,7 +1311,7 @@ pub fn g1_element() -> Rc<Type> {
 pub fn g2_element() -> Rc<Type> {
     Rc::new(Type::App {
         public: true,
-        opaque: false,
+        contains_opaque: false,
         module: "".to_string(),
         name: G2_ELEMENT.to_string(),
         args: vec![],
@@ -1322,7 +1322,7 @@ pub fn g2_element() -> Rc<Type> {
 pub fn miller_loop_result() -> Rc<Type> {
     Rc::new(Type::App {
         public: true,
-        opaque: false,
+        contains_opaque: false,
         module: "".to_string(),
         name: MILLER_LOOP_RESULT.to_string(),
         args: vec![],
@@ -1338,7 +1338,7 @@ pub fn bool() -> Rc<Type> {
     Rc::new(Type::App {
         args: vec![],
         public: true,
-        opaque: false,
+        contains_opaque: false,
         name: BOOL.to_string(),
         module: "".to_string(),
         alias: None,
@@ -1349,7 +1349,7 @@ pub fn prng() -> Rc<Type> {
     Rc::new(Type::App {
         args: vec![],
         public: true,
-        opaque: false,
+        contains_opaque: false,
         name: PRNG.to_string(),
         module: "".to_string(),
         alias: None,
@@ -1400,7 +1400,7 @@ pub fn fuzzer(a: Rc<Type>) -> Rc<Type> {
 pub fn list(t: Rc<Type>) -> Rc<Type> {
     Rc::new(Type::App {
         public: true,
-        opaque: false,
+        contains_opaque: false,
         name: LIST.to_string(),
         module: "".to_string(),
         args: vec![t],
@@ -1412,7 +1412,7 @@ pub fn string() -> Rc<Type> {
     Rc::new(Type::App {
         args: vec![],
         public: true,
-        opaque: false,
+        contains_opaque: false,
         name: STRING.to_string(),
         module: "".to_string(),
         alias: None,
@@ -1423,7 +1423,7 @@ pub fn void() -> Rc<Type> {
     Rc::new(Type::App {
         args: vec![],
         public: true,
-        opaque: false,
+        contains_opaque: false,
         name: VOID.to_string(),
         module: "".to_string(),
         alias: None,
@@ -1433,7 +1433,7 @@ pub fn void() -> Rc<Type> {
 pub fn option(a: Rc<Type>) -> Rc<Type> {
     Rc::new(Type::App {
         public: true,
-        opaque: false,
+        contains_opaque: false,
         name: OPTION.to_string(),
         module: "".to_string(),
         args: vec![a],
@@ -1444,7 +1444,7 @@ pub fn option(a: Rc<Type>) -> Rc<Type> {
 pub fn ordering() -> Rc<Type> {
     Rc::new(Type::App {
         public: true,
-        opaque: false,
+        contains_opaque: false,
         name: ORDERING.to_string(),
         module: "".to_string(),
         args: vec![],
@@ -1475,7 +1475,7 @@ pub fn unbound_var(id: u64) -> Rc<Type> {
 pub fn wrapped_redeemer(redeemer: Rc<Type>) -> Rc<Type> {
     Rc::new(Type::App {
         public: true,
-        opaque: false,
+        contains_opaque: false,
         module: "".to_string(),
         name: REDEEMER_WRAPPER.to_string(),
         args: vec![redeemer],

--- a/crates/aiken-lang/src/builtins.rs
+++ b/crates/aiken-lang/src/builtins.rs
@@ -1267,6 +1267,7 @@ pub fn prelude_data_types(id_gen: &IdGenerator) -> IndexMap<DataTypeKey, TypedDa
 pub fn int() -> Rc<Type> {
     Rc::new(Type::App {
         public: true,
+        opaque: false,
         name: INT.to_string(),
         module: "".to_string(),
         args: vec![],
@@ -1277,6 +1278,7 @@ pub fn int() -> Rc<Type> {
 pub fn data() -> Rc<Type> {
     Rc::new(Type::App {
         public: true,
+        opaque: false,
         name: DATA.to_string(),
         module: "".to_string(),
         args: vec![],
@@ -1288,6 +1290,7 @@ pub fn byte_array() -> Rc<Type> {
     Rc::new(Type::App {
         args: vec![],
         public: true,
+        opaque: false,
         name: BYTE_ARRAY.to_string(),
         module: "".to_string(),
         alias: None,
@@ -1297,6 +1300,7 @@ pub fn byte_array() -> Rc<Type> {
 pub fn g1_element() -> Rc<Type> {
     Rc::new(Type::App {
         public: true,
+        opaque: false,
         module: "".to_string(),
         name: G1_ELEMENT.to_string(),
         args: vec![],
@@ -1307,6 +1311,7 @@ pub fn g1_element() -> Rc<Type> {
 pub fn g2_element() -> Rc<Type> {
     Rc::new(Type::App {
         public: true,
+        opaque: false,
         module: "".to_string(),
         name: G2_ELEMENT.to_string(),
         args: vec![],
@@ -1317,6 +1322,7 @@ pub fn g2_element() -> Rc<Type> {
 pub fn miller_loop_result() -> Rc<Type> {
     Rc::new(Type::App {
         public: true,
+        opaque: false,
         module: "".to_string(),
         name: MILLER_LOOP_RESULT.to_string(),
         args: vec![],
@@ -1332,6 +1338,7 @@ pub fn bool() -> Rc<Type> {
     Rc::new(Type::App {
         args: vec![],
         public: true,
+        opaque: false,
         name: BOOL.to_string(),
         module: "".to_string(),
         alias: None,
@@ -1342,6 +1349,7 @@ pub fn prng() -> Rc<Type> {
     Rc::new(Type::App {
         args: vec![],
         public: true,
+        opaque: false,
         name: PRNG.to_string(),
         module: "".to_string(),
         alias: None,
@@ -1355,6 +1363,7 @@ pub fn fuzzer(a: Rc<Type>) -> Rc<Type> {
         name: "PRNG".to_string(),
         arguments: vec![],
     };
+
     Rc::new(Type::Fn {
         args: vec![prng()],
         ret: option(tuple(vec![prng(), a])),
@@ -1391,6 +1400,7 @@ pub fn fuzzer(a: Rc<Type>) -> Rc<Type> {
 pub fn list(t: Rc<Type>) -> Rc<Type> {
     Rc::new(Type::App {
         public: true,
+        opaque: false,
         name: LIST.to_string(),
         module: "".to_string(),
         args: vec![t],
@@ -1402,6 +1412,7 @@ pub fn string() -> Rc<Type> {
     Rc::new(Type::App {
         args: vec![],
         public: true,
+        opaque: false,
         name: STRING.to_string(),
         module: "".to_string(),
         alias: None,
@@ -1412,6 +1423,7 @@ pub fn void() -> Rc<Type> {
     Rc::new(Type::App {
         args: vec![],
         public: true,
+        opaque: false,
         name: VOID.to_string(),
         module: "".to_string(),
         alias: None,
@@ -1421,6 +1433,7 @@ pub fn void() -> Rc<Type> {
 pub fn option(a: Rc<Type>) -> Rc<Type> {
     Rc::new(Type::App {
         public: true,
+        opaque: false,
         name: OPTION.to_string(),
         module: "".to_string(),
         args: vec![a],
@@ -1431,6 +1444,7 @@ pub fn option(a: Rc<Type>) -> Rc<Type> {
 pub fn ordering() -> Rc<Type> {
     Rc::new(Type::App {
         public: true,
+        opaque: false,
         name: ORDERING.to_string(),
         module: "".to_string(),
         args: vec![],
@@ -1448,17 +1462,20 @@ pub fn function(args: Vec<Rc<Type>>, ret: Rc<Type>) -> Rc<Type> {
 
 pub fn generic_var(id: u64) -> Rc<Type> {
     let tipo = Rc::new(RefCell::new(TypeVar::Generic { id }));
+
     Rc::new(Type::Var { tipo, alias: None })
 }
 
 pub fn unbound_var(id: u64) -> Rc<Type> {
     let tipo = Rc::new(RefCell::new(TypeVar::Unbound { id }));
+
     Rc::new(Type::Var { tipo, alias: None })
 }
 
 pub fn wrapped_redeemer(redeemer: Rc<Type>) -> Rc<Type> {
     Rc::new(Type::App {
         public: true,
+        opaque: false,
         module: "".to_string(),
         name: REDEEMER_WRAPPER.to_string(),
         args: vec![redeemer],

--- a/crates/aiken-lang/src/tests/check.rs
+++ b/crates/aiken-lang/src/tests/check.rs
@@ -1858,7 +1858,7 @@ fn forbid_expect_into_nested_opaque_in_record_without_typecasting() {
 
         type Foo { foo: Thing }
 
-        fn bar(thing: Thing) {
+        fn bar(thing: Foo) {
           expect Foo { foo: Thing { inner } } : Foo = thing
           Void
         }
@@ -1904,4 +1904,19 @@ fn forbid_expect_into_nested_opaque_in_list() {
         check(parse(source_code)),
         Err((_, Error::ExpectOnOpaqueType { .. }))
     ))
+}
+
+#[test]
+fn allow_expect_on_var_patterns_that_are_opaque() {
+    let source_code = r#"
+        opaque type Thing { inner: Int }
+
+        fn bar(a: Option<Thing>) {
+          expect Some(thing) = a
+
+          thing.inner
+        }
+    "#;
+
+    assert!(check(parse(source_code)).is_ok())
 }

--- a/crates/aiken-lang/src/tests/check.rs
+++ b/crates/aiken-lang/src/tests/check.rs
@@ -1761,7 +1761,7 @@ fn backpassing_type_annotation() {
               (Foo(1), inputs)
             }
             [input, ..remaining_inputs] -> {
-        
+
               callback(input)(
                 fn(foo) {
                   transition_fold4(
@@ -1779,7 +1779,7 @@ fn backpassing_type_annotation() {
             transition_fold4(
               x,
             )
-          
+
           fn(g){
             g(if input.foo == 1{
               1
@@ -1787,13 +1787,14 @@ fn backpassing_type_annotation() {
               2
             })
           }
-          
+
         }
     "#;
 
     assert!(check(parse(source_code)).is_ok())
 }
 
+#[test]
 fn forbid_expect_into_opaque_type_from_data() {
     let source_code = r#"
         opaque type Thing { inner: Int }

--- a/crates/aiken-lang/src/tests/check.rs
+++ b/crates/aiken-lang/src/tests/check.rs
@@ -16,6 +16,7 @@ fn parse(source_code: &str) -> UntypedModule {
 
 fn check_module(
     ast: UntypedModule,
+    extra: Vec<(String, UntypedModule)>,
     kind: ModuleKind,
 ) -> Result<(Vec<Warning>, TypedModule), (Vec<Warning>, Error)> {
     let id_gen = IdGenerator::new();
@@ -25,6 +26,21 @@ fn check_module(
     let mut module_types = HashMap::new();
     module_types.insert("aiken".to_string(), builtins::prelude(&id_gen));
     module_types.insert("aiken/builtin".to_string(), builtins::plutus(&id_gen));
+
+    for (package, module) in extra {
+        let mut warnings = vec![];
+        let typed_module = module
+            .infer(
+                &id_gen,
+                kind,
+                &package,
+                &module_types,
+                Tracing::All(TraceLevel::Verbose),
+                &mut warnings,
+            )
+            .expect("extra dependency did not compile");
+        module_types.insert(package.clone(), typed_module.type_info.clone());
+    }
 
     let result = ast.infer(
         &id_gen,
@@ -41,13 +57,20 @@ fn check_module(
 }
 
 fn check(ast: UntypedModule) -> Result<(Vec<Warning>, TypedModule), (Vec<Warning>, Error)> {
-    check_module(ast, ModuleKind::Lib)
+    check_module(ast, Vec::new(), ModuleKind::Lib)
+}
+
+fn check_with_deps(
+    ast: UntypedModule,
+    extra: Vec<(String, UntypedModule)>,
+) -> Result<(Vec<Warning>, TypedModule), (Vec<Warning>, Error)> {
+    check_module(ast, extra, ModuleKind::Lib)
 }
 
 fn check_validator(
     ast: UntypedModule,
 ) -> Result<(Vec<Warning>, TypedModule), (Vec<Warning>, Error)> {
-    check_module(ast, ModuleKind::Validator)
+    check_module(ast, Vec::new(), ModuleKind::Validator)
 }
 
 #[test]
@@ -1813,7 +1836,7 @@ fn forbid_expect_into_opaque_type_from_data() {
 }
 
 #[test]
-fn forbid_expect_into_opaque_type_constructor_without_typecasting() {
+fn forbid_expect_into_opaque_type_constructor_without_typecasting_in_module() {
     let source_code = r#"
         opaque type Thing {
           Foo(Int)
@@ -1826,10 +1849,51 @@ fn forbid_expect_into_opaque_type_constructor_without_typecasting() {
         }
     "#;
 
+    assert!(check(parse(source_code)).is_ok());
+}
+
+#[test]
+fn forbid_importing_or_using_opaque_constructors() {
+    let dependency = r#"
+        pub opaque type Thing {
+          Foo(Int)
+          Bar(Int)
+        }
+    "#;
+
+    let source_code = r#"
+        use foo/thing.{Thing, Foo}
+
+        fn bar(thing: Thing) {
+          expect Foo(a) = thing
+          a
+        }
+    "#;
+
     assert!(matches!(
-        check(parse(source_code)),
-        Err((_, Error::ExpectOnOpaqueType { .. }))
-    ))
+        check_with_deps(
+            parse(source_code),
+            vec![("foo/thing".to_string(), parse(dependency))],
+        ),
+        Err((_, Error::UnknownModuleField { .. })),
+    ));
+
+    let source_code = r#"
+        use foo/thing.{Thing}
+
+        fn bar(thing: Thing) {
+          expect Foo(a) = thing
+          a
+        }
+    "#;
+
+    assert!(matches!(
+        check_with_deps(
+            parse(source_code),
+            vec![("foo/thing".to_string(), parse(dependency))],
+        ),
+        Err((_, Error::UnknownTypeConstructor { .. })),
+    ));
 }
 
 #[test]
@@ -1914,7 +1978,6 @@ fn allow_expect_on_var_patterns_that_are_opaque() {
 
         fn bar(a: Option<Thing>) {
           expect Some(thing) = a
-
           thing.inner
         }
     "#;

--- a/crates/aiken-lang/src/tests/check.rs
+++ b/crates/aiken-lang/src/tests/check.rs
@@ -1793,3 +1793,41 @@ fn backpassing_type_annotation() {
 
     assert!(check(parse(source_code)).is_ok())
 }
+
+fn forbid_expect_into_opaque_type_from_data() {
+    let source_code = r#"
+        opaque type Thing { inner: Int }
+
+        fn bar(n: Data) {
+          expect a: Thing = n
+
+          a
+        }
+    "#;
+
+    assert!(matches!(
+        check(parse(source_code)),
+        Err((_, Error::ExpectOnOpaqueType { .. }))
+    ))
+}
+
+#[test]
+fn forbid_expect_into_opaque_type_constructor() {
+    let source_code = r#"
+        opaque type Thing {
+          Foo(Int)
+          Bar(Int)
+        }
+
+        fn bar(n: Thing) {
+          expect Foo(a) = n
+
+          a
+        }
+    "#;
+
+    assert!(matches!(
+        check(parse(source_code)),
+        Err((_, Error::ExpectOnOpaqueType { .. }))
+    ))
+}

--- a/crates/aiken-lang/src/tipo.rs
+++ b/crates/aiken-lang/src/tipo.rs
@@ -81,19 +81,22 @@ impl PartialEq for Type {
                 module,
                 name,
                 args,
-                ..
+                opaque,
+                alias: _,
             } => {
                 if let Type::App {
                     public: public2,
                     module: module2,
                     name: name2,
                     args: args2,
-                    ..
+                    opaque: opaque2,
+                    alias: _,
                 } = other
                 {
                     name == name2
                         && module == module2
                         && public == public2
+                        && opaque == opaque2
                         && args.iter().zip(args2).all(|(left, right)| left == right)
                 } else {
                     false
@@ -104,7 +107,7 @@ impl PartialEq for Type {
                 if let Type::Fn {
                     args: args2,
                     ret: ret2,
-                    ..
+                    alias: _,
                 } = other
                 {
                     ret == ret2 && args.iter().zip(args2).all(|(left, right)| left == right)
@@ -113,7 +116,7 @@ impl PartialEq for Type {
                 }
             }
 
-            Type::Tuple { elems, .. } => {
+            Type::Tuple { elems, alias: _ } => {
                 if let Type::Tuple { elems: elems2, .. } = other {
                     elems.iter().zip(elems2).all(|(left, right)| left == right)
                 } else {
@@ -121,8 +124,12 @@ impl PartialEq for Type {
                 }
             }
 
-            Type::Var { tipo, .. } => {
-                if let Type::Var { tipo: tipo2, .. } = other {
+            Type::Var { tipo, alias: _ } => {
+                if let Type::Var {
+                    tipo: tipo2,
+                    alias: _,
+                } = other
+                {
                     tipo == tipo2
                 } else {
                     false
@@ -157,7 +164,7 @@ impl Type {
                 module,
                 name,
                 args,
-                ..
+                alias: _,
             } => Type::App {
                 public,
                 opaque,
@@ -166,9 +173,13 @@ impl Type {
                 args,
                 alias,
             },
-            Type::Fn { args, ret, .. } => Type::Fn { args, ret, alias },
-            Type::Var { tipo, .. } => Type::Var { tipo, alias },
-            Type::Tuple { elems, .. } => Type::Tuple { elems, alias },
+            Type::Fn {
+                args,
+                ret,
+                alias: _,
+            } => Type::Fn { args, ret, alias },
+            Type::Var { tipo, alias: _ } => Type::Var { tipo, alias },
+            Type::Tuple { elems, alias: _ } => Type::Tuple { elems, alias },
         })
     }
 
@@ -959,11 +970,13 @@ impl TypeVar {
             Self::Link { tipo } => tipo.get_inner_types(),
             Self::Unbound { .. } => vec![],
             var => {
-                vec![Type::Var {
-                    tipo: RefCell::new(var.clone()).into(),
-                    alias: None,
-                }
-                .into()]
+                vec![
+                    Type::Var {
+                        tipo: RefCell::new(var.clone()).into(),
+                        alias: None,
+                    }
+                    .into(),
+                ]
             }
         }
     }

--- a/crates/aiken-lang/src/tipo/environment.rs
+++ b/crates/aiken-lang/src/tipo/environment.rs
@@ -546,6 +546,7 @@ impl<'a> Environment<'a> {
         match t.deref() {
             Type::App {
                 public,
+                opaque,
                 name,
                 module,
                 args,
@@ -555,8 +556,10 @@ impl<'a> Environment<'a> {
                     .iter()
                     .map(|t| self.instantiate(t.clone(), ids, hydrator))
                     .collect();
+
                 Rc::new(Type::App {
                     public: *public,
+                    opaque: *opaque,
                     name: name.clone(),
                     module: module.clone(),
                     alias: alias.clone(),
@@ -983,6 +986,7 @@ impl<'a> Environment<'a> {
             Definition::DataType(DataType {
                 name,
                 public,
+                opaque,
                 parameters,
                 location,
                 constructors,
@@ -997,6 +1001,7 @@ impl<'a> Environment<'a> {
 
                 let tipo = Rc::new(Type::App {
                     public: *public,
+                    opaque: *opaque,
                     module: module.to_owned(),
                     name: name.clone(),
                     args: parameters.clone(),
@@ -1856,6 +1861,7 @@ pub(crate) fn generalise(t: Rc<Type>, ctx_level: usize) -> Rc<Type> {
 
         Type::App {
             public,
+            opaque,
             module,
             name,
             args,
@@ -1868,6 +1874,7 @@ pub(crate) fn generalise(t: Rc<Type>, ctx_level: usize) -> Rc<Type> {
 
             Rc::new(Type::App {
                 public: *public,
+                opaque: *opaque,
                 module: module.clone(),
                 name: name.clone(),
                 args,

--- a/crates/aiken-lang/src/tipo/environment.rs
+++ b/crates/aiken-lang/src/tipo/environment.rs
@@ -1415,8 +1415,13 @@ impl<'a> Environment<'a> {
             && !(t1.is_function() || t2.is_function())
             && !(t1.is_generic() || t2.is_generic())
             && !(t1.is_string() || t2.is_string())
+            && !(t1.contains_opaque() || t2.contains_opaque())
         {
             return Ok(());
+        }
+
+        if allow_cast && (t1.contains_opaque() || t2.contains_opaque()) {
+            return Err(Error::ExpectOnOpaqueType { location });
         }
 
         // Collapse right hand side type links. Left hand side will be collapsed in the next block.

--- a/crates/aiken-lang/src/tipo/error.rs
+++ b/crates/aiken-lang/src/tipo/error.rs
@@ -259,10 +259,16 @@ You can use '{discard}' and numbers to distinguish between similar names.
         name: String,
     },
 
-    #[error("I found an expect assignment involving an opaque type. This is not allowed.\n")]
+    #[error("I caught an opaque type possibly breaking its abstraction boundary.\n")]
     #[diagnostic(code("illegal::expect_on_opaque"))]
+    #[diagnostic(url("https://aiken-lang.org/language-tour/modules#opaque-types"))]
+    #[diagnostic(help(
+        "This expression is trying to convert something unknown into an opaque type. An opaque type is a data-type which hides its internal details; usually because it enforces some specific invariant on its internal structure. For example, you might define a {Natural} type that holds an {Integer} but ensures that it never gets negative.\n\nA direct consequence means that it isn't generally possible, nor safe, to turn *any* value into an opaque type. Instead, use the constructors and methods provided for lifting values into that opaque type while ensuring that any structural invariant is checked for.",
+        Natural = "Natural".if_supports_color(Stdout, |s| s.cyan()),
+        Integer = "Integer".if_supports_color(Stdout, |s| s.cyan()),
+    ))]
     ExpectOnOpaqueType {
-        #[label]
+        #[label("reckless opaque cast")]
         location: Span,
     },
 

--- a/crates/aiken-lang/src/tipo/error.rs
+++ b/crates/aiken-lang/src/tipo/error.rs
@@ -259,6 +259,13 @@ You can use '{discard}' and numbers to distinguish between similar names.
         name: String,
     },
 
+    #[error("I found an expect assignment involving an opaque type. This is not allowed.\n")]
+    #[diagnostic(code("illegal::expect_on_opaque"))]
+    ExpectOnOpaqueType {
+        #[label]
+        location: Span,
+    },
+
     #[error("I found a type definition that has a function type in it. This is not allowed.\n")]
     #[diagnostic(code("illegal::function_in_type"))]
     #[diagnostic(help(
@@ -1045,6 +1052,7 @@ impl ExtraData for Error {
             | Error::IncorrectTestArity { .. }
             | Error::GenericLeftAtBoundary { .. }
             | Error::UnexpectedMultiPatternAssignment { .. }
+            | Error::ExpectOnOpaqueType { .. }
             | Error::ValidatorMustReturnBool { .. } => None,
 
             Error::UnknownType { name, .. }

--- a/crates/aiken-lang/src/tipo/expr.rs
+++ b/crates/aiken-lang/src/tipo/expr.rs
@@ -976,11 +976,7 @@ impl<'a, 'b> ExprTyper<'a, 'b> {
             kind.is_let(),
         )?;
 
-        // FIXME: This check is insufficient as we need to also assert the type
-        // definition itself since there might be nested opaque types on the rhs.
-        //
-        // For that, we must lookup
-        if kind.is_expect() && value_typ.is_or_holds_opaque() {
+        if kind.is_expect() && value_typ.contains_opaque() {
             return Err(Error::ExpectOnOpaqueType { location });
         }
 
@@ -2347,7 +2343,7 @@ pub fn ensure_serialisable(allow_fn: bool, t: Rc<Type>, location: Span) -> Resul
             name: _,
             module: _,
             public: _,
-            opaque: _,
+            contains_opaque: _,
             alias: _,
         } => {
             if t.is_ml_result() {

--- a/crates/aiken-lang/src/tipo/expr.rs
+++ b/crates/aiken-lang/src/tipo/expr.rs
@@ -976,10 +976,6 @@ impl<'a, 'b> ExprTyper<'a, 'b> {
             kind.is_let(),
         )?;
 
-        if kind.is_expect() && value_typ.contains_opaque() {
-            return Err(Error::ExpectOnOpaqueType { location });
-        }
-
         // If `expect` is explicitly used, we still check exhaustiveness but instead of returning an
         // error we emit a warning which explains that using `expect` is unnecessary.
         match kind {

--- a/crates/aiken-lang/src/tipo/expr.rs
+++ b/crates/aiken-lang/src/tipo/expr.rs
@@ -939,7 +939,7 @@ impl<'a, 'b> ExprTyper<'a, 'b> {
                 ann_typ.clone(),
                 value_typ.clone(),
                 typed_value.type_defining_location(),
-                (kind.is_let() && ann_typ.is_data()) || (kind.is_expect() && value_is_data),
+                (kind.is_let() && ann_typ.is_data()) || kind.is_expect(),
             )?;
 
             value_typ = ann_typ.clone();

--- a/crates/aiken-lang/src/tipo/expr.rs
+++ b/crates/aiken-lang/src/tipo/expr.rs
@@ -968,10 +968,6 @@ impl<'a, 'b> ExprTyper<'a, 'b> {
             None
         };
 
-        if kind.is_expect() && value_typ.is_or_holds_opaque() {
-            return Err(Error::ExpectOnOpaqueType { location });
-        }
-
         // Ensure the pattern matches the type of the value
         let pattern = PatternTyper::new(self.environment, &self.hydrator).unify(
             untyped_pattern.clone(),
@@ -979,6 +975,14 @@ impl<'a, 'b> ExprTyper<'a, 'b> {
             ann_typ,
             kind.is_let(),
         )?;
+
+        // FIXME: This check is insufficient as we need to also assert the type
+        // definition itself since there might be nested opaque types on the rhs.
+        //
+        // For that, we must lookup
+        if kind.is_expect() && value_typ.is_or_holds_opaque() {
+            return Err(Error::ExpectOnOpaqueType { location });
+        }
 
         // If `expect` is explicitly used, we still check exhaustiveness but instead of returning an
         // error we emit a warning which explains that using `expect` is unnecessary.

--- a/crates/aiken-lang/src/tipo/pattern.rs
+++ b/crates/aiken-lang/src/tipo/pattern.rs
@@ -141,11 +141,11 @@ impl<'a, 'b> PatternTyper<'a, 'b> {
         pattern: UntypedPattern,
         tipo: Rc<Type>,
         ann_type: Option<Rc<Type>>,
-        is_assignment: bool,
+        is_let: bool,
     ) -> Result<TypedPattern, Error> {
         match pattern {
             Pattern::Discard { name, location } => {
-                if is_assignment {
+                if is_let {
                     // Register declaration for the unused variable detection
                     self.environment
                         .warnings

--- a/crates/aiken-lang/src/tipo/pattern.rs
+++ b/crates/aiken-lang/src/tipo/pattern.rs
@@ -202,7 +202,7 @@ impl<'a, 'b> PatternTyper<'a, 'b> {
                 location,
                 elements,
                 tail,
-            } => match tipo.get_app_args(true, "", "List", 1, self.environment) {
+            } => match tipo.get_app_args(true, false, "", "List", 1, self.environment) {
                 Some(args) => {
                     let tipo = args
                         .first()

--- a/crates/aiken-lang/src/tipo/pattern.rs
+++ b/crates/aiken-lang/src/tipo/pattern.rs
@@ -154,6 +154,7 @@ impl<'a, 'b> PatternTyper<'a, 'b> {
                             location,
                         });
                 };
+
                 Ok(Pattern::Discard { name, location })
             }
 

--- a/crates/aiken-lang/src/tipo/pretty.rs
+++ b/crates/aiken-lang/src/tipo/pretty.rs
@@ -368,7 +368,7 @@ mod tests {
                 module: "whatever".to_string(),
                 name: "Int".to_string(),
                 public: true,
-                opaque: false,
+                contains_opaque: false,
                 args: vec![],
                 alias: None
             },
@@ -379,14 +379,14 @@ mod tests {
                 module: "".to_string(),
                 name: "Pair".to_string(),
                 public: true,
-                opaque: false,
+                contains_opaque: false,
                 alias: None,
                 args: vec![
                     Rc::new(Type::App {
                         module: "whatever".to_string(),
                         name: "Int".to_string(),
                         public: true,
-                        opaque: false,
+                        contains_opaque: false,
                         args: vec![],
                         alias: None
                     }),
@@ -394,7 +394,7 @@ mod tests {
                         module: "whatever".to_string(),
                         name: "Bool".to_string(),
                         public: true,
-                        opaque: false,
+                        contains_opaque: false,
                         args: vec![],
                         alias: None
                     }),
@@ -410,7 +410,7 @@ mod tests {
                         module: "whatever".to_string(),
                         name: "Int".to_string(),
                         public: true,
-                        opaque: false,
+                        contains_opaque: false,
                         alias: None,
                     }),
                     Rc::new(Type::App {
@@ -418,7 +418,7 @@ mod tests {
                         module: "whatever".to_string(),
                         name: "Bool".to_string(),
                         public: true,
-                        opaque: false,
+                        contains_opaque: false,
                         alias: None,
                     }),
                 ],
@@ -427,7 +427,7 @@ mod tests {
                     module: "whatever".to_string(),
                     name: "Bool".to_string(),
                     public: true,
-                    opaque: false,
+                    contains_opaque: false,
                     alias: None,
                 }),
                 alias: None,
@@ -444,7 +444,7 @@ mod tests {
                         module: "whatever".to_string(),
                         name: "Int".to_string(),
                         public: true,
-                        opaque: false,
+                        contains_opaque: false,
                     }),
                 })),
             },
@@ -487,7 +487,7 @@ mod tests {
             Type::Fn {
                 args: vec![Rc::new(Type::App {
                     public: true,
-                    opaque: false,
+                    contains_opaque: false,
                     module: "".to_string(),
                     name: "PRNG".to_string(),
                     args: vec![],
@@ -495,14 +495,14 @@ mod tests {
                 })],
                 ret: Rc::new(Type::App {
                     public: true,
-                    opaque: false,
+                    contains_opaque: false,
                     module: "".to_string(),
                     name: "Option".to_string(),
                     args: vec![Rc::new(Type::Tuple {
                         elems: vec![
                             Rc::new(Type::App {
                                 public: true,
-                                opaque: false,
+                                contains_opaque: false,
                                 module: "".to_string(),
                                 name: "PRNG".to_string(),
                                 args: vec![],
@@ -510,7 +510,7 @@ mod tests {
                             }),
                             Rc::new(Type::App {
                                 public: true,
-                                opaque: false,
+                                contains_opaque: false,
                                 module: "".to_string(),
                                 name: "Bool".to_string(),
                                 args: vec![],
@@ -561,7 +561,7 @@ mod tests {
             Type::Fn {
                 args: vec![Rc::new(Type::App {
                     public: true,
-                    opaque: false,
+                    contains_opaque: false,
                     module: "".to_string(),
                     name: "PRNG".to_string(),
                     args: vec![],
@@ -569,14 +569,14 @@ mod tests {
                 })],
                 ret: Rc::new(Type::App {
                     public: true,
-                    opaque: false,
+                    contains_opaque: false,
                     module: "".to_string(),
                     name: "Option".to_string(),
                     args: vec![Rc::new(Type::Tuple {
                         elems: vec![
                             Rc::new(Type::App {
                                 public: true,
-                                opaque: false,
+                                contains_opaque: false,
                                 module: "".to_string(),
                                 name: "PRNG".to_string(),
                                 args: vec![],

--- a/crates/aiken-lang/src/tipo/pretty.rs
+++ b/crates/aiken-lang/src/tipo/pretty.rs
@@ -368,6 +368,7 @@ mod tests {
                 module: "whatever".to_string(),
                 name: "Int".to_string(),
                 public: true,
+                opaque: false,
                 args: vec![],
                 alias: None
             },
@@ -378,12 +379,14 @@ mod tests {
                 module: "".to_string(),
                 name: "Pair".to_string(),
                 public: true,
+                opaque: false,
                 alias: None,
                 args: vec![
                     Rc::new(Type::App {
                         module: "whatever".to_string(),
                         name: "Int".to_string(),
                         public: true,
+                        opaque: false,
                         args: vec![],
                         alias: None
                     }),
@@ -391,6 +394,7 @@ mod tests {
                         module: "whatever".to_string(),
                         name: "Bool".to_string(),
                         public: true,
+                        opaque: false,
                         args: vec![],
                         alias: None
                     }),
@@ -406,6 +410,7 @@ mod tests {
                         module: "whatever".to_string(),
                         name: "Int".to_string(),
                         public: true,
+                        opaque: false,
                         alias: None,
                     }),
                     Rc::new(Type::App {
@@ -413,6 +418,7 @@ mod tests {
                         module: "whatever".to_string(),
                         name: "Bool".to_string(),
                         public: true,
+                        opaque: false,
                         alias: None,
                     }),
                 ],
@@ -421,6 +427,7 @@ mod tests {
                     module: "whatever".to_string(),
                     name: "Bool".to_string(),
                     public: true,
+                    opaque: false,
                     alias: None,
                 }),
                 alias: None,
@@ -437,6 +444,7 @@ mod tests {
                         module: "whatever".to_string(),
                         name: "Int".to_string(),
                         public: true,
+                        opaque: false,
                     }),
                 })),
             },
@@ -479,6 +487,7 @@ mod tests {
             Type::Fn {
                 args: vec![Rc::new(Type::App {
                     public: true,
+                    opaque: false,
                     module: "".to_string(),
                     name: "PRNG".to_string(),
                     args: vec![],
@@ -486,12 +495,14 @@ mod tests {
                 })],
                 ret: Rc::new(Type::App {
                     public: true,
+                    opaque: false,
                     module: "".to_string(),
                     name: "Option".to_string(),
                     args: vec![Rc::new(Type::Tuple {
                         elems: vec![
                             Rc::new(Type::App {
                                 public: true,
+                                opaque: false,
                                 module: "".to_string(),
                                 name: "PRNG".to_string(),
                                 args: vec![],
@@ -499,6 +510,7 @@ mod tests {
                             }),
                             Rc::new(Type::App {
                                 public: true,
+                                opaque: false,
                                 module: "".to_string(),
                                 name: "Bool".to_string(),
                                 args: vec![],
@@ -549,6 +561,7 @@ mod tests {
             Type::Fn {
                 args: vec![Rc::new(Type::App {
                     public: true,
+                    opaque: false,
                     module: "".to_string(),
                     name: "PRNG".to_string(),
                     args: vec![],
@@ -556,12 +569,14 @@ mod tests {
                 })],
                 ret: Rc::new(Type::App {
                     public: true,
+                    opaque: false,
                     module: "".to_string(),
                     name: "Option".to_string(),
                     args: vec![Rc::new(Type::Tuple {
                         elems: vec![
                             Rc::new(Type::App {
                                 public: true,
+                                opaque: false,
                                 module: "".to_string(),
                                 name: "PRNG".to_string(),
                                 args: vec![],

--- a/crates/aiken-project/src/blueprint/snapshots/aiken_project__blueprint__validator__tests__opaque_singleton_multi_variants.snap
+++ b/crates/aiken-project/src/blueprint/snapshots/aiken_project__blueprint__validator__tests__opaque_singleton_multi_variants.snap
@@ -8,6 +8,7 @@ Schema {
         breadcrumbs: [
             App {
                 public: true,
+                opaque: true,
                 module: "test_module",
                 name: "Rational",
                 args: [],

--- a/crates/aiken-project/src/blueprint/snapshots/aiken_project__blueprint__validator__tests__opaque_singleton_multi_variants.snap
+++ b/crates/aiken-project/src/blueprint/snapshots/aiken_project__blueprint__validator__tests__opaque_singleton_multi_variants.snap
@@ -8,7 +8,7 @@ Schema {
         breadcrumbs: [
             App {
                 public: true,
-                opaque: true,
+                contains_opaque: true,
                 module: "test_module",
                 name: "Rational",
                 args: [],

--- a/crates/aiken-project/src/blueprint/snapshots/aiken_project__blueprint__validator__tests__opaque_singleton_variants.snap
+++ b/crates/aiken-project/src/blueprint/snapshots/aiken_project__blueprint__validator__tests__opaque_singleton_variants.snap
@@ -8,7 +8,7 @@ Schema {
         breadcrumbs: [
             App {
                 public: true,
-                opaque: true,
+                contains_opaque: true,
                 module: "test_module",
                 name: "Dict",
                 args: [
@@ -17,7 +17,7 @@ Schema {
                             value: Link {
                                 tipo: App {
                                     public: false,
-                                    opaque: false,
+                                    contains_opaque: false,
                                     module: "test_module",
                                     name: "UUID",
                                     args: [],
@@ -32,7 +32,7 @@ Schema {
                             value: Link {
                                 tipo: App {
                                     public: true,
-                                    opaque: false,
+                                    contains_opaque: false,
                                     module: "",
                                     name: "Int",
                                     args: [],

--- a/crates/aiken-project/src/blueprint/snapshots/aiken_project__blueprint__validator__tests__opaque_singleton_variants.snap
+++ b/crates/aiken-project/src/blueprint/snapshots/aiken_project__blueprint__validator__tests__opaque_singleton_variants.snap
@@ -8,6 +8,7 @@ Schema {
         breadcrumbs: [
             App {
                 public: true,
+                opaque: true,
                 module: "test_module",
                 name: "Dict",
                 args: [
@@ -16,6 +17,7 @@ Schema {
                             value: Link {
                                 tipo: App {
                                     public: false,
+                                    opaque: false,
                                     module: "test_module",
                                     name: "UUID",
                                     args: [],
@@ -30,6 +32,7 @@ Schema {
                             value: Link {
                                 tipo: App {
                                     public: true,
+                                    opaque: false,
                                     module: "",
                                     name: "Int",
                                     args: [],


### PR DESCRIPTION
- added a new field called `opaque: bool` to `Type::App` (can be used to simplify some things in code gen too)
- implement a simple method on `Type` called `is_opaque` that leverages the new field
- make a new error for when someone uses expect with an opaque type in anyway
- catch this situation in `infer_assignment` and return the new error

![CleanShot 2024-03-12 at 17 36 45@2x](https://github.com/aiken-lang/aiken/assets/12070598/1b69df70-d1a0-42ef-a478-a3a94a673ba0)


> I figured that opaque does not need to affect the type equality