### PR TITLE
Only compile modules the project depends on

### DIFF
--- a/crates/aiken-project/src/lib.rs
+++ b/crates/aiken-project/src/lib.rs
@@ -194,15 +194,11 @@ where
 
         self.read_source_files()?;
 
-        let destination = destination.unwrap_or_else(|| self.root.join("docs"));
-
         let mut modules = self.parse_sources(self.config.name.clone())?;
 
-        let our_modules: BTreeSet<String> = modules.keys().cloned().collect();
+        self.type_check(&mut modules, Tracing::silent(), false)?;
 
-        self.with_dependencies(&mut modules)?;
-
-        self.type_check(&our_modules, modules, Tracing::silent(), false)?;
+        let destination = destination.unwrap_or_else(|| self.root.join("docs"));
 
         self.event_listener.handle_event(Event::GeneratingDocFiles {
             output_path: destination.clone(),
@@ -296,11 +292,7 @@ where
 
         let mut modules = self.parse_sources(self.config.name.clone())?;
 
-        let our_modules: BTreeSet<String> = modules.keys().cloned().collect();
-
-        self.with_dependencies(&mut modules)?;
-
-        self.type_check(&our_modules, modules, options.tracing, true)?;
+        self.type_check(&mut modules, options.tracing, true)?;
 
         match options.code_gen_mode {
             CodeGenMode::Build(uplc_dump) => {
@@ -684,78 +676,33 @@ where
 
     fn type_check(
         &mut self,
-        our_modules: &BTreeSet<String>,
-        mut all_modules: ParsedModules,
+        modules: &mut ParsedModules,
         tracing: Tracing,
         validate_module_name: bool,
-    ) -> Result<(), Error> {
-        let processing_sequence = all_modules.sequence(our_modules)?;
+    ) -> Result<(), Vec<Error>> {
+        let our_modules: BTreeSet<String> = modules.keys().cloned().collect();
 
-        for name in processing_sequence {
-            if let Some(ParsedModule {
-                name,
-                path,
-                code,
-                kind,
-                extra,
-                package,
-                ast,
-            }) = all_modules.remove(&name)
-            {
-                let mut type_warnings = Vec::new();
+        self.with_dependencies(modules)?;
 
-                let ast = ast
-                    .infer(
-                        &self.id_gen,
-                        kind,
-                        &self.config.name.to_string(),
-                        &self.module_types,
-                        tracing,
-                        &mut type_warnings,
-                    )
-                    .map_err(|error| Error::Type {
-                        path: path.clone(),
-                        src: code.clone(),
-                        named: NamedSource::new(path.display().to_string(), code.clone()),
-                        error,
-                    })?;
+        for name in modules.sequence(&our_modules)? {
+            if let Some(module) = modules.remove(&name) {
+                let (checked_module, warnings) = module.infer(
+                    &self.id_gen,
+                    &self.config.name.to_string(),
+                    tracing,
+                    validate_module_name,
+                    &mut self.module_sources,
+                    &mut self.module_types,
+                    &mut self.functions,
+                    &mut self.data_types,
+                )?;
 
-                if validate_module_name {
-                    ast.validate_module_name()?;
+                if our_modules.contains(checked_module.name.as_str()) {
+                    self.warnings.extend(warnings);
                 }
 
-                // Register any warnings emitted as type warnings
-                let type_warnings = type_warnings
-                    .into_iter()
-                    .map(|w| Warning::from_type_warning(w, path.clone(), code.clone()));
-
-                if our_modules.contains(name.as_str()) {
-                    self.warnings.extend(type_warnings);
-                }
-
-                // Register module sources for an easier access later.
-                self.module_sources
-                    .insert(name.clone(), (code.clone(), LineNumbers::new(&code)));
-
-                // Register the types from this module so they can be
-                // imported into other modules.
-                self.module_types
-                    .insert(name.clone(), ast.type_info.clone());
-
-                // Register function definitions & data-types for easier access later.
-                ast.register_definitions(&mut self.functions, &mut self.data_types);
-
-                let checked_module = CheckedModule {
-                    kind,
-                    extra,
-                    name: name.clone(),
-                    code,
-                    ast,
-                    package,
-                    input_path: path,
-                };
-
-                self.checked_modules.insert(name, checked_module);
+                self.checked_modules
+                    .insert(checked_module.name.clone(), checked_module);
             }
         }
 

--- a/crates/aiken-project/src/lib.rs
+++ b/crates/aiken-project/src/lib.rs
@@ -51,7 +51,7 @@ use pallas::ledger::{
     traverse::ComputeHash,
 };
 use std::{
-    collections::{HashMap, HashSet},
+    collections::{BTreeSet, HashMap},
     fs::{self, File},
     io::BufReader,
     path::{Path, PathBuf},
@@ -198,7 +198,7 @@ where
 
         let mut modules = self.parse_sources(self.config.name.clone())?;
 
-        let our_modules: HashSet<String> = modules.keys().cloned().collect();
+        let our_modules: BTreeSet<String> = modules.keys().cloned().collect();
 
         self.with_dependencies(&mut modules)?;
 
@@ -296,7 +296,7 @@ where
 
         let mut modules = self.parse_sources(self.config.name.clone())?;
 
-        let our_modules: HashSet<String> = modules.keys().cloned().collect();
+        let our_modules: BTreeSet<String> = modules.keys().cloned().collect();
 
         self.with_dependencies(&mut modules)?;
 
@@ -684,7 +684,7 @@ where
 
     fn type_check(
         &mut self,
-        our_modules: &HashSet<String>,
+        our_modules: &BTreeSet<String>,
         mut all_modules: ParsedModules,
         tracing: Tracing,
         validate_module_name: bool,

--- a/crates/aiken-project/src/module.rs
+++ b/crates/aiken-project/src/module.rs
@@ -8,7 +8,7 @@ use aiken_lang::{
 };
 use petgraph::{algo, graph::NodeIndex, Direction, Graph};
 use std::{
-    collections::{HashMap, HashSet},
+    collections::{BTreeSet, HashMap},
     io,
     ops::{Deref, DerefMut},
     path::PathBuf,
@@ -47,7 +47,7 @@ impl ParsedModules {
         Self(HashMap::new())
     }
 
-    pub fn sequence(&self, our_modules: &HashSet<String>) -> Result<Vec<String>, Error> {
+    pub fn sequence(&self, our_modules: &BTreeSet<String>) -> Result<Vec<String>, Error> {
         let inputs = self
             .0
             .values()
@@ -60,7 +60,7 @@ impl ParsedModules {
 
         let mut indices = HashMap::with_capacity(capacity);
 
-        let mut our_indices = HashSet::with_capacity(our_modules.len());
+        let mut our_indices = BTreeSet::new();
 
         for (value, _) in &inputs {
             let index = graph.add_node(value.to_string());
@@ -90,7 +90,7 @@ impl ParsedModules {
             // know starting indices for our search, so when we remove a dependency, we need find
             // back what those indices are.
             if messed_up_indices {
-                our_indices = HashSet::with_capacity(our_modules.len());
+                our_indices = BTreeSet::new();
                 for j in graph.node_indices() {
                     if our_modules.contains(graph[j].as_str()) {
                         our_indices.insert(j);
@@ -125,7 +125,7 @@ impl ParsedModules {
 
                 let mut path = vec![];
 
-                find_cycle(origin, origin, &graph, &mut path, &mut HashSet::new());
+                find_cycle(origin, origin, &graph, &mut path, &mut BTreeSet::new());
 
                 let modules = path
                     .iter()
@@ -176,7 +176,7 @@ fn find_cycle<W>(
     parent: NodeIndex,
     graph: &petgraph::Graph<W, ()>,
     path: &mut Vec<NodeIndex>,
-    seen: &mut HashSet<NodeIndex>,
+    seen: &mut BTreeSet<NodeIndex>,
 ) -> bool {
     seen.insert(parent);
 


### PR DESCRIPTION
  This changes ensure that we only compile modules from dependencies
  that are used (or transitively used) in the project. This allows to
  discard entire compilation steps at a module level, for modules that
  we do not use.

  The main goal of this change isn't performances. It's about making
  dependencies management slightly easier in the time we decide whether
  and how we want to manage transitive dependencies in Aiken.

  A concrete case here is aiken-lang/stdlib, which will soon depend on
  aiken-lang/fuzz. However, we do not want to require every single
  project depending on stdlib to also require fuzz. So instead, we want
  to seggregate fuzz API from stdlib in separate module, and only
  compile those if they appear in the pruned dependency graph.

  While the goal isn't performances, here are some benchmarks analyzing
  the performances of deps pruning on a simple project depends on a few
  modules from stdlib:

	Benchmark 1: ./aiken-without-deps-pruning check scratchpad
	  Time (mean ± σ):     190.3 ms ± 101.1 ms    [User: 584.5 ms, System: 14.2 ms]
	  Range (min … max):   153.0 ms … 477.7 ms    10 runs

	Benchmark 2: ./aiken-with-deps-pruning check scratchpad
	  Time (mean ± σ):     162.3 ms ±  46.3 ms    [User: 572.6 ms, System: 14.0 ms]
	  Range (min … max):   142.8 ms … 293.7 ms    10 runs

  As we can see, this change seems to have an overall positive impact on
  the compilation time.

---

TODO: I haven't yet checked the error we get now from trying to compile/type-check a module that contains an unknown module. I reckon it would just fallback to the normal type-checker error, though highlighting something from a dependency which might be slightly confusing. 