### PR TITLE
Solved: Nix expression broken in Darwin

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -22,6 +22,7 @@
         [
           darwin.apple_sdk.frameworks.Security
           darwin.apple_sdk.frameworks.CoreServices
+          darwin.apple_sdk.frameworks.SystemConfiguration
         ];
 
       cargoTomlContents = builtins.readFile ./crates/aiken/Cargo.toml;


### PR DESCRIPTION
The current nix expression doesn't build on either `aarch64-darwin` or `x86_64-darwin`, but with this small patch, it does.

Tested on:
- `aarch64-darwin`
- `x86_64-darwin`
- `x86_64-linux`
