### PR TITLE
Conditional configuration & environment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - **aiken-lang**: add support for `mk_cons` and `mk_pair_data` builtins. See [#964](https://github.com/aiken-lang/aiken/issues/964). @KtorZ
 - **aiken-lang**: pattern-matching on bytearrays is now available. See [#989](https://github.com/aiken-lang/aiken/issues/989). @KtorZ
+- **aiken-project**: conditional configuration and environment. See [#937](https://github.com/aiken-lang/aiken/issues/937). @KtorZ
 
 ### Changed
 

--- a/crates/aiken-lang/src/ast.rs
+++ b/crates/aiken-lang/src/ast.rs
@@ -69,16 +69,18 @@ impl<Info, Definitions> Module<Info, Definitions> {
 }
 
 impl UntypedModule {
-    pub fn dependencies(&self) -> Vec<(String, Span)> {
+    pub fn dependencies(&self, env_modules: &[String]) -> Vec<String> {
         self.definitions()
             .flat_map(|def| {
-                if let Definition::Use(Use {
-                    location, module, ..
-                }) = def
-                {
-                    Some((module.join("/"), *location))
+                if let Definition::Use(Use { module, .. }) = def {
+                    let name = module.join("/");
+                    if name == ENV_MODULE {
+                        env_modules.to_vec()
+                    } else {
+                        vec![name]
+                    }
                 } else {
-                    None
+                    Vec::new()
                 }
             })
             .collect()

--- a/crates/aiken-lang/src/ast.rs
+++ b/crates/aiken-lang/src/ast.rs
@@ -21,6 +21,9 @@ pub const BACKPASS_VARIABLE: &str = "_backpass";
 pub const CAPTURE_VARIABLE: &str = "_capture";
 pub const PIPE_VARIABLE: &str = "_pipe";
 
+pub const ENV_MODULE: &str = "env";
+pub const DEFAULT_ENV_MODULE: &str = "default";
+
 pub type TypedModule = Module<TypeInfo, TypedDefinition>;
 pub type UntypedModule = Module<(), UntypedDefinition>;
 

--- a/crates/aiken-lang/src/ast.rs
+++ b/crates/aiken-lang/src/ast.rs
@@ -22,6 +22,7 @@ pub const CAPTURE_VARIABLE: &str = "_capture";
 pub const PIPE_VARIABLE: &str = "_pipe";
 
 pub const ENV_MODULE: &str = "env";
+pub const CONFIG_MODULE: &str = "config";
 pub const DEFAULT_ENV_MODULE: &str = "default";
 
 pub type TypedModule = Module<TypeInfo, TypedDefinition>;
@@ -32,6 +33,7 @@ pub enum ModuleKind {
     Lib,
     Validator,
     Env,
+    Config,
 }
 
 impl ModuleKind {
@@ -45,6 +47,10 @@ impl ModuleKind {
 
     pub fn is_env(&self) -> bool {
         matches!(self, ModuleKind::Env)
+    }
+
+    pub fn is_config(&self) -> bool {
+        matches!(self, ModuleKind::Config)
     }
 }
 
@@ -1073,6 +1079,15 @@ impl Annotation {
     pub fn int(location: Span) -> Self {
         Annotation::Constructor {
             name: "Int".to_string(),
+            module: None,
+            arguments: vec![],
+            location,
+        }
+    }
+
+    pub fn bytearray(location: Span) -> Self {
+        Annotation::Constructor {
+            name: "ByteArray".to_string(),
             module: None,
             arguments: vec![],
             location,

--- a/crates/aiken-lang/src/ast.rs
+++ b/crates/aiken-lang/src/ast.rs
@@ -28,6 +28,7 @@ pub type UntypedModule = Module<(), UntypedDefinition>;
 pub enum ModuleKind {
     Lib,
     Validator,
+    Env,
 }
 
 impl ModuleKind {
@@ -37,6 +38,10 @@ impl ModuleKind {
 
     pub fn is_lib(&self) -> bool {
         matches!(self, ModuleKind::Lib)
+    }
+
+    pub fn is_env(&self) -> bool {
+        matches!(self, ModuleKind::Env)
     }
 }
 

--- a/crates/aiken-lang/src/format.rs
+++ b/crates/aiken-lang/src/format.rs
@@ -25,8 +25,8 @@ use ordinal::Ordinal;
 use std::rc::Rc;
 use vec1::Vec1;
 
-const INDENT: isize = 2;
-const DOCS_MAX_COLUMNS: isize = 80;
+pub const INDENT: isize = 2;
+pub const DOCS_MAX_COLUMNS: isize = 80;
 
 pub fn pretty(writer: &mut String, module: UntypedModule, extra: ModuleExtra, src: &str) {
     let intermediate = Intermediate {
@@ -130,7 +130,7 @@ impl<'comments> Formatter<'comments> {
         end != 0
     }
 
-    fn definitions<'a>(&mut self, definitions: &'a [UntypedDefinition]) -> Document<'a> {
+    pub fn definitions<'a>(&mut self, definitions: &'a [UntypedDefinition]) -> Document<'a> {
         let mut has_imports = false;
         let mut has_declarations = false;
         let mut imports = Vec::new();

--- a/crates/aiken-lang/src/lib.rs
+++ b/crates/aiken-lang/src/lib.rs
@@ -49,6 +49,7 @@ macro_rules! aiken_fn {
                 $module_types,
                 $crate::ast::Tracing::silent(),
                 &mut warnings,
+                None,
             )
             .unwrap();
 

--- a/crates/aiken-lang/src/tests/check.rs
+++ b/crates/aiken-lang/src/tests/check.rs
@@ -38,6 +38,7 @@ fn check_module(
                 &module_types,
                 Tracing::All(TraceLevel::Verbose),
                 &mut warnings,
+                None,
             )
             .expect("extra dependency did not compile");
         module_types.insert(package.clone(), typed_module.type_info.clone());
@@ -50,6 +51,7 @@ fn check_module(
         &module_types,
         tracing,
         &mut warnings,
+        None,
     );
 
     result

--- a/crates/aiken-lang/src/tipo/environment.rs
+++ b/crates/aiken-lang/src/tipo/environment.rs
@@ -109,7 +109,7 @@ impl<'a> Environment<'a> {
                         .values()
                         .filter_map(|m| match m.kind {
                             ModuleKind::Env => Some(m.name.clone()),
-                            ModuleKind::Lib | ModuleKind::Validator => None,
+                            ModuleKind::Lib | ModuleKind::Validator | ModuleKind::Config => None,
                         })
                         .collect(),
                 }

--- a/crates/aiken-lang/src/tipo/environment.rs
+++ b/crates/aiken-lang/src/tipo/environment.rs
@@ -7,7 +7,7 @@ use super::{
 };
 use crate::{
     ast::{
-        Annotation, CallArg, DataType, Definition, Function, ModuleConstant, ModuleKind,
+        self, Annotation, CallArg, DataType, Definition, Function, ModuleConstant, ModuleKind,
         RecordConstructor, RecordConstructorArg, Span, TypeAlias, TypedDefinition, TypedFunction,
         TypedPattern, UnqualifiedImport, UntypedArg, UntypedDefinition, UntypedFunction, Use,
         Validator, PIPE_VARIABLE,
@@ -80,11 +80,33 @@ pub struct Environment<'a> {
     /// A mapping from known annotations to their resolved type.
     pub annotations: HashMap<Annotation, Rc<Type>>,
 
+    /// The user-defined target environment referred to as the module 'env'.
+    pub target_env: Option<&'a str>,
+
     /// Warnings
     pub warnings: &'a mut Vec<Warning>,
 }
 
 impl<'a> Environment<'a> {
+    pub fn find_module(&self, fragments: &[String], location: Span) -> Result<&'a TypeInfo, Error> {
+        let mut name = fragments.join("/");
+
+        if name == ast::ENV_MODULE {
+            name = self
+                .target_env
+                .unwrap_or(ast::DEFAULT_ENV_MODULE)
+                .to_string()
+        }
+
+        self.importable_modules
+            .get(&name)
+            .ok_or_else(|| Error::UnknownModule {
+                location,
+                name,
+                imported_modules: self.imported_modules.keys().cloned().collect(),
+            })
+    }
+
     pub fn close_scope(&mut self, data: ScopeResetData) {
         let unused = self
             .entity_usages
@@ -705,6 +727,7 @@ impl<'a> Environment<'a> {
         current_kind: &'a ModuleKind,
         importable_modules: &'a HashMap<String, TypeInfo>,
         warnings: &'a mut Vec<Warning>,
+        target_env: Option<&'a str>,
     ) -> Self {
         let prelude = importable_modules
             .get("aiken")
@@ -731,6 +754,7 @@ impl<'a> Environment<'a> {
             annotations: HashMap::new(),
             warnings,
             entity_usages: vec![HashMap::new()],
+            target_env,
         }
     }
 
@@ -772,17 +796,7 @@ impl<'a> Environment<'a> {
                 location,
                 package: _,
             }) => {
-                let name = module.join("/");
-
-                // Find imported module
-                let module_info =
-                    self.importable_modules
-                        .get(&name)
-                        .ok_or_else(|| Error::UnknownModule {
-                            location: *location,
-                            name: name.clone(),
-                            imported_modules: self.imported_modules.keys().cloned().collect(),
-                        })?;
+                let module_info = self.find_module(module, *location)?;
 
                 if module_info.kind.is_validator()
                     && (self.current_kind.is_lib()
@@ -791,7 +805,7 @@ impl<'a> Environment<'a> {
                 {
                     return Err(Error::ValidatorImported {
                         location: *location,
-                        name,
+                        name: module.join("/"),
                     });
                 }
 

--- a/crates/aiken-lang/src/tipo/environment.rs
+++ b/crates/aiken-lang/src/tipo/environment.rs
@@ -785,7 +785,9 @@ impl<'a> Environment<'a> {
                         })?;
 
                 if module_info.kind.is_validator()
-                    && (self.current_kind.is_lib() || !self.current_module.starts_with("tests"))
+                    && (self.current_kind.is_lib()
+                        || self.current_kind.is_env()
+                        || !self.current_module.starts_with("tests"))
                 {
                     return Err(Error::ValidatorImported {
                         location: *location,

--- a/crates/aiken-lang/src/tipo/expr.rs
+++ b/crates/aiken-lang/src/tipo/expr.rs
@@ -956,9 +956,9 @@ impl<'a, 'b> ExprTyper<'a, 'b> {
                 .ok_or_else(|| Error::UnknownModule {
                     name: module_alias.to_string(),
                     location: *module_location,
-                    imported_modules: self
+                    known_modules: self
                         .environment
-                        .imported_modules
+                        .importable_modules
                         .keys()
                         .map(|t| t.to_string())
                         .collect(),
@@ -2327,9 +2327,9 @@ impl<'a, 'b> ExprTyper<'a, 'b> {
                     .ok_or_else(|| Error::UnknownModule {
                         location: *location,
                         name: module_name.to_string(),
-                        imported_modules: self
+                        known_modules: self
                             .environment
-                            .imported_modules
+                            .importable_modules
                             .keys()
                             .map(|t| t.to_string())
                             .collect(),

--- a/crates/aiken-lsp/src/server/lsp_project.rs
+++ b/crates/aiken-lsp/src/server/lsp_project.rs
@@ -40,6 +40,7 @@ impl LspProject {
             u32::default(),
             PropertyTest::DEFAULT_MAX_SUCCESS,
             Tracing::silent(),
+            None,
         );
 
         self.project.restore(checkpoint);

--- a/crates/aiken-project/src/config.rs
+++ b/crates/aiken-project/src/config.rs
@@ -1,13 +1,20 @@
-use std::{fmt::Display, fs, io, path::Path};
-
 use crate::{github::repo::LatestRelease, package_name::PackageName, paths, Error};
-use aiken_lang::ast::Span;
-use semver::Version;
-
-use miette::NamedSource;
-use serde::{Deserialize, Serialize};
-
 pub use aiken_lang::plutus_version::PlutusVersion;
+use aiken_lang::{
+    ast::{
+        Annotation, ByteArrayFormatPreference, Constant, ModuleConstant, Span, UntypedDefinition,
+    },
+    expr::UntypedExpr,
+    parser::token::Base,
+};
+use miette::NamedSource;
+use semver::Version;
+use serde::{
+    de,
+    ser::{self, SerializeSeq},
+    Deserialize, Serialize,
+};
+use std::{collections::BTreeMap, fmt::Display, fs, io, path::Path};
 
 #[derive(Deserialize, Serialize, Clone)]
 pub struct Config {
@@ -27,6 +34,141 @@ pub struct Config {
     pub repository: Option<Repository>,
     #[serde(default)]
     pub dependencies: Vec<Dependency>,
+    #[serde(default)]
+    pub config: BTreeMap<String, BTreeMap<String, SimpleExpr>>,
+}
+
+#[derive(Clone, Debug)]
+pub enum SimpleExpr {
+    Int(i64),
+    Bool(bool),
+    ByteArray(String),
+    List(Vec<SimpleExpr>),
+}
+
+impl SimpleExpr {
+    pub fn as_untyped_expr(&self) -> UntypedExpr {
+        match self {
+            SimpleExpr::Bool(b) => UntypedExpr::Var {
+                location: Span::empty(),
+                name: if *b { "True" } else { "False" }.to_string(),
+            },
+            SimpleExpr::Int(i) => UntypedExpr::UInt {
+                location: Span::empty(),
+                value: format!("{i}"),
+                base: Base::Decimal {
+                    numeric_underscore: false,
+                },
+            },
+            SimpleExpr::ByteArray(s) => UntypedExpr::ByteArray {
+                location: Span::empty(),
+                bytes: s.as_bytes().to_vec(),
+                preferred_format: ByteArrayFormatPreference::Utf8String,
+            },
+            SimpleExpr::List(es) => UntypedExpr::List {
+                location: Span::empty(),
+                elements: es.iter().map(|e| e.as_untyped_expr()).collect(),
+                tail: None,
+            },
+        }
+    }
+
+    pub fn as_definition(&self, identifier: &str) -> UntypedDefinition {
+        let location = Span::empty();
+
+        let (value, annotation) = match self {
+            SimpleExpr::Bool(..) => todo!("requires https://github.com/aiken-lang/aiken/pull/992"),
+            SimpleExpr::Int(i) => (
+                // TODO: Replace with 'self.as_untyped_expr()' after https://github.com/aiken-lang/aiken/pull/992
+                Constant::Int {
+                    location,
+                    value: format!("{i}"),
+                    base: Base::Decimal {
+                        numeric_underscore: false,
+                    },
+                },
+                Some(Annotation::int(location)),
+            ),
+            SimpleExpr::ByteArray(s) => (
+                // TODO: Replace with 'self.as_untyped_expr()' after https://github.com/aiken-lang/aiken/pull/992
+                Constant::ByteArray {
+                    location,
+                    bytes: s.as_bytes().to_vec(),
+                    preferred_format: ByteArrayFormatPreference::Utf8String,
+                },
+                Some(Annotation::bytearray(location)),
+            ),
+            SimpleExpr::List(..) => todo!("requires https://github.com/aiken-lang/aiken/pull/992"),
+        };
+
+        UntypedDefinition::ModuleConstant(ModuleConstant {
+            location: Span::empty(),
+            doc: None,
+            public: true,
+            name: identifier.to_string(),
+            annotation,
+            value: Box::new(value),
+            tipo: (),
+        })
+    }
+}
+
+impl Serialize for SimpleExpr {
+    fn serialize<S: ser::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        match self {
+            SimpleExpr::Bool(b) => serializer.serialize_bool(*b),
+            SimpleExpr::Int(i) => serializer.serialize_i64(*i),
+            SimpleExpr::ByteArray(s) => serializer.serialize_str(s.as_str()),
+            SimpleExpr::List(es) => {
+                let mut seq = serializer.serialize_seq(Some(es.len()))?;
+                for e in es {
+                    seq.serialize_element(e)?;
+                }
+                seq.end()
+            }
+        }
+    }
+}
+
+impl<'a> Deserialize<'a> for SimpleExpr {
+    fn deserialize<D: de::Deserializer<'a>>(deserializer: D) -> Result<Self, D::Error> {
+        struct SimpleExprVisitor;
+
+        impl<'a> de::Visitor<'a> for SimpleExprVisitor {
+            type Value = SimpleExpr;
+
+            fn expecting(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {
+                formatter.write_str("Int | Bool | ByteArray | List<any_of_those>")
+            }
+
+            fn visit_bool<E>(self, b: bool) -> Result<Self::Value, E> {
+                Ok(SimpleExpr::Bool(b))
+            }
+
+            fn visit_i64<E>(self, i: i64) -> Result<Self::Value, E> {
+                Ok(SimpleExpr::Int(i))
+            }
+
+            fn visit_str<E>(self, s: &str) -> Result<Self::Value, E> {
+                Ok(SimpleExpr::ByteArray(s.to_string()))
+            }
+
+            fn visit_seq<A>(self, mut seq: A) -> Result<Self::Value, A::Error>
+            where
+                A: de::SeqAccess<'a>,
+            {
+                let mut es = Vec::new();
+
+                while let Some(e) = seq.next_element()? {
+                    es.push(e);
+                }
+
+                Ok(SimpleExpr::List(es))
+            }
+        }
+
+        deserializer.deserialize_any(SimpleExprVisitor)
+    }
 }
 
 fn deserialize_version<'de, D>(deserializer: D) -> Result<Version, D::Error>
@@ -108,6 +250,7 @@ impl Config {
                 },
                 source: Platform::Github,
             }],
+            config: BTreeMap::new(),
         }
     }
 
@@ -180,4 +323,47 @@ Version:          {}"#,
         built_info::CFG_TARGET_ARCH,
         compiler_version(true),
     )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use proptest::prelude::*;
+
+    #[allow(clippy::arc_with_non_send_sync)]
+    fn arbitrary_simple_expr() -> impl Strategy<Value = SimpleExpr> {
+        let leaf = prop_oneof![
+            (any::<i64>)().prop_map(SimpleExpr::Int),
+            (any::<bool>)().prop_map(SimpleExpr::Bool),
+            "[a-z]*".prop_map(SimpleExpr::ByteArray)
+        ];
+
+        leaf.prop_recursive(3, 8, 3, |inner| {
+            prop_oneof![
+                inner.clone(),
+                prop::collection::vec(inner.clone(), 0..3).prop_map(SimpleExpr::List)
+            ]
+        })
+    }
+
+    #[derive(Deserialize, Serialize)]
+    struct TestConfig {
+        expr: SimpleExpr,
+    }
+
+    proptest! {
+        #[test]
+        fn round_trip_simple_expr(expr in arbitrary_simple_expr()) {
+            let pretty = toml::to_string_pretty(&TestConfig { expr });
+            assert!(
+                matches!(
+                    pretty.as_ref().map(|s| toml::from_str::<TestConfig>(s.as_str())),
+                    Ok(Ok(..)),
+                ),
+                "\ncounterexample: {}\n",
+                pretty.unwrap_or_default(),
+            )
+
+        }
+    }
 }

--- a/crates/aiken-project/src/error.rs
+++ b/crates/aiken-project/src/error.rs
@@ -127,6 +127,9 @@ pub enum Error {
 
     #[error("I couldn't find any exportable function named '{name}' in module '{module}'.")]
     ExportNotFound { module: String, name: String },
+
+    #[error("I located conditional modules under 'env', but no default one!")]
+    NoDefaultEnvironment,
 }
 
 impl Error {
@@ -195,6 +198,7 @@ impl ExtraData for Error {
             | Error::NoValidatorNotFound { .. }
             | Error::MoreThanOneValidatorFound { .. }
             | Error::Module { .. }
+            | Error::NoDefaultEnvironment { .. }
             | Error::ExportNotFound { .. } => None,
             Error::Type { error, .. } => error.extra_data(),
         }
@@ -224,6 +228,7 @@ impl GetSource for Error {
             | Error::NoValidatorNotFound { .. }
             | Error::MoreThanOneValidatorFound { .. }
             | Error::ExportNotFound { .. }
+            | Error::NoDefaultEnvironment { .. }
             | Error::Module { .. } => None,
             Error::DuplicateModule { second: path, .. }
             | Error::MissingManifest { path }
@@ -252,6 +257,7 @@ impl GetSource for Error {
             | Error::Json { .. }
             | Error::MalformedStakeAddress { .. }
             | Error::NoValidatorNotFound { .. }
+            | Error::NoDefaultEnvironment { .. }
             | Error::MoreThanOneValidatorFound { .. }
             | Error::ExportNotFound { .. }
             | Error::Module { .. } => None,
@@ -307,6 +313,7 @@ impl Diagnostic for Error {
             Error::NoValidatorNotFound { .. } => None,
             Error::MoreThanOneValidatorFound { .. } => None,
             Error::ExportNotFound { .. } => None,
+            Error::NoDefaultEnvironment { .. } => None,
             Error::Module(e) => e.code().map(boxed),
         }
     }
@@ -329,6 +336,9 @@ impl Diagnostic for Error {
             Error::StandardIo(_) => None,
             Error::MissingManifest { .. } => Some(Box::new(
                 "Try running `aiken new <REPOSITORY/PROJECT>` to initialise a project with an example manifest.",
+            )),
+            Error::NoDefaultEnvironment { .. } => Some(Box::new(
+                "Environment module names are free, but there must be at least one named 'default.ak'.",
             )),
             Error::TomlLoading { .. } => None,
             Error::Format { .. } => None,
@@ -408,6 +418,7 @@ impl Diagnostic for Error {
             Error::MalformedStakeAddress { .. } => None,
             Error::NoValidatorNotFound { .. } => None,
             Error::MoreThanOneValidatorFound { .. } => None,
+            Error::NoDefaultEnvironment { .. } => None,
             Error::Module(e) => e.labels(),
         }
     }
@@ -419,6 +430,7 @@ impl Diagnostic for Error {
             Error::ImportCycle { .. } => None,
             Error::ExportNotFound { .. } => None,
             Error::Blueprint(e) => e.source_code(),
+            Error::NoDefaultEnvironment { .. } => None,
             Error::Parse { named, .. } => Some(named),
             Error::Type { named, .. } => Some(named),
             Error::StandardIo(_) => None,
@@ -462,6 +474,7 @@ impl Diagnostic for Error {
             Error::MalformedStakeAddress { .. } => None,
             Error::NoValidatorNotFound { .. } => None,
             Error::MoreThanOneValidatorFound { .. } => None,
+            Error::NoDefaultEnvironment { .. } => None,
             Error::Module(e) => e.url(),
         }
     }
@@ -476,6 +489,7 @@ impl Diagnostic for Error {
             Error::Parse { .. } => None,
             Error::Type { error, .. } => error.related(),
             Error::StandardIo(_) => None,
+            Error::NoDefaultEnvironment { .. } => None,
             Error::MissingManifest { .. } => None,
             Error::TomlLoading { .. } => None,
             Error::Format { .. } => None,

--- a/crates/aiken-project/src/error.rs
+++ b/crates/aiken-project/src/error.rs
@@ -526,6 +526,8 @@ pub enum Warning {
     InvalidModuleName { path: PathBuf },
     #[error("aiken.toml demands compiler version {demanded}, but you are using {current}.")]
     CompilerVersionMismatch { demanded: String, current: String },
+    #[error("No configuration found for environment {env}.")]
+    NoConfigurationForEnv { env: String },
 }
 
 impl ExtraData for Warning {
@@ -534,7 +536,8 @@ impl ExtraData for Warning {
             Warning::NoValidators { .. }
             | Warning::DependencyAlreadyExists { .. }
             | Warning::InvalidModuleName { .. }
-            | Warning::CompilerVersionMismatch { .. } => None,
+            | Warning::CompilerVersionMismatch { .. }
+            | Warning::NoConfigurationForEnv { .. } => None,
             Warning::Type { warning, .. } => warning.extra_data(),
         }
     }
@@ -546,6 +549,7 @@ impl GetSource for Warning {
             Warning::InvalidModuleName { path } | Warning::Type { path, .. } => Some(path.clone()),
             Warning::NoValidators
             | Warning::DependencyAlreadyExists { .. }
+            | Warning::NoConfigurationForEnv { .. }
             | Warning::CompilerVersionMismatch { .. } => None,
         }
     }
@@ -556,6 +560,7 @@ impl GetSource for Warning {
             Warning::NoValidators
             | Warning::InvalidModuleName { .. }
             | Warning::DependencyAlreadyExists { .. }
+            | Warning::NoConfigurationForEnv { .. }
             | Warning::CompilerVersionMismatch { .. } => None,
         }
     }
@@ -571,6 +576,7 @@ impl Diagnostic for Warning {
             Warning::Type { named, .. } => Some(named),
             Warning::NoValidators
             | Warning::InvalidModuleName { .. }
+            | Warning::NoConfigurationForEnv { .. }
             | Warning::DependencyAlreadyExists { .. }
             | Warning::CompilerVersionMismatch { .. } => None,
         }
@@ -582,6 +588,7 @@ impl Diagnostic for Warning {
             Warning::InvalidModuleName { .. }
             | Warning::NoValidators
             | Warning::DependencyAlreadyExists { .. }
+            | Warning::NoConfigurationForEnv { .. }
             | Warning::CompilerVersionMismatch { .. } => None,
         }
     }
@@ -600,6 +607,9 @@ impl Diagnostic for Warning {
             Warning::DependencyAlreadyExists { .. } => {
                 Some(Box::new("aiken::packages::already_exists"))
             }
+            Warning::NoConfigurationForEnv { .. } => {
+                Some(Box::new("aiken::project::config::missing::env"))
+            }
         }
     }
 
@@ -616,6 +626,9 @@ impl Diagnostic for Warning {
             )),
             Warning::DependencyAlreadyExists { .. } => Some(Box::new(
                 "If you need to change the version, try 'aiken packages upgrade' instead.",
+            )),
+            Warning::NoConfigurationForEnv { .. } => Some(Box::new(
+                "When configuration keys are missing for a target environment, no 'config' module will be created. This may lead to issues down the line.",
             )),
         }
     }

--- a/crates/aiken-project/src/module.rs
+++ b/crates/aiken-project/src/module.rs
@@ -32,16 +32,9 @@ pub struct ParsedModule {
 }
 
 impl ParsedModule {
-    pub fn deps_for_graph(&self) -> (String, Vec<String>) {
+    pub fn deps_for_graph(&self, env_modules: &[String]) -> (String, Vec<String>) {
         let name = self.name.clone();
-
-        let deps: Vec<_> = self
-            .ast
-            .dependencies()
-            .into_iter()
-            .map(|(dep, _span)| dep)
-            .collect();
-
+        let deps: Vec<_> = self.ast.dependencies(env_modules);
         (name, deps)
     }
 
@@ -124,10 +117,19 @@ impl ParsedModules {
     }
 
     pub fn sequence(&self, our_modules: &BTreeSet<String>) -> Result<Vec<String>, Error> {
+        let env_modules = self
+            .0
+            .values()
+            .filter_map(|m| match m.kind {
+                ModuleKind::Env => Some(m.name.clone()),
+                ModuleKind::Lib | ModuleKind::Validator => None,
+            })
+            .collect::<Vec<String>>();
+
         let inputs = self
             .0
             .values()
-            .map(|m| m.deps_for_graph())
+            .map(|m| m.deps_for_graph(&env_modules))
             .collect::<Vec<(String, Vec<String>)>>();
 
         let capacity = inputs.len();

--- a/crates/aiken-project/src/module.rs
+++ b/crates/aiken-project/src/module.rs
@@ -122,7 +122,7 @@ impl ParsedModules {
             .values()
             .filter_map(|m| match m.kind {
                 ModuleKind::Env => Some(m.name.clone()),
-                ModuleKind::Lib | ModuleKind::Validator => None,
+                ModuleKind::Lib | ModuleKind::Validator | ModuleKind::Config => None,
             })
             .collect::<Vec<String>>();
 

--- a/crates/aiken-project/src/module.rs
+++ b/crates/aiken-project/src/module.rs
@@ -51,6 +51,7 @@ impl ParsedModule {
         id_gen: &IdGenerator,
         package: &str,
         tracing: Tracing,
+        env: Option<&str>,
         validate_module_name: bool,
         module_sources: &mut HashMap<String, (String, LineNumbers)>,
         module_types: &mut HashMap<String, TypeInfo>,
@@ -68,6 +69,7 @@ impl ParsedModule {
                 module_types,
                 tracing,
                 &mut warnings,
+                env,
             )
             .map_err(|error| Error::Type {
                 path: self.path.clone(),

--- a/crates/aiken-project/src/options.rs
+++ b/crates/aiken-project/src/options.rs
@@ -3,6 +3,7 @@ use aiken_lang::ast::Tracing;
 pub struct Options {
     pub code_gen_mode: CodeGenMode,
     pub tracing: Tracing,
+    pub env: Option<String>,
 }
 
 impl Default for Options {
@@ -10,6 +11,7 @@ impl Default for Options {
         Self {
             code_gen_mode: CodeGenMode::NoOp,
             tracing: Tracing::silent(),
+            env: None,
         }
     }
 }

--- a/crates/aiken-project/src/test_framework.rs
+++ b/crates/aiken-project/src/test_framework.rs
@@ -1314,6 +1314,7 @@ mod test {
                     &module_types,
                     Tracing::All(TraceLevel::Verbose),
                     &mut warnings,
+                    None,
                 )
                 .expect("Failed to type-check module.");
 

--- a/crates/aiken-project/src/tests/mod.rs
+++ b/crates/aiken-project/src/tests/mod.rs
@@ -99,6 +99,7 @@ impl TestProject {
                 &self.module_types,
                 Tracing::All(TraceLevel::Verbose),
                 &mut warnings,
+                None,
             )
             .expect("Failed to type-check module");
 

--- a/crates/aiken/src/cmd/blueprint/address.rs
+++ b/crates/aiken/src/cmd/blueprint/address.rs
@@ -1,4 +1,3 @@
-use aiken_lang::ast::Tracing;
 use aiken_project::watch::with_project;
 use std::path::PathBuf;
 
@@ -20,10 +19,6 @@ pub struct Args {
     #[clap(long)]
     delegated_to: Option<String>,
 
-    /// Force the project to be rebuilt, otherwise relies on existing artifacts (i.e. plutus.json)
-    #[clap(long)]
-    rebuild: bool,
-
     /// Output the address for mainnet (this command defaults to testnet)
     #[clap(long)]
     mainnet: bool,
@@ -35,15 +30,10 @@ pub fn exec(
         module,
         validator,
         delegated_to,
-        rebuild,
         mainnet,
     }: Args,
 ) -> miette::Result<()> {
     with_project(directory.as_deref(), false, |p| {
-        if rebuild {
-            p.build(false, Tracing::silent())?;
-        }
-
         let title = module.as_ref().map(|m| {
             format!(
                 "{m}{}",

--- a/crates/aiken/src/cmd/blueprint/hash.rs
+++ b/crates/aiken/src/cmd/blueprint/hash.rs
@@ -1,4 +1,3 @@
-use aiken_lang::ast::Tracing;
 use aiken_project::watch::with_project;
 use std::path::PathBuf;
 
@@ -15,10 +14,6 @@ pub struct Args {
     /// Name of the validator within the module. Optional if there's only one validator
     #[clap(short, long)]
     validator: Option<String>,
-
-    /// Force the project to be rebuilt, otherwise relies on existing artifacts (i.e. plutus.json)
-    #[clap(long)]
-    rebuild: bool,
 }
 
 pub fn exec(
@@ -26,14 +21,9 @@ pub fn exec(
         directory,
         module,
         validator,
-        rebuild,
     }: Args,
 ) -> miette::Result<()> {
     with_project(directory.as_deref(), false, |p| {
-        if rebuild {
-            p.build(false, Tracing::silent())?;
-        }
-
         let title = module.as_ref().map(|m| {
             format!(
                 "{m}{}",

--- a/crates/aiken/src/cmd/blueprint/policy.rs
+++ b/crates/aiken/src/cmd/blueprint/policy.rs
@@ -1,4 +1,3 @@
-use aiken_lang::ast::Tracing;
 use aiken_project::watch::with_project;
 use std::path::PathBuf;
 
@@ -15,10 +14,6 @@ pub struct Args {
     /// Name of the validator within the module. Optional if there's only one validator
     #[clap(short, long)]
     validator: Option<String>,
-
-    /// Force the project to be rebuilt, otherwise relies on existing artifacts (i.e. plutus.json)
-    #[clap(long)]
-    rebuild: bool,
 }
 
 pub fn exec(
@@ -26,14 +21,9 @@ pub fn exec(
         directory,
         module,
         validator,
-        rebuild,
     }: Args,
 ) -> miette::Result<()> {
     with_project(directory.as_deref(), false, |p| {
-        if rebuild {
-            p.build(false, Tracing::silent())?;
-        }
-
         let title = module.as_ref().map(|m| {
             format!(
                 "{m}{}",

--- a/crates/aiken/src/cmd/build.rs
+++ b/crates/aiken/src/cmd/build.rs
@@ -21,6 +21,10 @@ pub struct Args {
     #[clap(short, long)]
     uplc: bool,
 
+    /// Environment to build against.
+    #[clap(long)]
+    env: Option<String>,
+
     /// Filter traces to be included in the generated program(s).
     ///
     ///   - user-defined:
@@ -63,6 +67,7 @@ pub fn exec(
         uplc,
         filter_traces,
         trace_level,
+        env,
     }: Args,
 ) -> miette::Result<()> {
     let result = if watch {
@@ -73,6 +78,7 @@ pub fn exec(
                     Some(filter_traces) => filter_traces(trace_level),
                     None => Tracing::All(trace_level),
                 },
+                env.clone(),
             )
         })
     } else {
@@ -83,6 +89,7 @@ pub fn exec(
                     Some(filter_traces) => filter_traces(trace_level),
                     None => Tracing::All(trace_level),
                 },
+                env.clone(),
             )
         })
     };

--- a/crates/aiken/src/cmd/check.rs
+++ b/crates/aiken/src/cmd/check.rs
@@ -48,6 +48,10 @@ pub struct Args {
     #[clap(short, long)]
     exact_match: bool,
 
+    /// Environment to build against.
+    #[clap(long)]
+    env: Option<String>,
+
     /// Filter traces to be included in the generated program(s).
     ///
     ///   - user-defined:
@@ -95,6 +99,7 @@ pub fn exec(
         trace_level,
         seed,
         max_success,
+        env,
     }: Args,
 ) -> miette::Result<()> {
     let mut rng = rand::thread_rng();
@@ -114,6 +119,7 @@ pub fn exec(
                     Some(filter_traces) => filter_traces(trace_level),
                     None => Tracing::All(trace_level),
                 },
+                env.clone(),
             )
         })
     } else {
@@ -129,6 +135,7 @@ pub fn exec(
                     Some(filter_traces) => filter_traces(trace_level),
                     None => Tracing::All(trace_level),
                 },
+                env.clone(),
             )
         })
     };


### PR DESCRIPTION
## Context

Closes #937.

## Preview

![image](https://github.com/user-attachments/assets/01ec27bb-2bd4-427b-9178-4d343403bf84)

☝️  Many things happening on the image above:

- The project defines a bunch of _environments_ under the `env` directory. 
- The project defines an extra set of _configurations_ in its `aiken.toml`
- Tests make use of the special `env` and `config` modules, which are populated based on the `--env` flag. Defaulting to the environment/config called _default_ when not present.
- Tests are making conflicting assertions which can only pass in one of the given environment. As illustrated, since `--env preprod` is passed, only the preprod tests pass.

### No default environment?

<img width="627" alt="image" src="https://github.com/user-attachments/assets/fccd186a-7e1d-47b4-b770-8a26ffd28f58">

### Unknown environment?

| Completely unknown | Close enough |  
| --- | --- | 
| <img width="472" alt="image" src="https://github.com/user-attachments/assets/110c0e70-8bd9-41c4-b6e3-f5d1d016fd16"> | <img width="501" alt="image" src="https://github.com/user-attachments/assets/7aa209fc-e8ed-4782-9a8c-3db290fdc1b0">

### Missing configuration?

<img width="657" alt="image" src="https://github.com/user-attachments/assets/393d5fc4-987b-4759-ab2a-7ece0ac3e43a">

> [!NOTE]
>
> This only triggers a warning because it may not be problematic should the configuration be unused. If it is used, we simply fallback to a usual 'unknown module' error.

## Changelog

- :round_pushpin: **Parse sources of conditional env modules.**
    Do nothing about it yet, but trigger an error if env/default.ak is
  missing; but only if there's any module at all under env.

- :round_pushpin: **Thread down environment module from cli down to the type-checker**
    We simply provide a flag with a free-form output which acts as
  the module to lookup in the 'env' folder. The strategy is to replace
  the environment module name on-the-fly when a user tries to import
  'env'.

  If the environment isn't found, an 'UnknownModule' error is raised
  (which I will slightly adjust in a following commits to something more
  related to environment)

  There are few important consequences to this design which may not seem
  immediately obvious:

  1. We parse and type-check every env modules, even if they aren't
     used. This ensures that code doesn't break with a compilation error
     simply because people forgot to type-check a given env.

     Note that compilation could still fail because the env module
     itself could provide an invalid API. So it only prevents each
     modules to be independently wrong when taken in isolation.

  2. Technically, this also means that one can import env modules in
     other env modules by their names. I don't know if it's a good or
     bad idea at this point but it doesn't really do any wrong;
     dependencies and cycles are handlded all-the-same.

- :round_pushpin: **Ensure env modules dependencies are properly handled.**
    We figure out dependencies by looking at 'use' definition in parsed
  modules. However, in the case of environment modules, we must consider
  all of them when seeing "use env". Without that, the env modules are
  simply compiled in parallel and may not yet have been compiled when
  they are needed as actual dependencies.

- :round_pushpin: **Create dedicated error when environment isn't found.**
    This is less confusing that getting an 'UnknownModule' error reporting
  even a different module name than the one actually being important
  ('env').

  Also, this commit fixes a few errors found in the type-checker
  when reporting 'UnknownModule' errors. About half the time, we would
  actually attached _imported modules_ instead of _importable modules_
  to the error, making the neighboring suggestion quite worse (nay
  useless).

- :round_pushpin: **Allow simple expressions as configuration in aiken.toml**
    This is currently extremely limited as it only supports (UTF-8)
  bytearrays and integers. We should seek to at least support hex bytes
  sequences, as well as bools, lists and possibly options.

  For the latter, we the rework on constant outlined in #992 is
  necessary.

- :round_pushpin: **Allow bytes to be defined as plain strings, or with specified encoding.**
    The syntax is as follows:

  { "bytes" = "...", "encoding" = "<encoding>" }

  The following encoding are accepted:

  "utf8", "utf-8", "hex", "base16"

  Note: the duplicates are only there to make it easier for people to
  discover them by accident. When "hex" (resp. "base16") is specified,
  the bytes string will be decoded and must be a valid hex string.

- :round_pushpin: **Fill-in CHANGELOG.**