### PR TITLE
Add acceptance test 111

### DIFF
--- a/examples/acceptance_tests/111/aiken.toml
+++ b/examples/acceptance_tests/111/aiken.toml
@@ -1,0 +1,9 @@
+name = "aiken-lang/acceptance_test_111"
+version = "0.0.0"
+license = "Apache-2.0"
+description = "Aiken contracts for project 'aiken-lang/111'"
+
+[repository]
+user = "aiken-lang"
+project = "111"
+platform = "github"

--- a/examples/acceptance_tests/111/lib/foo.ak
+++ b/examples/acceptance_tests/111/lib/foo.ak
@@ -1,0 +1,16 @@
+type Point =
+  (ByteArray, Int)
+
+type NestedTuples {
+  points: (Point, Point),
+}
+
+test boom() {
+  let original = NestedTuples { points: (("", 14), ("foo", 42)) }
+
+  let data: Data = original
+
+  expect recovered: NestedTuples = data
+
+  original == recovered
+}


### PR DESCRIPTION
  Seems like nested tuples are inferred wrongly when type-casted.

  ```
  type mismatch
     Expected (list a)
          Got integer
  ```