### PR TITLE
Gen uplc builtin fixes

### DIFF
--- a/crates/aiken-lang/src/gen_uplc.rs
+++ b/crates/aiken-lang/src/gen_uplc.rs
@@ -4089,10 +4089,16 @@ impl<'a> CodeGenerator<'a> {
                     builtin,
                     ..
                 } => {
-                    assert!(
-                        builtin.is_none(),
-                        "found remaining builtin function {func_name:?} ({builtin:?} declared as a module function in {module:?}"
-                    );
+                    if let Some(func) = builtin {
+                        return self.gen_uplc(
+                            Air::Builtin {
+                                count: 0,
+                                func: *func,
+                                tipo: constructor.tipo,
+                            },
+                            arg_stack,
+                        );
+                    }
 
                     if let Some((names, index, cyclic_name)) = self.cyclic_functions.get(&(
                         FunctionAccessKey {
@@ -4513,8 +4519,12 @@ impl<'a> CodeGenerator<'a> {
 
                         term = builder::apply_builtin_forces(term, func.force_count());
 
-                        for arg in arg_vec {
-                            term = term.apply(arg.clone());
+                        if func.arg_is_unit() {
+                            term = term.apply(Term::unit())
+                        } else {
+                            for arg in arg_vec {
+                                term = term.apply(arg.clone());
+                            }
                         }
 
                         term

--- a/crates/aiken-lang/src/gen_uplc.rs
+++ b/crates/aiken-lang/src/gen_uplc.rs
@@ -4509,11 +4509,6 @@ impl<'a> CodeGenerator<'a> {
                     DefaultFunction::HeadList if !tipo.is_pair() => {
                         builder::undata_builtin(&func, count, ret_tipo, arg_vec)
                     }
-                    DefaultFunction::MkPairData => {
-                        unimplemented!(
-                            "MkPairData should be handled by an anon function ( a, b, .., z).\n"
-                        )
-                    }
                     _ => {
                         let mut term: Term<Name> = func.into();
 

--- a/crates/aiken-lang/src/gen_uplc/builder.rs
+++ b/crates/aiken-lang/src/gen_uplc/builder.rs
@@ -1642,6 +1642,7 @@ pub fn to_data_builtin(
 
 pub fn special_case_builtin(
     func: &DefaultFunction,
+    tipo: Rc<Type>,
     count: usize,
     mut args: Vec<Term<Name>>,
 ) -> Term<Name> {
@@ -1652,6 +1653,26 @@ pub fn special_case_builtin(
 
             term.lambda("_").apply(unit)
         }
+
+        DefaultFunction::MkCons => {
+            let arg_type = tipo
+                .arg_types()
+                .and_then(|generics| generics.first().cloned())
+                .expect("mk_cons should have (exactly) one type parameter");
+
+            if let [head, tail] = &args[..] {
+                Term::mk_cons()
+                    .apply(if arg_type.is_pair() {
+                        head.clone()
+                    } else {
+                        convert_type_to_data(head.clone(), &arg_type)
+                    })
+                    .apply(tail.clone())
+            } else {
+                unreachable!("mk_cons has two arguments.");
+            }
+        }
+
         DefaultFunction::ChooseUnit
         | DefaultFunction::IfThenElse
         | DefaultFunction::ChooseList

--- a/crates/aiken-project/src/tests/gen_uplc.rs
+++ b/crates/aiken-project/src/tests/gen_uplc.rs
@@ -7154,3 +7154,34 @@ fn mk_nil_list_data() {
         false,
     )
 }
+
+#[test]
+fn mk_pair_data() {
+    let src = r#"
+        use aiken/builtin.{i_data}
+
+        test nil_equals() {
+            builtin.mk_pair_data(i_data(1), i_data(2)).1st == i_data(1)
+        }
+    "#;
+
+    assert_uplc(
+        src,
+        Term::equals_data()
+            .apply(
+                Term::fst_pair().apply(
+                    Term::mk_pair_data()
+                        .apply(Term::Constant(
+                            Constant::Data(Data::integer(1.into())).into(),
+                        ))
+                        .apply(Term::Constant(
+                            Constant::Data(Data::integer(2.into())).into(),
+                        )),
+                ),
+            )
+            .apply(Term::Constant(
+                Constant::Data(Data::integer(1.into())).into(),
+            )),
+        false,
+    )
+}

--- a/crates/aiken-project/src/tests/gen_uplc.rs
+++ b/crates/aiken-project/src/tests/gen_uplc.rs
@@ -7025,3 +7025,94 @@ fn qualified_prelude_functions() {
         false,
     )
 }
+
+#[test]
+fn mk_cons_direct_invoke_1() {
+    let src = r#"
+        use aiken/builtin
+
+        test mk_cons_1() {
+            builtin.cons_list(1, []) == [1]
+        }
+    "#;
+
+    assert_uplc(
+        src,
+        Term::equals_data()
+            .apply(
+                Term::list_data().apply(
+                    Term::mk_cons()
+                        .apply(Term::data(Data::integer(1.into())))
+                        .apply(Term::empty_list()),
+                ),
+            )
+            .apply(Term::data(Data::list(vec![Data::integer(1.into())]))),
+        false,
+    )
+}
+
+#[test]
+fn mk_cons_direct_invoke_2() {
+    let src = r#"
+        use aiken/builtin.{cons_list}
+
+        test mk_cons_2() {
+            cons_list(Some(42), [None]) == [Some(42), None]
+        }
+    "#;
+
+    let none = Data::constr(1, Vec::new());
+    let some = Data::constr(0, vec![Data::integer(42.into())]);
+
+    assert_uplc(
+        src,
+        Term::equals_data()
+            .apply(
+                Term::list_data().apply(Term::mk_cons().apply(Term::data(some.clone())).apply(
+                    Term::Constant(
+                        Constant::ProtoList(Type::Data, vec![Constant::Data(none.clone())]).into(),
+                    ),
+                )),
+            )
+            .apply(Term::data(Data::list(vec![some, none]))),
+        false,
+    )
+}
+
+#[test]
+fn mk_cons_direct_invoke_3() {
+    let src = r#"
+        use aiken/builtin.{cons_list, i_data, mk_nil_pair_data}
+
+        test mk_cons_3() {
+          cons_list(Pair(i_data(1), i_data(1)), mk_nil_pair_data()) == [
+            Pair(i_data(1), i_data(1)),
+          ]
+        }
+    "#;
+
+    assert_uplc(
+        src,
+        Term::equals_data()
+            .apply(
+                Term::map_data().apply(
+                    Term::mk_cons()
+                        .apply(Term::Constant(
+                            Constant::ProtoPair(
+                                Type::Data,
+                                Type::Data,
+                                Constant::Data(Data::integer(1.into())).into(),
+                                Constant::Data(Data::integer(1.into())).into(),
+                            )
+                            .into(),
+                        ))
+                        .apply(Term::mk_nil_pair_data().apply(Term::unit())),
+                ),
+            )
+            .apply(Term::data(Data::map(vec![(
+                Data::integer(1.into()),
+                Data::integer(1.into()),
+            )]))),
+        false,
+    )
+}

--- a/crates/aiken-project/src/tests/gen_uplc.rs
+++ b/crates/aiken-project/src/tests/gen_uplc.rs
@@ -7116,3 +7116,41 @@ fn mk_cons_direct_invoke_3() {
         false,
     )
 }
+
+#[test]
+fn mk_nil_pair_data() {
+    let src = r#"
+        use aiken/builtin.{mk_nil_pair_data}
+
+        test nil_equals() {
+            mk_nil_pair_data() == mk_nil_pair_data()
+        }
+    "#;
+
+    assert_uplc(
+        src,
+        Term::equals_data()
+            .apply(Term::map_data().apply(Term::mk_nil_pair_data().apply(Term::unit())))
+            .apply(Term::map_data().apply(Term::mk_nil_pair_data().apply(Term::unit()))),
+        false,
+    )
+}
+
+#[test]
+fn mk_nil_list_data() {
+    let src = r#"
+        use aiken/builtin.{mk_nil_data}
+
+        test nil_equals() {
+            mk_nil_data() == mk_nil_data()
+        }
+    "#;
+
+    assert_uplc(
+        src,
+        Term::equals_data()
+            .apply(Term::list_data().apply(Term::mk_nil_data().apply(Term::unit())))
+            .apply(Term::list_data().apply(Term::mk_nil_data().apply(Term::unit()))),
+        false,
+    )
+}

--- a/crates/uplc/src/machine/runtime.rs
+++ b/crates/uplc/src/machine/runtime.rs
@@ -1,23 +1,20 @@
-use std::{mem::size_of, ops::Deref, rc::Rc};
-
-use num_bigint::BigInt;
-use num_integer::Integer;
-use num_traits::{Signed, Zero};
-use once_cell::sync::Lazy;
-use pallas_primitives::conway::{Language, PlutusData};
-
+use super::{
+    cost_model::{BuiltinCosts, ExBudget},
+    value::{from_pallas_bigint, to_pallas_bigint},
+    Error, Value,
+};
 use crate::{
     ast::{Constant, Data, Type},
     builtins::DefaultFunction,
     machine::value::integer_log2,
     plutus_data_to_bytes,
 };
-
-use super::{
-    cost_model::{BuiltinCosts, ExBudget},
-    value::{from_pallas_bigint, to_pallas_bigint},
-    Error, Value,
-};
+use num_bigint::BigInt;
+use num_integer::Integer;
+use num_traits::{Signed, Zero};
+use once_cell::sync::Lazy;
+use pallas_primitives::conway::{Language, PlutusData};
+use std::{mem::size_of, ops::Deref, rc::Rc};
 
 static SCALAR_PERIOD: Lazy<BigInt> = Lazy::new(|| {
     BigInt::from_bytes_be(
@@ -111,6 +108,85 @@ impl From<DefaultFunction> for BuiltinRuntime {
 }
 
 impl DefaultFunction {
+    pub fn arg_is_unit(&self) -> bool {
+        match self {
+            DefaultFunction::MkNilData | DefaultFunction::MkNilPairData => true,
+            DefaultFunction::AddInteger
+            | DefaultFunction::SubtractInteger
+            | DefaultFunction::MultiplyInteger
+            | DefaultFunction::DivideInteger
+            | DefaultFunction::QuotientInteger
+            | DefaultFunction::RemainderInteger
+            | DefaultFunction::ModInteger
+            | DefaultFunction::EqualsInteger
+            | DefaultFunction::LessThanInteger
+            | DefaultFunction::LessThanEqualsInteger
+            | DefaultFunction::AppendByteString
+            | DefaultFunction::ConsByteString
+            | DefaultFunction::SliceByteString
+            | DefaultFunction::LengthOfByteString
+            | DefaultFunction::IndexByteString
+            | DefaultFunction::EqualsByteString
+            | DefaultFunction::LessThanByteString
+            | DefaultFunction::LessThanEqualsByteString
+            | DefaultFunction::Sha2_256
+            | DefaultFunction::Sha3_256
+            | DefaultFunction::Blake2b_224
+            | DefaultFunction::Blake2b_256
+            | DefaultFunction::Keccak_256
+            | DefaultFunction::VerifyEd25519Signature
+            | DefaultFunction::VerifyEcdsaSecp256k1Signature
+            | DefaultFunction::VerifySchnorrSecp256k1Signature
+            | DefaultFunction::AppendString
+            | DefaultFunction::EqualsString
+            | DefaultFunction::EncodeUtf8
+            | DefaultFunction::DecodeUtf8
+            | DefaultFunction::IfThenElse
+            | DefaultFunction::ChooseUnit
+            | DefaultFunction::Trace
+            | DefaultFunction::FstPair
+            | DefaultFunction::SndPair
+            | DefaultFunction::ChooseList
+            | DefaultFunction::MkCons
+            | DefaultFunction::HeadList
+            | DefaultFunction::TailList
+            | DefaultFunction::NullList
+            | DefaultFunction::ChooseData
+            | DefaultFunction::ConstrData
+            | DefaultFunction::MapData
+            | DefaultFunction::ListData
+            | DefaultFunction::IData
+            | DefaultFunction::BData
+            | DefaultFunction::UnConstrData
+            | DefaultFunction::UnMapData
+            | DefaultFunction::UnListData
+            | DefaultFunction::UnIData
+            | DefaultFunction::UnBData
+            | DefaultFunction::EqualsData
+            | DefaultFunction::SerialiseData
+            | DefaultFunction::MkPairData
+            | DefaultFunction::Bls12_381_G1_Add
+            | DefaultFunction::Bls12_381_G1_Neg
+            | DefaultFunction::Bls12_381_G1_ScalarMul
+            | DefaultFunction::Bls12_381_G1_Equal
+            | DefaultFunction::Bls12_381_G1_Compress
+            | DefaultFunction::Bls12_381_G1_Uncompress
+            | DefaultFunction::Bls12_381_G1_HashToGroup
+            | DefaultFunction::Bls12_381_G2_Add
+            | DefaultFunction::Bls12_381_G2_Neg
+            | DefaultFunction::Bls12_381_G2_ScalarMul
+            | DefaultFunction::Bls12_381_G2_Equal
+            | DefaultFunction::Bls12_381_G2_Compress
+            | DefaultFunction::Bls12_381_G2_Uncompress
+            | DefaultFunction::Bls12_381_G2_HashToGroup
+            | DefaultFunction::Bls12_381_MillerLoop
+            | DefaultFunction::Bls12_381_MulMlResult
+            | DefaultFunction::Bls12_381_FinalVerify
+            | DefaultFunction::IntegerToByteString
+            | DefaultFunction::ByteStringToInteger => false,
+        }
+    }
+
     pub fn arity(&self) -> usize {
         match self {
             DefaultFunction::AddInteger => 2,


### PR DESCRIPTION
- :round_pushpin: **Support mk_cons builtin**
    While this builtin is readily available through the Aiken syntax
  `[head, ..tail]`, there's no reason to not support its builtin form
  even though we may not encourage its usage. For completeness and to
  avoid bad surprises, it is now supported.

  Fixes #964.

- :round_pushpin: **Fix zero-arg builtins invokations.**
    There are currently two zero-arg builtins:

  - mkNilData
  - mkNilPairData

  And while they have strictly speaking no arguments, the VM still
  requires that they are called with an extra unit argument applied.
