### PR TITLE
Allow downcasting to data in piped function calls.

### DIFF
--- a/crates/aiken-lang/src/tests/check.rs
+++ b/crates/aiken-lang/src/tests/check.rs
@@ -2132,6 +2132,40 @@ fn can_down_cast_to_data_always() {
 }
 
 #[test]
+fn can_down_cast_to_data_on_fn_call() {
+    let source_code = r#"
+        pub type Foo { Foo }
+
+        pub fn serialise(data: Data) -> ByteArray {
+            ""
+        }
+
+        test foo() {
+            serialise(Foo) == ""
+        }
+    "#;
+
+    assert!(check(parse(source_code)).is_ok());
+}
+
+#[test]
+fn can_down_cast_to_data_on_pipe() {
+    let source_code = r#"
+        pub type Foo { Foo }
+
+        pub fn serialise(data: Data) -> ByteArray {
+            ""
+        }
+
+        test foo() {
+            (Foo |> serialise) == ""
+        }
+    "#;
+
+    assert!(check(parse(source_code)).is_ok());
+}
+
+#[test]
 fn correct_span_for_backpassing_args() {
     let source_code = r#"
         fn fold(list: List<a>, acc: b, f: fn(a, b) -> b) -> b {

--- a/crates/aiken-lang/src/tipo/environment.rs
+++ b/crates/aiken-lang/src/tipo/environment.rs
@@ -1431,7 +1431,7 @@ impl<'a> Environment<'a> {
                     lhs,
                     Type::with_alias(tipo.clone(), alias.clone()),
                     location,
-                    false,
+                    allow_cast,
                 );
             }
         }
@@ -1470,7 +1470,7 @@ impl<'a> Environment<'a> {
                     Ok(())
                 }
 
-                Action::Unify(t) => self.unify(t, rhs, location, false),
+                Action::Unify(t) => self.unify(t, rhs, location, allow_cast),
 
                 Action::CouldNotUnify => Err(Error::CouldNotUnify {
                     location,
@@ -1550,7 +1550,7 @@ impl<'a> Environment<'a> {
                 },
             ) if args1.len() == args2.len() => {
                 for (a, b) in args1.iter().zip(args2) {
-                    self.unify(a.clone(), b.clone(), location, false)
+                    self.unify(a.clone(), b.clone(), location, allow_cast)
                         .map_err(|_| Error::CouldNotUnify {
                             location,
                             expected: lhs.clone(),


### PR DESCRIPTION
  We have been a bit too strict on disallowing 'allow_cast' propagations. This is really only problematic for nested elements like Tuple's elements or App's args. However, for linked and unbound var it is probably okay, and it certainly is as well for function arguments.