### PR TITLE
Allow assignment as last expression

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,10 @@
 
 - **aiken-lang**: remove warning on discarded expect, allowing to keep 'side-effects' when necessary. See [#967](https://github.com/aiken-lang/aiken/pull/967). @KtorZ
 
+- **aiken-lang**: allow expect as last (or only) expression in function body, when clauses and if branches. Such expressions unify with `Void`. See [#1000](https://github.com/aiken-lang/aiken/pull/1000). @KtorZ
+
+- **aiken-lang**: allow tests to return `Void`. Tests that return `Void` are treated the same as tests that return `True`. See [#1000](https://github.com/aiken-lang/aiken/pull/1000). @KtorZ
+
 - **aiken-lang**: rework traces to be (1) variadic, (2) generic in its arguments and (3) structured. @KtorZ
 
   In more details:

--- a/crates/aiken-lang/src/ast.rs
+++ b/crates/aiken-lang/src/ast.rs
@@ -1423,6 +1423,26 @@ impl UntypedPattern {
             is_record: false,
         }
     }
+
+    /// Returns Some(<bool>) if the pattern is a [`Boolean`] literal,
+    /// holding the target value. None if it isn't a bool pattern.
+    pub fn get_bool(&self) -> Option<bool> {
+        match self {
+            Self::Constructor {
+                module: None,
+                name,
+                constructor: (),
+                ..
+            } if name == "True" => Some(true),
+            Self::Constructor {
+                module: None,
+                name,
+                constructor: (),
+                ..
+            } if name == "False" => Some(false),
+            _ => None,
+        }
+    }
 }
 
 impl TypedPattern {

--- a/crates/aiken-lang/src/ast.rs
+++ b/crates/aiken-lang/src/ast.rs
@@ -1423,26 +1423,6 @@ impl UntypedPattern {
             is_record: false,
         }
     }
-
-    /// Returns Some(<bool>) if the pattern is a [`Boolean`] literal,
-    /// holding the target value. None if it isn't a bool pattern.
-    pub fn get_bool(&self) -> Option<bool> {
-        match self {
-            Self::Constructor {
-                module: None,
-                name,
-                constructor: (),
-                ..
-            } if name == "True" => Some(true),
-            Self::Constructor {
-                module: None,
-                name,
-                constructor: (),
-                ..
-            } if name == "False" => Some(false),
-            _ => None,
-        }
-    }
 }
 
 impl TypedPattern {

--- a/crates/aiken-lang/src/expr.rs
+++ b/crates/aiken-lang/src/expr.rs
@@ -1,4 +1,5 @@
-use crate::{
+use crate::tipo::ValueConstructorVariant;
+pub(crate) use crate::{
     ast::{
         self, Annotation, ArgBy, ArgName, AssignmentPattern, BinOp, Bls12_381Point,
         ByteArrayFormatPreference, CallArg, Curve, DataType, DataTypeKey, DefinitionLocation,
@@ -7,7 +8,7 @@ use crate::{
         TypedDataType, TypedIfBranch, TypedRecordUpdateArg, UnOp, UntypedArg,
         UntypedAssignmentKind, UntypedClause, UntypedIfBranch, UntypedRecordUpdateArg,
     },
-    builtins::void,
+    builtins::{bool, void},
     parser::token::Base,
     tipo::{
         check_replaceable_opaque_type, convert_opaque_type, lookup_data_type_by_tipo,
@@ -470,6 +471,44 @@ impl TypedExpr {
             TypedExpr::UnOp { value, .. } => value
                 .find_node(byte_index)
                 .or(Some(Located::Expression(self))),
+        }
+    }
+
+    pub fn void(location: Span) -> Self {
+        TypedExpr::Var {
+            name: "Void".to_string(),
+            constructor: ValueConstructor {
+                public: true,
+                variant: ValueConstructorVariant::Record {
+                    name: "Void".to_string(),
+                    arity: 0,
+                    field_map: None,
+                    location: Span::empty(),
+                    module: String::new(),
+                    constructors_count: 1,
+                },
+                tipo: void(),
+            },
+            location,
+        }
+    }
+
+    pub fn bool(value: bool, location: Span) -> Self {
+        TypedExpr::Var {
+            name: "Bool".to_string(),
+            constructor: ValueConstructor {
+                public: true,
+                variant: ValueConstructorVariant::Record {
+                    name: if value { "True" } else { "False" }.to_string(),
+                    arity: 0,
+                    field_map: None,
+                    location: Span::empty(),
+                    module: String::new(),
+                    constructors_count: 2,
+                },
+                tipo: bool(),
+            },
+            location,
         }
     }
 }

--- a/crates/aiken-lang/src/expr.rs
+++ b/crates/aiken-lang/src/expr.rs
@@ -492,25 +492,6 @@ impl TypedExpr {
             location,
         }
     }
-
-    pub fn bool(value: bool, location: Span) -> Self {
-        TypedExpr::Var {
-            name: "Bool".to_string(),
-            constructor: ValueConstructor {
-                public: true,
-                variant: ValueConstructorVariant::Record {
-                    name: if value { "True" } else { "False" }.to_string(),
-                    arity: 0,
-                    field_map: None,
-                    location: Span::empty(),
-                    module: String::new(),
-                    constructors_count: 2,
-                },
-                tipo: bool(),
-            },
-            location,
-        }
-    }
 }
 
 // Represent how a function was written so that we can format it back.

--- a/crates/aiken-lang/src/parser/definition/snapshots/def_invalid_property_test.snap
+++ b/crates/aiken-lang/src/parser/definition/snapshots/def_invalid_property_test.snap
@@ -52,14 +52,7 @@ Test(
         location: 0..26,
         name: "foo",
         public: false,
-        return_annotation: Some(
-            Constructor {
-                location: 0..39,
-                module: None,
-                name: "Bool",
-                arguments: [],
-            },
-        ),
+        return_annotation: None,
         return_type: (),
         end_position: 38,
         on_test_failure: FailImmediately,

--- a/crates/aiken-lang/src/parser/definition/snapshots/def_property_test.snap
+++ b/crates/aiken-lang/src/parser/definition/snapshots/def_property_test.snap
@@ -37,14 +37,7 @@ Test(
         location: 0..28,
         name: "foo",
         public: false,
-        return_annotation: Some(
-            Constructor {
-                location: 0..41,
-                module: None,
-                name: "Bool",
-                arguments: [],
-            },
-        ),
+        return_annotation: None,
         return_type: (),
         end_position: 40,
         on_test_failure: FailImmediately,

--- a/crates/aiken-lang/src/parser/definition/snapshots/def_property_test_annotated_fuzzer.snap
+++ b/crates/aiken-lang/src/parser/definition/snapshots/def_property_test_annotated_fuzzer.snap
@@ -44,14 +44,7 @@ Test(
         location: 0..26,
         name: "foo",
         public: false,
-        return_annotation: Some(
-            Constructor {
-                location: 0..39,
-                module: None,
-                name: "Bool",
-                arguments: [],
-            },
-        ),
+        return_annotation: None,
         return_type: (),
         end_position: 38,
         on_test_failure: FailImmediately,

--- a/crates/aiken-lang/src/parser/definition/snapshots/def_test.snap
+++ b/crates/aiken-lang/src/parser/definition/snapshots/def_test.snap
@@ -13,14 +13,7 @@ Test(
         location: 0..10,
         name: "foo",
         public: false,
-        return_annotation: Some(
-            Constructor {
-                location: 0..23,
-                module: None,
-                name: "Bool",
-                arguments: [],
-            },
-        ),
+        return_annotation: None,
         return_type: (),
         end_position: 22,
         on_test_failure: FailImmediately,

--- a/crates/aiken-lang/src/parser/definition/snapshots/def_test_fail.snap
+++ b/crates/aiken-lang/src/parser/definition/snapshots/def_test_fail.snap
@@ -44,14 +44,7 @@ Test(
         location: 0..26,
         name: "invalid_inputs",
         public: false,
-        return_annotation: Some(
-            Constructor {
-                location: 0..61,
-                module: None,
-                name: "Bool",
-                arguments: [],
-            },
-        ),
+        return_annotation: None,
         return_type: (),
         end_position: 60,
         on_test_failure: SucceedEventually,

--- a/crates/aiken-lang/src/parser/definition/test.rs
+++ b/crates/aiken-lang/src/parser/definition/test.rs
@@ -45,7 +45,7 @@ pub fn parser() -> impl Parser<Token, ast::UntypedDefinition, Error = ParseError
                 end_position: span.end - 1,
                 name,
                 public: false,
-                return_annotation: Some(ast::Annotation::boolean(span)),
+                return_annotation: None,
                 return_type: (),
                 on_test_failure: fail.unwrap_or(OnTestFailure::FailImmediately),
             })

--- a/crates/aiken-lang/src/tipo/error.rs
+++ b/crates/aiken-lang/src/tipo/error.rs
@@ -2,7 +2,7 @@ use super::Type;
 use crate::{
     ast::{Annotation, BinOp, CallArg, LogicalOpChainKind, Span, UntypedFunction, UntypedPattern},
     error::ExtraData,
-    expr::{self, AssignmentPattern, UntypedExpr},
+    expr::{self, AssignmentPattern, UntypedAssignmentKind, UntypedExpr},
     format::Formatter,
     levenshtein,
     pretty::Documentable,
@@ -472,6 +472,7 @@ If you really meant to return that last expression, try to replace it with the f
         location: Span,
         expr: expr::UntypedExpr,
         patterns: Vec1<AssignmentPattern>,
+        kind: UntypedAssignmentKind,
     },
 
     #[error(
@@ -1013,13 +1014,25 @@ The best thing to do from here is to remove it."#))]
     },
 
     #[error("I caught a test with too many arguments.\n")]
-    #[diagnostic(code("illegal::test_arity"))]
+    #[diagnostic(code("illegal::test::arity"))]
     #[diagnostic(help(
         "Tests are allowed to have 0 or 1 argument, but no more. Here I've found a test definition with {count} arguments. If you need to provide multiple values to a test, use a Record or a Tuple.",
     ))]
     IncorrectTestArity {
         count: usize,
         #[label("too many arguments")]
+        location: Span,
+    },
+
+    #[error("I caught a test with an illegal return type.\n")]
+    #[diagnostic(code("illegal::test::return"))]
+    #[diagnostic(help(
+        "Tests must return either {Bool} or {Void}. Note that `expect` assignment are implicitly typed {Void} (and thus, may be the last expression of a test).",
+        Bool = "Bool".if_supports_color(Stderr, |s| s.cyan()),
+        Void = "Void".if_supports_color(Stderr, |s| s.cyan()),
+    ))]
+    IllegalTestType {
+        #[label("expected Bool or Void")]
         location: Span,
     },
 
@@ -1092,6 +1105,7 @@ impl ExtraData for Error {
             | Error::UpdateMultiConstructorType { .. }
             | Error::ValidatorImported { .. }
             | Error::IncorrectTestArity { .. }
+            | Error::IllegalTestType { .. }
             | Error::GenericLeftAtBoundary { .. }
             | Error::UnexpectedMultiPatternAssignment { .. }
             | Error::ExpectOnOpaqueType { .. }

--- a/crates/aiken-lang/src/tipo/error.rs
+++ b/crates/aiken-lang/src/tipo/error.rs
@@ -2,7 +2,7 @@ use super::Type;
 use crate::{
     ast::{Annotation, BinOp, CallArg, LogicalOpChainKind, Span, UntypedFunction, UntypedPattern},
     error::ExtraData,
-    expr::{self, UntypedExpr},
+    expr::{self, AssignmentPattern, UntypedExpr},
     format::Formatter,
     levenshtein,
     pretty::Documentable,
@@ -15,6 +15,7 @@ use owo_colors::{
     Stream::{Stderr, Stdout},
 };
 use std::{collections::HashMap, fmt::Display, rc::Rc};
+use vec1::Vec1;
 
 #[derive(Debug, Clone, thiserror::Error)]
 #[error(
@@ -470,6 +471,7 @@ If you really meant to return that last expression, try to replace it with the f
         #[label("let-binding as last expression")]
         location: Span,
         expr: expr::UntypedExpr,
+        patterns: Vec1<AssignmentPattern>,
     },
 
     #[error(

--- a/crates/aiken-lang/src/tipo/infer.rs
+++ b/crates/aiken-lang/src/tipo/infer.rs
@@ -392,12 +392,25 @@ fn infer_definition(
 
             let typed_f = infer_function(&f.into(), module_name, hydrators, environment, tracing)?;
 
-            environment.unify(
+            let is_bool = environment.unify(
                 typed_f.return_type.clone(),
                 builtins::bool(),
                 typed_f.location,
                 false,
-            )?;
+            );
+
+            let is_void = environment.unify(
+                typed_f.return_type.clone(),
+                builtins::void(),
+                typed_f.location,
+                false,
+            );
+
+            if is_bool.or(is_void).is_err() {
+                return Err(Error::IllegalTestType {
+                    location: typed_f.location,
+                });
+            }
 
             Ok(Definition::Test(Function {
                 doc: typed_f.doc,

--- a/crates/uplc/src/machine/eval_result.rs
+++ b/crates/uplc/src/machine/eval_result.rs
@@ -39,7 +39,11 @@ impl EvalResult {
         } else {
             self.result.is_err()
                 || matches!(self.result, Ok(Term::Error))
-                || !matches!(self.result, Ok(Term::Constant(ref con)) if matches!(con.as_ref(), Constant::Bool(true)))
+                || !matches!(
+                  self.result,
+                  Ok(Term::Constant(ref con))
+                  if matches!(con.as_ref(), Constant::Bool(true)) || matches!(con.as_ref(), Constant::Unit)
+                )
         }
     }
 


### PR DESCRIPTION
- [x] Allow expect as last (or only) expression in function body, when clauses and if branches. Such expressions unify with `Void`. Fundamentally, we merely desugar last `expect` into a sequence of `expect ...` + `Void` as follows:

  <table>
  <thead><tr><th>expression</th><th>desugar into</th></tr></thead>
  <tbody>
  <tr>
  <td>

  ```aiken
  fn expect_bool(data: Data) -> Void {
    expect _: Bool = data
  }
  ```
  </td>
  <td>

  ```aiken
  fn expect_bool(data: Data) -> Void {
    expect _: Bool = data
    Void
  }
  ```
  </td>
  </tr>
  </tbody>
  </table>

- [x] allow tests to return `Void`. Tests that return `Void` are treated the same as tests that return `True`. This changes works well in combination with the previous one, obviously. But it also work with arbitrary functions calls in tests that would return `Void` (assuming that those calls contain assertions doing validations as side-effects).

  ```aiken
  fn some_validations(fixture) -> Void {
    expect ...
    expect ...
  }

  test foo() {
    some_validation(my_fixture)
  }
  ```

