### PR TITLE
Fix pattern inference and annotation requirements.

### DIFF
--- a/crates/aiken-lang/src/gen_uplc.rs
+++ b/crates/aiken-lang/src/gen_uplc.rs
@@ -1404,7 +1404,10 @@ impl<'a> CodeGenerator<'a> {
                         ),
                     )
                 } else {
-                    assert!(data_type.constructors.len() == 1);
+                    assert!(
+                        data_type.constructors.len() == 1,
+                        "data_type={data_type:#?}"
+                    );
                     then
                 };
 

--- a/crates/aiken-lang/src/tipo/pattern.rs
+++ b/crates/aiken-lang/src/tipo/pattern.rs
@@ -141,11 +141,11 @@ impl<'a, 'b> PatternTyper<'a, 'b> {
         pattern: UntypedPattern,
         tipo: Rc<Type>,
         ann_type: Option<Rc<Type>>,
-        is_let: bool,
+        warn_on_discard: bool,
     ) -> Result<TypedPattern, Error> {
         match pattern {
             Pattern::Discard { name, location } => {
-                if is_let {
+                if warn_on_discard {
                     // Register declaration for the unused variable detection
                     self.environment
                         .warnings


### PR DESCRIPTION
## Preview

> [!NOTE]
>
> See also the added test scenarios.

| code | before | after | 
| --- | --- | --- | 
| <img width="200" alt="image" src="https://github.com/user-attachments/assets/1b0635c4-a04e-478f-b0ba-73ed22474410"> | <img width="400" alt="image" src="https://github.com/user-attachments/assets/197dd697-4bea-4b03-93a9-6937351fa25b"> | <img width="400" alt="image" src="https://github.com/user-attachments/assets/af13023f-f562-47f4-999f-92dc8fd93776"> |
| <img width="200" alt="image" src="https://github.com/user-attachments/assets/0c671ccd-a2fb-4a86-8969-93815df41c4e">| <img width="400" alt="image" src="https://github.com/user-attachments/assets/93d6a4d9-19f3-40de-9b69-0d3a12243232"> | <img width="400" alt="image" src="https://github.com/user-attachments/assets/7b222c89-efaf-429c-a60b-3e2486ab7cd3"> |
|  <img width="233" alt="image" src="https://github.com/user-attachments/assets/2d57ac61-cab1-4392-84a6-111b4de3975f"> | <img width="400" alt="image" src="https://github.com/user-attachments/assets/9c0e1705-6586-4aef-96cb-b2131f8497c7"> | <img width="200" alt="image" src="https://github.com/user-attachments/assets/d38a2616-237d-4ab0-985b-ad6665ce2d89"> |
| <img width="200" alt="image" src="https://github.com/user-attachments/assets/ab086d86-0a62-4bd3-b7a5-487acab30635"> | <img width="707" alt="image" src="https://github.com/user-attachments/assets/7810d6ec-89d4-4c3a-ad5f-bdf565e5f82b"> | <img width="200" alt="image" src="https://github.com/user-attachments/assets/d38a2616-237d-4ab0-985b-ad6665ce2d89"> |

## Changlog

- :round_pushpin: **Fix casting inferrence on patterns**
    The original goal for this commit was to allow casting from Data on
  patterns without annotation. For example, given some custom type
  'OrderDatum':

  ```
  expect OrderDatum { requested_handle, destination, .. }: OrderDatum = datum
  ```

  would work fine, but:

  ```
  expect OrderDatum { requested_handle, destination, .. } = datum
  ```

  Yet, the annotation feels unnecessary at this point because type can
  be inferred from the pattern itself. So this commit allows, whenever
  possible (ie when the pattern is neither a discard nor a var), to
  infer the type from a pattern.

  Along the way, I also found a couple of weird behaviours surrounding
  this kind of assignments, in particular in combination with let. I'll
  highlight those in the next PR (#979).
