### PR TITLE
Supercharge traces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,41 @@
 
 - **aiken-lang**: remove warning on discarded expect, allowing to keep 'side-effects' when necessary. See #967. @KtorZ
 
+- **aiken-lang**: rework traces to be (1) variadic, (2) generic in its arguments and (3) structured. @KtorZ
+
+  In more details:
+  1. Enables the `trace` keyword to take one, two or any argument really separated by comma after the first. For example:
+
+     ```ak
+     trace @"a classic trace"
+
+     // ..
+
+     trace @"condition_1": @"foo"
+
+     // ...
+
+     trace @"condition_2": @"foo", @"bar"
+     ```
+
+  2. Enables the `trace` keyword to not only take strings as arguments; but any
+     data-type that is serialisable (i.e. that can be cast to Data). It is fundamentally identical to calling the [`cbor.diagnostic`](https://aiken-lang.github.io/stdlib/aiken/cbor.html#diagnostic) function from the standard lib; except that this is done and glued with the rest of the trace automatically.
+
+     ```ak
+     trace @"condition_1": [1, 2, 3]
+
+     // ...
+
+     let my_var = Some("foo")
+     trace my_var
+     ```
+
+  3. Changes the behavior of the `--trace-level compact` mode to now:
+    - remove trace-if-false (`?` operator) traces entirely in this mode;
+    - only keep the label (first trace argument) and error when it isn't a string.
+
+  See also [#978](https://github.com/aiken-lang/aiken/pull/978).
+
 ## v1.0.29-alpha - 2024-06-06
 
 ### Added

--- a/crates/aiken-lang/src/ast.rs
+++ b/crates/aiken-lang/src/ast.rs
@@ -1957,6 +1957,10 @@ pub enum TraceLevel {
 }
 
 impl Tracing {
+    pub fn verbose() -> Self {
+        Tracing::All(TraceLevel::Verbose)
+    }
+
     pub fn silent() -> Self {
         Tracing::All(TraceLevel::Silent)
     }

--- a/crates/aiken-lang/src/expr.rs
+++ b/crates/aiken-lang/src/expr.rs
@@ -548,7 +548,8 @@ pub enum UntypedExpr {
         kind: TraceKind,
         location: Span,
         then: Box<Self>,
-        text: Box<Self>,
+        label: Box<Self>,
+        arguments: Vec<Self>,
     },
 
     TraceIfFalse {
@@ -1134,10 +1135,11 @@ impl UntypedExpr {
             location,
             kind: TraceKind::Todo,
             then: Box::new(UntypedExpr::ErrorTerm { location }),
-            text: Box::new(reason.unwrap_or_else(|| UntypedExpr::String {
+            label: Box::new(reason.unwrap_or_else(|| UntypedExpr::String {
                 location,
                 value: DEFAULT_TODO_STR.to_string(),
             })),
+            arguments: Vec::new(),
         }
     }
 
@@ -1147,7 +1149,8 @@ impl UntypedExpr {
                 location,
                 kind: TraceKind::Error,
                 then: Box::new(UntypedExpr::ErrorTerm { location }),
-                text: Box::new(reason),
+                label: Box::new(reason),
+                arguments: Vec::new(),
             }
         } else {
             UntypedExpr::ErrorTerm { location }

--- a/crates/aiken-lang/src/gen_uplc.rs
+++ b/crates/aiken-lang/src/gen_uplc.rs
@@ -17,7 +17,7 @@ use crate::{
         Span, TraceLevel, Tracing, TypedArg, TypedClause, TypedDataType, TypedFunction,
         TypedPattern, TypedValidator, UnOp,
     },
-    builtins::{bool, data, int, list, void},
+    builtins::{bool, data, int, list, void, PRELUDE},
     expr::TypedExpr,
     gen_uplc::{
         air::ExpectLevel,
@@ -748,7 +748,19 @@ impl<'a> CodeGenerator<'a> {
                     }
                     ModuleValueConstructor::Fn { name, module, .. } => {
                         let func = self.functions.get(&FunctionAccessKey {
-                            module_name: module_name.clone(),
+                            // NOTE: This is needed because we register prelude functions under an
+                            // empty module name. This is to facilitate their access when used
+                            // directly. Note that, if we weren't doing this particular
+                            // transformation, we would need to do the other direction anyway:
+                            //
+                            //     if module_name.is_empty() { PRELUDE.to_string() } else { module_name.clone() }
+                            //
+                            // So either way, we need to take care of this.
+                            module_name: if module_name == PRELUDE {
+                                String::new()
+                            } else {
+                                module_name.clone()
+                            },
                             function_name: name.clone(),
                         });
 

--- a/crates/aiken-lang/src/gen_uplc.rs
+++ b/crates/aiken-lang/src/gen_uplc.rs
@@ -748,11 +748,7 @@ impl<'a> CodeGenerator<'a> {
                     }
                     ModuleValueConstructor::Fn { name, module, .. } => {
                         let func = self.functions.get(&FunctionAccessKey {
-                            module_name: if module_name == "aiken" {
-                                "".to_string()
-                            } else {
-                                module_name.clone()
-                            },
+                            module_name: module_name.clone(),
                             function_name: name.clone(),
                         });
 

--- a/crates/aiken-lang/src/gen_uplc.rs
+++ b/crates/aiken-lang/src/gen_uplc.rs
@@ -43,7 +43,6 @@ use itertools::Itertools;
 use petgraph::{algo, Graph};
 use std::{collections::HashMap, rc::Rc};
 use tree::Fields;
-
 use uplc::{
     ast::{Constant as UplcConstant, Name, NamedDeBruijn, Program, Term, Type as UplcType},
     builder::{CONSTR_FIELDS_EXPOSER, CONSTR_INDEX_EXPOSER, EXPECT_ON_LIST},
@@ -749,7 +748,11 @@ impl<'a> CodeGenerator<'a> {
                     }
                     ModuleValueConstructor::Fn { name, module, .. } => {
                         let func = self.functions.get(&FunctionAccessKey {
-                            module_name: module_name.clone(),
+                            module_name: if module_name == "aiken" {
+                                "".to_string()
+                            } else {
+                                module_name.clone()
+                            },
                             function_name: name.clone(),
                         });
 

--- a/crates/aiken-lang/src/lib.rs
+++ b/crates/aiken-lang/src/lib.rs
@@ -31,5 +31,36 @@ impl IdGenerator {
     }
 }
 
+#[macro_export]
+macro_rules! aiken_fn {
+    ($module_types:expr, $id_gen:expr, $src:expr) => {{
+        let (untyped_module, _) = $crate::parser::module($src, $crate::ast::ModuleKind::Lib)
+            .expect("failed to parse module.");
+
+        let module_name = "";
+
+        let mut warnings = vec![];
+
+        let typed_module = untyped_module
+            .infer(
+                $id_gen,
+                $crate::ast::ModuleKind::Lib,
+                module_name,
+                $module_types,
+                $crate::ast::Tracing::silent(),
+                &mut warnings,
+            )
+            .unwrap();
+
+        if let Some($crate::ast::Definition::Fn(typed_fn)) =
+            typed_module.definitions.into_iter().last()
+        {
+            typed_fn
+        } else {
+            unreachable!()
+        }
+    }};
+}
+
 #[cfg(test)]
 mod tests;

--- a/crates/aiken-lang/src/parser/definition/snapshots/function_empty.snap
+++ b/crates/aiken-lang/src/parser/definition/snapshots/function_empty.snap
@@ -11,10 +11,11 @@ Fn(
             then: ErrorTerm {
                 location: 0..15,
             },
-            text: String {
+            label: String {
                 location: 0..15,
                 value: "aiken::todo",
             },
+            arguments: [],
         },
         doc: None,
         location: 0..12,

--- a/crates/aiken-lang/src/parser/definition/snapshots/function_non_public.snap
+++ b/crates/aiken-lang/src/parser/definition/snapshots/function_non_public.snap
@@ -11,10 +11,11 @@ Fn(
             then: ErrorTerm {
                 location: 0..11,
             },
-            text: String {
+            label: String {
                 location: 0..11,
                 value: "aiken::todo",
             },
+            arguments: [],
         },
         doc: None,
         location: 0..8,

--- a/crates/aiken-lang/src/parser/expr/fail_todo_trace.rs
+++ b/crates/aiken-lang/src/parser/expr/fail_todo_trace.rs
@@ -2,7 +2,7 @@ use crate::{
     ast::TraceKind,
     expr::UntypedExpr,
     parser::{
-        error::ParseError,
+        error::{ParseError, Pattern},
         expr::{string, when::clause},
         token::Token,
     },

--- a/crates/aiken-lang/src/parser/expr/fail_todo_trace.rs
+++ b/crates/aiken-lang/src/parser/expr/fail_todo_trace.rs
@@ -28,13 +28,25 @@ pub fn parser<'a>(
             .map_with_span(UntypedExpr::fail),
         just(Token::Trace)
             .ignore_then(choice((string::hybrid(), expression.clone())))
+            .then(
+                just(Token::Colon)
+                    .ignore_then(
+                        choice((string::hybrid(), expression.clone()))
+                            .separated_by(just(Token::Comma)),
+                    )
+                    .or_not()
+                    .map(|opt| opt.unwrap_or_default()),
+            )
             .then(sequence.clone().or_not())
-            .map_with_span(|(text, then_), span| UntypedExpr::Trace {
-                kind: TraceKind::Trace,
-                location: span,
-                then: Box::new(then_.unwrap_or_else(|| UntypedExpr::todo(None, span))),
-                text: Box::new(text),
-            }),
+            .map_with_span(
+                |((label, arguments), continuation), span| UntypedExpr::Trace {
+                    kind: TraceKind::Trace,
+                    location: span,
+                    then: Box::new(continuation.unwrap_or_else(|| UntypedExpr::todo(None, span))),
+                    label: Box::new(label),
+                    arguments,
+                },
+            ),
     ))
 }
 
@@ -115,6 +127,26 @@ mod tests {
     }
 
     #[test]
+    fn trace_string() {
+        assert_expr!(
+            r#"
+            trace @"foo"
+            a
+            "#
+        );
+    }
+
+    #[test]
+    fn trace_bytearray() {
+        assert_expr!(
+            r#"
+            trace "foo"
+            a
+            "#
+        );
+    }
+
+    #[test]
     fn trace_expr() {
         assert_expr!(
             r#"
@@ -129,6 +161,24 @@ mod tests {
         assert_expr!(
             r#"
             trace some_var
+            "#
+        );
+    }
+
+    #[test]
+    fn trace_labelled() {
+        assert_expr!(
+            r#"
+            trace foo: "bar"
+            "#
+        );
+    }
+
+    #[test]
+    fn trace_variadic() {
+        assert_expr!(
+            r#"
+            trace "foo": @"bar", baz
             "#
         );
     }

--- a/crates/aiken-lang/src/parser/expr/snapshots/error_basic.snap
+++ b/crates/aiken-lang/src/parser/expr/snapshots/error_basic.snap
@@ -8,8 +8,9 @@ Trace {
     then: ErrorTerm {
         location: 0..11,
     },
-    text: String {
+    label: String {
         location: 5..11,
         value: "foo",
     },
+    arguments: [],
 }

--- a/crates/aiken-lang/src/parser/expr/snapshots/error_sugar.snap
+++ b/crates/aiken-lang/src/parser/expr/snapshots/error_sugar.snap
@@ -8,8 +8,9 @@ Trace {
     then: ErrorTerm {
         location: 0..10,
     },
-    text: String {
+    label: String {
         location: 5..10,
         value: "foo",
     },
+    arguments: [],
 }

--- a/crates/aiken-lang/src/parser/expr/snapshots/fail_expr.snap
+++ b/crates/aiken-lang/src/parser/expr/snapshots/fail_expr.snap
@@ -8,7 +8,7 @@ Trace {
     then: ErrorTerm {
         location: 0..67,
     },
-    text: Call {
+    label: Call {
         arguments: [
             CallArg {
                 label: None,
@@ -51,4 +51,5 @@ Trace {
         },
         location: 5..67,
     },
+    arguments: [],
 }

--- a/crates/aiken-lang/src/parser/expr/snapshots/if_soft_cast_discard_assign.snap
+++ b/crates/aiken-lang/src/parser/expr/snapshots/if_soft_cast_discard_assign.snap
@@ -20,10 +20,11 @@ If {
                 then: ErrorTerm {
                     location: 20..24,
                 },
-                text: String {
+                label: String {
                     location: 20..24,
                     value: "aiken::todo",
                 },
+                arguments: [],
             },
             is: Some(
                 AssignmentPattern {
@@ -51,9 +52,10 @@ If {
         then: ErrorTerm {
             location: 36..40,
         },
-        text: String {
+        label: String {
             location: 36..40,
             value: "aiken::todo",
         },
+        arguments: [],
     },
 }

--- a/crates/aiken-lang/src/parser/expr/snapshots/if_soft_cast_not_var_condition.snap
+++ b/crates/aiken-lang/src/parser/expr/snapshots/if_soft_cast_not_var_condition.snap
@@ -20,10 +20,11 @@ If {
                 then: ErrorTerm {
                     location: 31..35,
                 },
-                text: String {
+                label: String {
                     location: 31..35,
                     value: "aiken::todo",
                 },
+                arguments: [],
             },
             is: Some(
                 AssignmentPattern {
@@ -68,9 +69,10 @@ If {
         then: ErrorTerm {
             location: 47..51,
         },
-        text: String {
+        label: String {
             location: 47..51,
             value: "aiken::todo",
         },
+        arguments: [],
     },
 }

--- a/crates/aiken-lang/src/parser/expr/snapshots/todo_basic.snap
+++ b/crates/aiken-lang/src/parser/expr/snapshots/todo_basic.snap
@@ -8,8 +8,9 @@ Trace {
     then: ErrorTerm {
         location: 0..11,
     },
-    text: String {
+    label: String {
         location: 5..11,
         value: "foo",
     },
+    arguments: [],
 }

--- a/crates/aiken-lang/src/parser/expr/snapshots/todo_empty.snap
+++ b/crates/aiken-lang/src/parser/expr/snapshots/todo_empty.snap
@@ -8,8 +8,9 @@ Trace {
     then: ErrorTerm {
         location: 0..4,
     },
-    text: String {
+    label: String {
         location: 0..4,
         value: "aiken::todo",
     },
+    arguments: [],
 }

--- a/crates/aiken-lang/src/parser/expr/snapshots/todo_expr.snap
+++ b/crates/aiken-lang/src/parser/expr/snapshots/todo_expr.snap
@@ -8,7 +8,7 @@ Trace {
     then: ErrorTerm {
         location: 0..32,
     },
-    text: Call {
+    label: Call {
         arguments: [
             CallArg {
                 label: None,
@@ -49,4 +49,5 @@ Trace {
         },
         location: 5..32,
     },
+    arguments: [],
 }

--- a/crates/aiken-lang/src/parser/expr/snapshots/todo_sugar.snap
+++ b/crates/aiken-lang/src/parser/expr/snapshots/todo_sugar.snap
@@ -8,8 +8,9 @@ Trace {
     then: ErrorTerm {
         location: 0..10,
     },
-    text: String {
+    label: String {
         location: 5..10,
         value: "foo",
     },
+    arguments: [],
 }

--- a/crates/aiken-lang/src/parser/expr/snapshots/trace_bytearray.snap
+++ b/crates/aiken-lang/src/parser/expr/snapshots/trace_bytearray.snap
@@ -1,0 +1,17 @@
+---
+source: crates/aiken-lang/src/parser/expr/fail_todo_trace.rs
+description: "Code:\n\ntrace \"foo\"\na\n"
+---
+Trace {
+    kind: Trace,
+    location: 0..13,
+    then: Var {
+        location: 12..13,
+        name: "a",
+    },
+    label: String {
+        location: 6..11,
+        value: "foo",
+    },
+    arguments: [],
+}

--- a/crates/aiken-lang/src/parser/expr/snapshots/trace_expr.snap
+++ b/crates/aiken-lang/src/parser/expr/snapshots/trace_expr.snap
@@ -9,7 +9,7 @@ Trace {
         location: 34..35,
         name: "a",
     },
-    text: Call {
+    label: Call {
         arguments: [
             CallArg {
                 label: None,
@@ -50,4 +50,5 @@ Trace {
         },
         location: 6..33,
     },
+    arguments: [],
 }

--- a/crates/aiken-lang/src/parser/expr/snapshots/trace_expr_todo.snap
+++ b/crates/aiken-lang/src/parser/expr/snapshots/trace_expr_todo.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/aiken-lang/src/parser/expr/fail_todo_trace.rs
-description: "Code:\n\ntrace some_var \n"
+description: "Code:\n\ntrace some_var\n"
 ---
 Trace {
     kind: Trace,
@@ -11,13 +11,15 @@ Trace {
         then: ErrorTerm {
             location: 0..14,
         },
-        text: String {
+        label: String {
             location: 0..14,
             value: "aiken::todo",
         },
+        arguments: [],
     },
-    text: Var {
+    label: Var {
         location: 6..14,
         name: "some_var",
     },
+    arguments: [],
 }

--- a/crates/aiken-lang/src/parser/expr/snapshots/trace_labelled.snap
+++ b/crates/aiken-lang/src/parser/expr/snapshots/trace_labelled.snap
@@ -1,0 +1,30 @@
+---
+source: crates/aiken-lang/src/parser/expr/fail_todo_trace.rs
+description: "Code:\n\ntrace foo: \"bar\"\n"
+---
+Trace {
+    kind: Trace,
+    location: 0..16,
+    then: Trace {
+        kind: Todo,
+        location: 0..16,
+        then: ErrorTerm {
+            location: 0..16,
+        },
+        label: String {
+            location: 0..16,
+            value: "aiken::todo",
+        },
+        arguments: [],
+    },
+    label: Var {
+        location: 6..9,
+        name: "foo",
+    },
+    arguments: [
+        String {
+            location: 11..16,
+            value: "bar",
+        },
+    ],
+}

--- a/crates/aiken-lang/src/parser/expr/snapshots/trace_string.snap
+++ b/crates/aiken-lang/src/parser/expr/snapshots/trace_string.snap
@@ -1,0 +1,17 @@
+---
+source: crates/aiken-lang/src/parser/expr/fail_todo_trace.rs
+description: "Code:\n\ntrace @\"foo\"\na\n"
+---
+Trace {
+    kind: Trace,
+    location: 0..14,
+    then: Var {
+        location: 13..14,
+        name: "a",
+    },
+    label: String {
+        location: 6..12,
+        value: "foo",
+    },
+    arguments: [],
+}

--- a/crates/aiken-lang/src/parser/expr/snapshots/trace_variadic.snap
+++ b/crates/aiken-lang/src/parser/expr/snapshots/trace_variadic.snap
@@ -1,0 +1,34 @@
+---
+source: crates/aiken-lang/src/parser/expr/fail_todo_trace.rs
+description: "Code:\n\ntrace \"foo\": @\"bar\", baz\n"
+---
+Trace {
+    kind: Trace,
+    location: 0..24,
+    then: Trace {
+        kind: Todo,
+        location: 0..24,
+        then: ErrorTerm {
+            location: 0..24,
+        },
+        label: String {
+            location: 0..24,
+            value: "aiken::todo",
+        },
+        arguments: [],
+    },
+    label: String {
+        location: 6..11,
+        value: "foo",
+    },
+    arguments: [
+        String {
+            location: 13..19,
+            value: "bar",
+        },
+        Var {
+            location: 21..24,
+            name: "baz",
+        },
+    ],
+}

--- a/crates/aiken-lang/src/parser/expr/when/snapshots/when_clause_double_todo.snap
+++ b/crates/aiken-lang/src/parser/expr/when/snapshots/when_clause_double_todo.snap
@@ -32,10 +32,11 @@ When {
                 then: ErrorTerm {
                     location: 28..32,
                 },
-                text: String {
+                label: String {
                     location: 28..32,
                     value: "aiken::todo",
                 },
+                arguments: [],
             },
         },
         UntypedClause {
@@ -61,10 +62,11 @@ When {
                 then: ErrorTerm {
                     location: 47..51,
                 },
-                text: String {
+                label: String {
                     location: 47..51,
                     value: "aiken::todo",
                 },
+                arguments: [],
             },
         },
     ],

--- a/crates/aiken-lang/src/parser/expr/when/snapshots/when_clause_todo.snap
+++ b/crates/aiken-lang/src/parser/expr/when/snapshots/when_clause_todo.snap
@@ -54,10 +54,11 @@ When {
                 then: ErrorTerm {
                     location: 47..68,
                 },
-                text: String {
+                label: String {
                     location: 52..68,
                     value: "unimplemented",
                 },
+                arguments: [],
             },
         },
     ],

--- a/crates/aiken-lang/src/parser/token.rs
+++ b/crates/aiken-lang/src/parser/token.rs
@@ -183,6 +183,6 @@ impl fmt::Display for Token {
             Token::Validator => "validator",
             Token::Via => "via",
         };
-        write!(f, "\"{s}\"")
+        write!(f, "{s}")
     }
 }

--- a/crates/aiken-lang/src/tests/format.rs
+++ b/crates/aiken-lang/src/tests/format.rs
@@ -985,3 +985,18 @@ fn format_validator_pattern() {
         "#
     );
 }
+
+#[test]
+fn format_variadic_trace() {
+    assert_format!(
+        r#"
+        fn foo() {
+            trace @"foo": @"bar"
+            trace "foo": "bar"
+            trace @"foo": "bar", @"baz"
+            trace bar: @"baz"
+            Void
+        }
+        "#
+    );
+}

--- a/crates/aiken-lang/src/tests/snapshots/format_variadic_trace.snap
+++ b/crates/aiken-lang/src/tests/snapshots/format_variadic_trace.snap
@@ -1,0 +1,11 @@
+---
+source: crates/aiken-lang/src/tests/format.rs
+description: "Code:\n\nfn foo() {\n    trace @\"foo\": @\"bar\"\n    trace \"foo\": \"bar\"\n    trace @\"foo\": \"bar\", @\"baz\"\n    trace bar: @\"baz\"\n    Void\n}\n"
+---
+fn foo() {
+  trace @"foo": @"bar"
+  trace @"foo": @"bar"
+  trace @"foo": @"bar", @"baz"
+  trace bar: @"baz"
+  Void
+}

--- a/crates/aiken-lang/src/tipo.rs
+++ b/crates/aiken-lang/src/tipo.rs
@@ -12,10 +12,10 @@ use itertools::Itertools;
 use std::{cell::RefCell, collections::HashMap, ops::Deref, rc::Rc};
 use uplc::{ast::Type as UplcType, builtins::DefaultFunction};
 
-mod environment;
+pub(crate) mod environment;
 pub mod error;
 mod exhaustive;
-mod expr;
+pub(crate) mod expr;
 pub mod fields;
 mod hydrator;
 mod infer;

--- a/crates/aiken-lang/src/tipo/expr.rs
+++ b/crates/aiken-lang/src/tipo/expr.rs
@@ -24,7 +24,6 @@ use crate::{
     },
     expr::{FnStyle, TypedExpr, UntypedExpr},
     format,
-    line_numbers::LineNumbers,
     tipo::{fields::FieldMap, DefaultFunction, PatternConstructor, TypeVar},
     IdGenerator,
 };
@@ -41,7 +40,6 @@ pub(crate) fn infer_function(
     module_name: &str,
     hydrators: &mut HashMap<String, Hydrator>,
     environment: &mut Environment<'_>,
-    lines: &LineNumbers,
     tracing: Tracing,
 ) -> Result<Function<Rc<Type>, TypedExpr, TypedArg>, Error> {
     if let Some(typed_fun) = environment.inferred_functions.get(&fun.name) {
@@ -122,7 +120,7 @@ pub(crate) fn infer_function(
         .remove(name)
         .unwrap_or_else(|| panic!("Could not find hydrator for fn {name}"));
 
-    let mut expr_typer = ExprTyper::new(environment, lines, tracing);
+    let mut expr_typer = ExprTyper::new(environment, tracing);
     expr_typer.hydrator = hydrator;
     expr_typer.not_yet_inferred = BTreeSet::from_iter(hydrators.keys().cloned());
 
@@ -155,12 +153,11 @@ pub(crate) fn infer_function(
             environment.current_module,
             hydrators,
             environment,
-            lines,
             tracing,
         )?;
 
         // Then, try again the entire function definition.
-        return infer_function(fun, module_name, hydrators, environment, lines, tracing);
+        return infer_function(fun, module_name, hydrators, environment, tracing);
     }
 
     let (arguments, body, return_type) = inferred?;
@@ -223,8 +220,6 @@ pub(crate) fn infer_function(
 
 #[derive(Debug)]
 pub(crate) struct ExprTyper<'a, 'b> {
-    pub(crate) lines: &'a LineNumbers,
-
     pub(crate) environment: &'a mut Environment<'b>,
 
     // We tweak the tracing behavior during type-check. Traces are either kept or left out of the
@@ -244,18 +239,13 @@ pub(crate) struct ExprTyper<'a, 'b> {
 }
 
 impl<'a, 'b> ExprTyper<'a, 'b> {
-    pub fn new(
-        environment: &'a mut Environment<'b>,
-        lines: &'a LineNumbers,
-        tracing: Tracing,
-    ) -> Self {
+    pub fn new(environment: &'a mut Environment<'b>, tracing: Tracing) -> Self {
         Self {
             hydrator: Hydrator::new(),
             not_yet_inferred: BTreeSet::new(),
             environment,
             tracing,
             ungeneralised_function_used: false,
-            lines,
         }
     }
 
@@ -681,25 +671,16 @@ impl<'a, 'b> ExprTyper<'a, 'b> {
                         .to_pretty_string(999)
                 ),
             }),
-            TraceLevel::Compact => Some(TypedExpr::String {
-                location,
-                tipo: string(),
-                value: self
-                    .lines
-                    .line_and_column_number(location.start)
-                    .expect("Spans are within bounds.")
-                    .to_string(),
-            }),
-            TraceLevel::Silent => None,
+            TraceLevel::Compact | TraceLevel::Silent => None,
         };
 
         let typed_value = self.infer(value)?;
 
         self.unify(bool(), typed_value.tipo(), typed_value.location(), false)?;
 
-        match self.tracing.trace_level(false) {
-            TraceLevel::Silent => Ok(typed_value),
-            TraceLevel::Verbose | TraceLevel::Compact => Ok(TypedExpr::If {
+        match text {
+            None => Ok(typed_value),
+            Some(text) => Ok(TypedExpr::If {
                 location,
                 branches: vec1::vec1![IfBranch {
                     condition: typed_value,
@@ -710,7 +691,7 @@ impl<'a, 'b> ExprTyper<'a, 'b> {
                 final_else: Box::new(TypedExpr::Trace {
                     location,
                     tipo: bool(),
-                    text: Box::new(text.expect("TraceLevel::Silent excluded from pattern-guard")),
+                    text: Box::new(text),
                     then: Box::new(var_false),
                 }),
                 tipo: bool(),
@@ -2426,28 +2407,10 @@ impl<'a, 'b> ExprTyper<'a, 'b> {
         label: UntypedExpr,
         arguments: Vec<UntypedExpr>,
     ) -> Result<TypedExpr, Error> {
-        let label = self.infer_trace_arg(label)?;
-
         let typed_arguments = arguments
             .into_iter()
             .map(|arg| self.infer_trace_arg(arg))
             .collect::<Result<Vec<_>, Error>>()?;
-
-        let text = if typed_arguments.is_empty() {
-            label
-        } else {
-            let delimiter = |ix| TypedExpr::String {
-                location: Span::empty(),
-                tipo: string(),
-                value: if ix == 0 { ": " } else { ", " }.to_string(),
-            };
-            typed_arguments
-                .into_iter()
-                .enumerate()
-                .fold(label, |text, (ix, arg)| {
-                    append_string_expr(append_string_expr(text, delimiter(ix)), arg)
-                })
-        };
 
         let then = self.infer(then)?;
         let tipo = then.tipo();
@@ -2461,26 +2424,42 @@ impl<'a, 'b> ExprTyper<'a, 'b> {
 
         match self.tracing.trace_level(false) {
             TraceLevel::Silent => Ok(then),
-            TraceLevel::Compact => Ok(TypedExpr::Trace {
-                location,
-                tipo,
-                then: Box::new(then),
-                text: Box::new(TypedExpr::String {
+            TraceLevel::Compact => {
+                let text = self.infer(label)?;
+                self.unify(string(), text.tipo(), text.location(), false)?;
+                Ok(TypedExpr::Trace {
                     location,
-                    tipo: string(),
-                    value: self
-                        .lines
-                        .line_and_column_number(location.start)
-                        .expect("Spans are within bounds.")
-                        .to_string(),
-                }),
-            }),
-            TraceLevel::Verbose => Ok(TypedExpr::Trace {
-                location,
-                tipo,
-                then: Box::new(then),
-                text: Box::new(text),
-            }),
+                    tipo,
+                    then: Box::new(then),
+                    text: Box::new(text),
+                })
+            }
+            TraceLevel::Verbose => {
+                let label = self.infer_trace_arg(label)?;
+
+                let text = if typed_arguments.is_empty() {
+                    label
+                } else {
+                    let delimiter = |ix| TypedExpr::String {
+                        location: Span::empty(),
+                        tipo: string(),
+                        value: if ix == 0 { ": " } else { ", " }.to_string(),
+                    };
+                    typed_arguments
+                        .into_iter()
+                        .enumerate()
+                        .fold(label, |text, (ix, arg)| {
+                            append_string_expr(append_string_expr(text, delimiter(ix)), arg)
+                        })
+                };
+
+                Ok(TypedExpr::Trace {
+                    location,
+                    tipo,
+                    then: Box::new(then),
+                    text: Box::new(text),
+                })
+            }
         }
     }
 

--- a/crates/aiken-lang/src/tipo/expr.rs
+++ b/crates/aiken-lang/src/tipo/expr.rs
@@ -513,12 +513,14 @@ impl<'a, 'b> ExprTyper<'a, 'b> {
                 self.infer_assignment(pattern, *value, kind, &annotation, location)
             }
 
+            // TODO: Trace.arguments
             UntypedExpr::Trace {
                 location,
                 then,
-                text,
+                label,
                 kind,
-            } => self.infer_trace(kind, *then, location, *text),
+                ..
+            } => self.infer_trace(kind, *then, location, *label),
 
             UntypedExpr::When {
                 location,

--- a/crates/aiken-lang/src/tipo/expr.rs
+++ b/crates/aiken-lang/src/tipo/expr.rs
@@ -20,7 +20,7 @@ use crate::{
     },
     builtins::{
         bool, byte_array, data, from_default_function, function, g1_element, g2_element, int, list,
-        pair, string, tuple, void, BUILTIN, PRELUDE,
+        pair, string, tuple, void, BUILTIN,
     },
     expr::{FnStyle, TypedExpr, UntypedExpr},
     format,
@@ -2827,7 +2827,7 @@ fn diagnose_expr(expr: TypedExpr) -> TypedExpr {
         from_default_function(DefaultFunction::DecodeUtf8, &IdGenerator::new());
 
     let decode_utf8 = TypedExpr::ModuleSelect {
-        location: Span::empty(),
+        location: expr.location(),
         tipo: decode_utf8_constructor.tipo.clone(),
         label: DefaultFunction::DecodeUtf8.aiken_name(),
         module_name: BUILTIN.to_string(),
@@ -2839,29 +2839,21 @@ fn diagnose_expr(expr: TypedExpr) -> TypedExpr {
         ),
     };
 
-    let diagnostic_constructor = ValueConstructor::public(
-        function(vec![data(), byte_array()], byte_array()),
-        ValueConstructorVariant::ModuleFn {
-            name: "diagnostic".to_string(),
-            field_map: None,
-            module: PRELUDE.to_string(),
-            arity: 2,
-            location: Span::empty(),
-            builtin: None,
+    let diagnostic = TypedExpr::Var {
+        location: expr.location(),
+        name: "diagnostic".to_string(),
+        constructor: ValueConstructor {
+            public: true,
+            tipo: function(vec![data(), byte_array()], byte_array()),
+            variant: ValueConstructorVariant::ModuleFn {
+                name: "diagnostic".to_string(),
+                field_map: None,
+                module: "".to_string(),
+                arity: 2,
+                location: Span::empty(),
+                builtin: None,
+            },
         },
-    );
-
-    let diagnostic = TypedExpr::ModuleSelect {
-        location: Span::empty(),
-        tipo: diagnostic_constructor.tipo.clone(),
-        label: "diagnostic".to_string(),
-        module_name: PRELUDE.to_string(),
-        module_alias: "".to_string(),
-        constructor: diagnostic_constructor.variant.to_module_value_constructor(
-            diagnostic_constructor.tipo,
-            "",
-            "diagnostic",
-        ),
     };
 
     let location = expr.location();
@@ -2873,7 +2865,7 @@ fn diagnose_expr(expr: TypedExpr) -> TypedExpr {
             label: None,
             location: expr.location(),
             value: TypedExpr::Call {
-                tipo: string(),
+                tipo: byte_array(),
                 fun: Box::new(diagnostic.clone()),
                 args: vec![
                     CallArg {

--- a/crates/aiken-project/src/blueprint/snapshots/aiken_project__blueprint__validator__tests__free_vars.snap
+++ b/crates/aiken-project/src/blueprint/snapshots/aiken_project__blueprint__validator__tests__free_vars.snap
@@ -9,7 +9,7 @@ Schema {
             Var {
                 tipo: RefCell {
                     value: Generic {
-                        id: 35,
+                        id: 64,
                     },
                 },
                 alias: None,

--- a/crates/aiken-project/src/error.rs
+++ b/crates/aiken-project/src/error.rs
@@ -324,7 +324,7 @@ impl Diagnostic for Error {
                 "Try moving the shared code to a separate module that the others can depend on\n- {}",
                 modules.join("\n- ")
             ))),
-            Error::Parse { error, .. } => error.kind.help(),
+            Error::Parse { error, .. } => error.help(),
             Error::Type { error, .. } => error.help(),
             Error::StandardIo(_) => None,
             Error::MissingManifest { .. } => Some(Box::new(

--- a/crates/aiken-project/src/lib.rs
+++ b/crates/aiken-project/src/lib.rs
@@ -130,7 +130,7 @@ where
         module_types.insert("aiken".to_string(), builtins::prelude(&id_gen));
         module_types.insert("aiken/builtin".to_string(), builtins::plutus(&id_gen));
 
-        let functions = builtins::prelude_functions(&id_gen);
+        let functions = builtins::prelude_functions(&id_gen, &module_types);
 
         let data_types = builtins::prelude_data_types(&id_gen);
 

--- a/crates/aiken-project/src/snapshots/aiken_project__export__tests__cannot_export_generics.snap
+++ b/crates/aiken-project/src/snapshots/aiken_project__export__tests__cannot_export_generics.snap
@@ -9,7 +9,7 @@ Schema {
             Var {
                 tipo: RefCell {
                     value: Generic {
-                        id: 35,
+                        id: 64,
                     },
                 },
                 alias: None,

--- a/crates/aiken-project/src/test_framework.rs
+++ b/crates/aiken-project/src/test_framework.rs
@@ -1328,7 +1328,7 @@ mod test {
                 .last()
                 .expect("No test found in declared src?");
 
-            let mut functions = builtins::prelude_functions(&id_gen);
+            let mut functions = builtins::prelude_functions(&id_gen, &module_types);
             let mut data_types = builtins::prelude_data_types(&id_gen);
             ast.register_definitions(&mut functions, &mut data_types);
 

--- a/crates/aiken-project/src/tests/gen_uplc.rs
+++ b/crates/aiken-project/src/tests/gen_uplc.rs
@@ -7003,3 +7003,25 @@ fn bls12_381_elements_from_data_conversion() {
         false,
     )
 }
+
+#[test]
+fn qualified_prelude_functions() {
+    let src = r#"
+        use aiken
+
+        test foo() {
+            aiken.identity(True) && identity(True)
+        }
+    "#;
+
+    let constant_true = Term::Constant(Constant::Bool(true).into());
+    let constant_false = Term::Constant(Constant::Bool(false).into());
+
+    assert_uplc(
+        src,
+        constant_true
+            .clone()
+            .delayed_if_then_else(constant_true, constant_false),
+        false,
+    )
+}

--- a/crates/aiken-project/src/tests/mod.rs
+++ b/crates/aiken-project/src/tests/mod.rs
@@ -46,7 +46,7 @@ impl TestProject {
         module_types.insert("aiken".to_string(), builtins::prelude(&id_gen));
         module_types.insert("aiken/builtin".to_string(), builtins::plutus(&id_gen));
 
-        let functions = builtins::prelude_functions(&id_gen);
+        let functions = builtins::prelude_functions(&id_gen, &module_types);
         let data_types = builtins::prelude_data_types(&id_gen);
 
         TestProject {


### PR DESCRIPTION
## Preview

### Default options

| code | result | 
| --- | --- |
| `trace @"my_label"` |  <img width="350" alt="image" src="https://github.com/user-attachments/assets/a1f537b1-6d54-40c4-b066-4ca5ffe64bc1"> |
| `trace @"my_label": @"foo", @"bar"` |  <img width="350" alt="image" src="https://github.com/user-attachments/assets/b0a554ac-1d80-49d5-9554-c56b7071a354"> |
| `trace @"my_label": [1, 2, 3], Some(#"00ff")` |  <img width="350" alt="image" src="https://github.com/user-attachments/assets/d41bfe8b-75d0-4d81-acc3-5cabab939acf"> | 
| `trace (14, 42)` | <img width="350" alt="image" src="https://github.com/user-attachments/assets/d87a1d80-a35d-401b-9c6e-75bab07e6e2c"> |
| `trace fn(x) { x + 1 }` | <img width="350" alt="image" src="https://github.com/user-attachments/assets/7da31eae-4ae7-4862-bd6c-b3d198fbf47c"> |
| `trace @"my_label", @"foo", @"bar"` | <img width="350" alt="image" src="https://github.com/user-attachments/assets/0882e4c4-1b40-47a5-a10e-7370be3061a4"> |

### `--trace-level compact`

| code | result | 
| --- | --- |
| `trace @"my_label"` | <img width="350" alt="image" src="https://github.com/user-attachments/assets/a1f537b1-6d54-40c4-b066-4ca5ffe64bc1">  |
| `trace @"my_label": @"foo", @"bar"` | <img width="350" alt="image" src="https://github.com/user-attachments/assets/a1f537b1-6d54-40c4-b066-4ca5ffe64bc1"> |
| `trace @"my_label": [1, 2, 3], Some(#"00ff")` | <img width="350" alt="image" src="https://github.com/user-attachments/assets/a1f537b1-6d54-40c4-b066-4ca5ffe64bc1">  | 
| `trace (14, 42)` | <img width="350" alt="image" src="https://github.com/user-attachments/assets/23ed786d-72e6-4f71-a853-3816793cef1e"> |
| `trace fn(x) { x + 1 }` | <img width="350" alt="image" src="https://github.com/user-attachments/assets/d606682d-4d35-4632-a889-6acd59241463"> |
| `trace @"my_label", @"foo", @"bar"` | <img width="350" alt="image" src="https://github.com/user-attachments/assets/0882e4c4-1b40-47a5-a10e-7370be3061a4"> |

## Changes

- :round_pushpin: **Allow variadic arguments in trace**
    Although, doesn't do anything with them yet. The idea is to simplify
  the use of trace to make it a lot more useful than it currently is.

- :round_pushpin: **Type-check variadic traces & desugarize them.**
  
- :round_pushpin: **Add 'diagnostic' to the prelude, as well as companion functions.**
    This is not fully satisfactory as it pollutes a bit the prelude. Ideally, those functions should only be visible
  and usable by the underlying trace code. But for now, we'll just go with it.

- :round_pushpin: **Allow serialisable (Data-able) arguments to trace**
    Somehow, we have to patch some function in gen_uplc because of the
  module name. I have to look further into this because it isn't normal.

- :round_pushpin: **Remove unnecessary code_gen patch.**
    This is a little weird but, prelude functions are handled slightly
  differently.

- :round_pushpin: **re-introduce code-gen patch, but with a test.**
    Actually, this has been a bug for a long time it seems. Calling any
  prelude functions using a qualified import would result in a codegen
  crash. Whoopsie.

  This is now fixed as shown by the regression test.

- :round_pushpin: **Rework 'compact' mode for traces**
    - Trace-if-false are now completely discarded in compact mode.

  - Only the label (i.e. first trace argument) is preserved.

  - When compiling with tracing _compact_, the first label MUST unify to
    a string. This shouldn't be an issue generally speaking and would
    enforce that traces follow the pattern

    ```
    label: arg_0[, arg_1, ..., arg_n]
    ```

  Note that what isn't obvious with these changes is that we now support
  what the "emit" keyword was trying to achieve; as we compile now with
  user-defined traces only, and in compact mode to only keep event
  labels in the final contract; while allowing larger payloads with
  verbose tracing.

- :round_pushpin: **Display expected patterns/tokens in parse error when applicable.**
    We've never been using those 'expected' tokens captured during
  parsing, which is lame because they contain useful information!

  This is much better than merely showing our infamous

    "Try removing it!"

- :round_pushpin: **Provide better parse errors in trace when using comma instead of colon.**
  
- :round_pushpin: **Fill-in CHANGELOG**