### PR TITLE
Add wrap constructor to V1/V2 StakeCredential

### DIFF
--- a/crates/uplc/src/tx/to_plutus_data.rs
+++ b/crates/uplc/src/tx/to_plutus_data.rs
@@ -872,9 +872,10 @@ impl<'a> ToPlutusData for WithWrappedTransactionId<'a, ScriptPurpose> {
             ScriptPurpose::Spending(out_ref, ()) => {
                 wrap_with_constr(1, WithWrappedTransactionId(out_ref).to_plutus_data())
             }
-            ScriptPurpose::Rewarding(stake_credential) => {
-                wrap_with_constr(2, stake_credential.to_plutus_data())
-            }
+            ScriptPurpose::Rewarding(stake_credential) => wrap_with_constr(
+                2,
+                WithWrappedStakeCredential(stake_credential).to_plutus_data(),
+            ),
             ScriptPurpose::Certifying(_, dcert) => {
                 wrap_with_constr(3, WithPartialCertificates(dcert).to_plutus_data())
             }
@@ -1240,6 +1241,12 @@ impl<'a> ToPlutusData for WithWrappedStakeCredential<'a, KeyValuePairs<Address, 
                 .collect::<Vec<_>>(),
         )
         .to_plutus_data()
+    }
+}
+
+impl<'a> ToPlutusData for WithWrappedStakeCredential<'a, StakeCredential> {
+    fn to_plutus_data(&self) -> PlutusData {
+        wrap_with_constr(0, self.0.to_plutus_data())
     }
 }
 


### PR DESCRIPTION
I'm not entirely sure if this is the right approach, but I wanted to suggest a potential solution to the missing constructor when a V1/V2 validator Purpose is of the [Rewarding](
https://github.com/IntersectMBO/plutus/blob/e56ab7369d71a5d5ac7f27aaa54c9f823cb3b660/plutus-ledger-api/src/PlutusLedgerApi/V1/Contexts.hs#L91) type. In such cases, the [StakingCredential](https://github.com/IntersectMBO/plutus/blob/e56ab7369d71a5d5ac7f27aaa54c9f823cb3b660/plutus-ledger-api/src/PlutusLedgerApi/V1/Credential.hs#L32-L46) type must be wrapped in a StakingHash constructor as per the Plutus Ledger API for V1/V2:
Previous Aiken versions used to encode the StakeCredential as follows:
`121([_ 122([_ h\'524A8B6C686BF0C225C8BC8EB63100BDF1047A35599626878EDF3BFE\'])])`

For V3, however, this extra constructor in the [Rewarding](https://github.com/IntersectMBO/plutus/blob/e56ab7369d71a5d5ac7f27aaa54c9f823cb3b660/plutus-ledger-api/src/PlutusLedgerApi/V3/Contexts.hs#L429) Purpose is not required , which seems to be correctly reflected in the latest Aiken version:

I'd also suggest renaming StakeCredential to Credential, as the current name can be misleading.
```
pub enum StakeCredential {
    AddrKeyhash(AddrKeyhash),
    Scripthash(Scripthash),
}
```
