### PR TITLE
chore(ci): Bump github actions/checkout from 3 to 4

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -13,7 +13,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Build
         run: cargo build --verbose --workspace --target x86_64-unknown-linux-gnu
         env:

--- a/crates/aiken-lang/src/expr.rs
+++ b/crates/aiken-lang/src/expr.rs
@@ -1337,7 +1337,7 @@ impl UntypedExpr {
         match self {
             Self::BinOp { name, .. } => name.precedence(),
             Self::PipeLine { .. } => 0,
-            _ => std::u8::MAX,
+            _ => u8::MAX,
         }
     }
 

--- a/crates/aiken-project/src/test_framework.rs
+++ b/crates/aiken-project/src/test_framework.rs
@@ -731,7 +731,7 @@ impl<'a> Counterexample<'a> {
                         let jv = self.choices[j];
 
                         // Replace
-                        if iv > 0 && jv <= u8::max_value() - iv {
+                        if iv > 0 && jv <= u8::MAX - iv {
                             self.binary_search_replace(0, iv, |v| vec![(i, v), (j, jv + (iv - v))]);
                         }
 


### PR DESCRIPTION
* Correct the usage of a legacy numeric constant
* Update the checkout actions from 3 to  4 to use Node.js 20. This change should resolve the warning message.

![image](https://github.com/aiken-lang/aiken/assets/4198294/52883df2-d7a7-4bef-b041-b552e990c527)
