### PR TITLE
feat: Emit keyword

### DIFF
--- a/crates/aiken-lang/src/ast.rs
+++ b/crates/aiken-lang/src/ast.rs
@@ -1732,6 +1732,7 @@ pub enum TraceKind {
     Trace,
     Todo,
     Error,
+    Emit,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]

--- a/crates/aiken-lang/src/ast.rs
+++ b/crates/aiken-lang/src/ast.rs
@@ -205,6 +205,7 @@ fn str_to_keyword(word: &str) -> Option<Token> {
         "todo" => Some(Token::Todo),
         "type" => Some(Token::Type),
         "trace" => Some(Token::Trace),
+        "emit" => Some(Token::Emit),
         "test" => Some(Token::Test),
         // TODO: remove this in a future release
         "error" => Some(Token::Fail),
@@ -1927,7 +1928,7 @@ pub enum Error {
     #[diagnostic(code("illegal::module_name"))]
     #[diagnostic(help(r#"You cannot use keywords as part of a module path name. As a quick reminder, here's a list of all the keywords (and thus, of invalid module path names):
 
-    as, expect, check, const, else, fn, if, is, let, opaque, pub, test, todo, trace, type, use, when"#))]
+    as, expect, check, const, else, fn, if, is, let, opaque, pub, test, todo, trace, emit, type, use, when"#))]
     KeywordInModuleName { name: String, keyword: String },
 
     #[error("I realized you used '{}' as a module name, which is reserved (and not available).\n",

--- a/crates/aiken-lang/src/expr.rs
+++ b/crates/aiken-lang/src/expr.rs
@@ -371,7 +371,7 @@ impl TypedExpr {
                 .find_node(byte_index)
                 .or_else(|| then.find_node(byte_index))
                 .or(Some(Located::Expression(self))),
-            
+
             TypedExpr::Emit { text, then, .. } => text
                 .find_node(byte_index)
                 .or_else(|| then.find_node(byte_index))
@@ -1302,7 +1302,9 @@ impl UntypedExpr {
                 .map(|e| e.start_byte_index())
                 .unwrap_or(location.start),
             Self::PipeLine { expressions, .. } => expressions.first().start_byte_index(),
-            Self::Trace { location, .. } | Self::Emit{ location, .. } | Self::Assignment { location, .. } => location.start,
+            Self::Trace { location, .. }
+            | Self::Emit { location, .. }
+            | Self::Assignment { location, .. } => location.start,
             _ => self.location().start,
         }
     }

--- a/crates/aiken-lang/src/expr.rs
+++ b/crates/aiken-lang/src/expr.rs
@@ -545,12 +545,6 @@ pub enum UntypedExpr {
         text: Box<Self>,
     },
 
-    Emit {
-        location: Span,
-        then: Box<Self>,
-        text: Box<Self>,
-    },
-
     TraceIfFalse {
         location: Span,
         value: Box<Self>,
@@ -1262,7 +1256,6 @@ impl UntypedExpr {
         match self {
             Self::PipeLine { expressions, .. } => expressions.last().location(),
             Self::Trace { then, .. } => then.location(),
-            Self::Emit { then, .. } => then.location(),
             Self::TraceIfFalse { location, .. }
             | Self::Fn { location, .. }
             | Self::Var { location, .. }
@@ -1302,9 +1295,7 @@ impl UntypedExpr {
                 .map(|e| e.start_byte_index())
                 .unwrap_or(location.start),
             Self::PipeLine { expressions, .. } => expressions.first().start_byte_index(),
-            Self::Trace { location, .. }
-            | Self::Emit { location, .. }
-            | Self::Assignment { location, .. } => location.start,
+            Self::Trace { location, .. } | Self::Assignment { location, .. } => location.start,
             _ => self.location().start,
         }
     }

--- a/crates/aiken-lang/src/format.rs
+++ b/crates/aiken-lang/src/format.rs
@@ -957,9 +957,7 @@ impl<'comments> Formatter<'comments> {
                 kind, text, then, ..
             } => self.trace(kind, text, then),
 
-            UntypedExpr::Emit {
-                text, then, ..
-            } => self.emit(text, then),
+            UntypedExpr::Emit { text, then, .. } => self.emit(text, then),
 
             UntypedExpr::When {
                 subject, clauses, ..
@@ -1049,23 +1047,18 @@ impl<'comments> Formatter<'comments> {
         }
     }
 
-    pub fn emit<'a>(
-        &mut self,
-        text: &'a UntypedExpr,
-        then: &'a UntypedExpr,
-    ) -> Document<'a> {
+    pub fn emit<'a>(&mut self, text: &'a UntypedExpr, then: &'a UntypedExpr) -> Document<'a> {
         let body = "emit"
-                .to_doc()
-                .append(" ")
-                .append(self.wrap_expr(text))
-                .group();
-        body
-                .append(if self.pop_empty_lines(then.start_byte_index()) {
-                    lines(2)
-                } else {
-                    line()
-                })
-                .append(self.expr(then, true))
+            .to_doc()
+            .append(" ")
+            .append(self.wrap_expr(text))
+            .group();
+        body.append(if self.pop_empty_lines(then.start_byte_index()) {
+            lines(2)
+        } else {
+            line()
+        })
+        .append(self.expr(then, true))
     }
 
     pub fn pattern_constructor<'a>(

--- a/crates/aiken-lang/src/gen_uplc.rs
+++ b/crates/aiken-lang/src/gen_uplc.rs
@@ -530,6 +530,14 @@ impl<'a> CodeGenerator<'a> {
                     self.build(then, module_build_name, &[]),
                 ),
 
+                TypedExpr::Emit {
+                    tipo, then, text, ..
+                } => AirTree::emit(
+                    self.build(text, module_build_name, &[]),
+                    tipo.clone(),
+                    self.build(then, module_build_name, &[]),
+                ),
+
                 TypedExpr::When {
                     tipo,
                     subject,
@@ -5302,6 +5310,15 @@ impl<'a> CodeGenerator<'a> {
                 }
             }
             Air::Trace { .. } => {
+                let text = arg_stack.pop().unwrap();
+
+                let term = arg_stack.pop().unwrap();
+
+                let term = term.delayed_trace(text);
+
+                Some(term)
+            }
+            Air::Emit { .. } => {
                 let text = arg_stack.pop().unwrap();
 
                 let term = arg_stack.pop().unwrap();

--- a/crates/aiken-lang/src/gen_uplc/air.rs
+++ b/crates/aiken-lang/src/gen_uplc/air.rs
@@ -198,6 +198,9 @@ pub enum Air {
     Trace {
         tipo: Rc<Type>,
     },
+    Emit {
+        tipo: Rc<Type>,
+    },
     NoOp,
     FieldsEmpty,
     ListEmpty,

--- a/crates/aiken-lang/src/gen_uplc/tree.rs
+++ b/crates/aiken-lang/src/gen_uplc/tree.rs
@@ -354,6 +354,11 @@ pub enum AirTree {
         msg: Box<AirTree>,
         then: Box<AirTree>,
     },
+    Emit {
+        tipo: Rc<Type>,
+        msg: Box<AirTree>,
+        then: Box<AirTree>,
+    },
     // End Expressions
 }
 
@@ -825,6 +830,13 @@ impl AirTree {
     }
     pub fn trace(msg: AirTree, tipo: Rc<Type>, then: AirTree) -> AirTree {
         AirTree::Trace {
+            tipo,
+            msg: msg.into(),
+            then: then.into(),
+        }
+    }
+    pub fn emit(msg: AirTree, tipo: Rc<Type>, then: AirTree) -> AirTree {
+        AirTree::Emit {
             tipo,
             msg: msg.into(),
             then: then.into(),
@@ -1379,6 +1391,11 @@ impl AirTree {
                 msg.create_air_vec(air_vec);
                 then.create_air_vec(air_vec);
             }
+            AirTree::Emit { tipo, msg, then } => {
+                air_vec.push(Air::Emit { tipo: tipo.clone() });
+                msg.create_air_vec(air_vec);
+                then.create_air_vec(air_vec);
+            }
         }
     }
 
@@ -1400,7 +1417,8 @@ impl AirTree {
             | AirTree::Constr { tipo, .. }
             | AirTree::RecordUpdate { tipo, .. }
             | AirTree::ErrorTerm { tipo, .. }
-            | AirTree::Trace { tipo, .. } => tipo.clone(),
+            | AirTree::Trace { tipo, .. }
+            | AirTree::Emit { tipo, .. } => tipo.clone(),
             AirTree::Void => void(),
             AirTree::Var { constructor, .. } => constructor.tipo.clone(),
             AirTree::Fn { func_body, .. } => func_body.return_type(),
@@ -1456,7 +1474,8 @@ impl AirTree {
             | AirTree::If { tipo, .. }
             | AirTree::Constr { tipo, .. }
             | AirTree::ErrorTerm { tipo, .. }
-            | AirTree::Trace { tipo, .. } => vec![tipo],
+            | AirTree::Trace { tipo, .. }
+            | AirTree::Emit { tipo, .. } => vec![tipo],
             AirTree::Var { constructor, .. } => {
                 vec![constructor.tipo.borrow_mut()]
             }
@@ -1940,6 +1959,23 @@ impl AirTree {
                     apply_with_func_last,
                 );
             }
+            AirTree::Emit { msg, then, .. } => {
+                msg.do_traverse_tree_with(
+                    tree_path,
+                    current_depth + 1,
+                    index_count.next_number(),
+                    with,
+                    apply_with_func_last,
+                );
+
+                then.do_traverse_tree_with(
+                    tree_path,
+                    current_depth + 1,
+                    index_count.next_number(),
+                    with,
+                    apply_with_func_last,
+                );
+            }
             AirTree::DefineFunc {
                 func_body, then, ..
             } => {
@@ -2276,6 +2312,15 @@ impl AirTree {
                     item.do_find_air_tree_node(tree_path_iter)
                 }
                 AirTree::Trace { msg, then, .. } => {
+                    if *index == 0 {
+                        msg.as_mut().do_find_air_tree_node(tree_path_iter)
+                    } else if *index == 1 {
+                        then.as_mut().do_find_air_tree_node(tree_path_iter)
+                    } else {
+                        panic!("Tree Path index outside tree children nodes")
+                    }
+                }
+                AirTree::Emit { msg, then, .. } => {
                     if *index == 0 {
                         msg.as_mut().do_find_air_tree_node(tree_path_iter)
                     } else if *index == 1 {

--- a/crates/aiken-lang/src/parser/expr/fail_todo_trace.rs
+++ b/crates/aiken-lang/src/parser/expr/fail_todo_trace.rs
@@ -39,7 +39,8 @@ pub fn parser<'a>(
         just(Token::Emit)
             .ignore_then(choice((string::hybrid(), expression.clone())))
             .then(sequence.clone().or_not())
-            .map_with_span(|(text, then_), span| UntypedExpr::Emit {
+            .map_with_span(|(text, then_), span| UntypedExpr::Trace {
+                kind: TraceKind::Emit,
                 location: span,
                 then: Box::new(then_.unwrap_or_else(|| UntypedExpr::todo(None, span))),
                 text: Box::new(text),

--- a/crates/aiken-lang/src/parser/expr/fail_todo_trace.rs
+++ b/crates/aiken-lang/src/parser/expr/fail_todo_trace.rs
@@ -36,6 +36,14 @@ pub fn parser<'a>(
                 then: Box::new(then_.unwrap_or_else(|| UntypedExpr::todo(None, span))),
                 text: Box::new(text),
             }),
+        just(Token::Emit)
+            .ignore_then(choice((string::hybrid(), expression.clone())))
+            .then(sequence.clone().or_not())
+            .map_with_span(|(text, then_), span| UntypedExpr::Emit {
+                location: span,
+                then: Box::new(then_.unwrap_or_else(|| UntypedExpr::todo(None, span))),
+                text: Box::new(text),
+            }),
     ))
 }
 

--- a/crates/aiken-lang/src/parser/lexer.rs
+++ b/crates/aiken-lang/src/parser/lexer.rs
@@ -220,6 +220,7 @@ pub fn lexer() -> impl Parser<char, Vec<(Token, Span)>, Error = ParseError> {
 
     let keyword = text::ident().map(|s: String| match s.as_str() {
         "trace" => Token::Trace,
+        "emit" => Token::Emit,
         // TODO: remove this in a future release
         "error" => Token::Fail,
         "fail" => Token::Fail,

--- a/crates/aiken-lang/src/parser/token.rs
+++ b/crates/aiken-lang/src/parser/token.rs
@@ -89,6 +89,7 @@ pub enum Token {
     Type,
     When,
     Trace,
+    Emit,
     Validator,
     Via,
 }
@@ -175,6 +176,7 @@ impl fmt::Display for Token {
             Token::Pub => "pub",
             Token::Todo => "todo",
             Token::Trace => "trace",
+            Token::Emit => "emit",
             Token::Type => "type",
             Token::Test => "test",
             Token::Fail => "fail",

--- a/crates/aiken-lang/src/tipo/expr.rs
+++ b/crates/aiken-lang/src/tipo/expr.rs
@@ -281,6 +281,22 @@ impl<'a, 'b> ExprTyper<'a, 'b> {
                 kind,
             } => self.infer_trace(kind, *then, location, *text),
 
+            UntypedExpr::Emit {
+                location,
+                then,
+                text,
+            } => {
+                let text = self.infer(*text)?;
+                self.unify(string(), text.tipo(), text.location(), false)?;
+                let then = self.infer(*then)?;
+                Ok(TypedExpr::Emit {
+                    location,
+                    tipo: then.tipo(),
+                    then: Box::new(then),
+                    text: Box::new(text),
+                })
+            }
+
             UntypedExpr::When {
                 location,
                 subject,
@@ -2324,7 +2340,7 @@ fn assert_no_assignment(expr: &UntypedExpr) -> Result<(), Error> {
             location: expr.location(),
             expr: *value.clone(),
         }),
-        UntypedExpr::Trace { then, .. } => assert_no_assignment(then),
+        UntypedExpr::Trace { then, .. } | UntypedExpr::Emit { then, .. } => assert_no_assignment(then),
         UntypedExpr::Fn { .. }
         | UntypedExpr::BinOp { .. }
         | UntypedExpr::ByteArray { .. }

--- a/crates/aiken-lang/src/tipo/expr.rs
+++ b/crates/aiken-lang/src/tipo/expr.rs
@@ -2340,7 +2340,9 @@ fn assert_no_assignment(expr: &UntypedExpr) -> Result<(), Error> {
             location: expr.location(),
             expr: *value.clone(),
         }),
-        UntypedExpr::Trace { then, .. } | UntypedExpr::Emit { then, .. } => assert_no_assignment(then),
+        UntypedExpr::Trace { then, .. } | UntypedExpr::Emit { then, .. } => {
+            assert_no_assignment(then)
+        }
         UntypedExpr::Fn { .. }
         | UntypedExpr::BinOp { .. }
         | UntypedExpr::ByteArray { .. }

--- a/crates/aiken-lang/src/tipo/expr.rs
+++ b/crates/aiken-lang/src/tipo/expr.rs
@@ -281,22 +281,6 @@ impl<'a, 'b> ExprTyper<'a, 'b> {
                 kind,
             } => self.infer_trace(kind, *then, location, *text),
 
-            UntypedExpr::Emit {
-                location,
-                then,
-                text,
-            } => {
-                let text = self.infer(*text)?;
-                self.unify(string(), text.tipo(), text.location(), false)?;
-                let then = self.infer(*then)?;
-                Ok(TypedExpr::Emit {
-                    location,
-                    tipo: then.tipo(),
-                    then: Box::new(then),
-                    text: Box::new(text),
-                })
-            }
-
             UntypedExpr::When {
                 location,
                 subject,
@@ -2340,9 +2324,7 @@ fn assert_no_assignment(expr: &UntypedExpr) -> Result<(), Error> {
             location: expr.location(),
             expr: *value.clone(),
         }),
-        UntypedExpr::Trace { then, .. } | UntypedExpr::Emit { then, .. } => {
-            assert_no_assignment(then)
-        }
+        UntypedExpr::Trace { then, .. } => assert_no_assignment(then),
         UntypedExpr::Fn { .. }
         | UntypedExpr::BinOp { .. }
         | UntypedExpr::ByteArray { .. }

--- a/crates/aiken-project/src/test_framework.rs
+++ b/crates/aiken-project/src/test_framework.rs
@@ -1085,6 +1085,7 @@ impl TryFrom<TypedExpr> for Assertion<TypedExpr> {
             }
 
             TypedExpr::Trace { then, .. } => (*then).try_into(),
+            TypedExpr::Emit { then, .. } => (*then).try_into(),
 
             TypedExpr::Sequence { expressions, .. } | TypedExpr::Pipeline { expressions, .. } => {
                 if let Ok(Assertion {


### PR DESCRIPTION
This adds the emit keyword (emissions) which is a kind of trace that is used for effectful offchain functionality and therefore should never be erased (even when Silent option to the keep traces flag is passed).

This is largely a UX feature to make it easier to implement the following pattern:
https://x.com/SebastienGllmt/status/1774479357370945544?s=20