### PR TITLE
Add KaTeX support for documentation generation

### DIFF
--- a/crates/aiken-project/Cargo.toml
+++ b/crates/aiken-project/Cargo.toml
@@ -53,6 +53,7 @@ uplc = { path = '../uplc', version = "1.1.7" }
 vec1 = "1.10.1"
 walkdir.workspace = true
 zip = "0.6.4"
+katex = "0.4"
 
 [dev-dependencies]
 blst = "0.3.11"

--- a/crates/aiken-project/src/docs.rs
+++ b/crates/aiken-project/src/docs.rs
@@ -268,15 +268,38 @@ fn generate_module(
         timestamp: timestamp.as_secs().to_string(),
     };
 
+    let rendered_content = convert_latex_markers(
+                                    inject_math_library(
+                                        module.render().expect("Module documentation template rendering"),
+                                        )
+                                    );
+
     (
         search_indexes,
         DocFile {
             path: PathBuf::from(format!("{}.html", module.module_name)),
-            content: module
-                .render()
-                .expect("Module documentation template rendering"),
+            content: rendered_content,
         },
     )
+}
+
+
+fn convert_latex_markers(input: String) -> String {
+    input.replace("#[", "\\(")
+         .replace("]#", "\\)")
+}
+
+fn inject_math_library(html: String) -> String {
+    let mathjax_script = r#"
+    <script type="text/javascript" id="MathJax-script" async
+        src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js">
+    </script>
+    <script>
+      MathJax.typeset();
+    </script>
+    "#;
+
+    html.replace("</head>", &format!("{}\n</head>", mathjax_script))
 }
 
 fn generate_static_assets(search_indexes: Vec<SearchIndex>) -> Vec<DocFile> {


### PR DESCRIPTION
This PR addresses the request for LaTeX support mentioned in https://github.com/aiken-lang/aiken/discussions/1062. It introduces the following enhancements:

- Custom LaTeX Markers: Added support for `$`/`$` markers to denote (inline) LaTeX content or `$$`/`$$` to denote (block) LaTeX  in documentation
- ~~MathJax Integration: The MathJax library was included to render mathematical formulas directly in the browser.~~
- [Katex](https://katex.org/) is used, with rendering done at generation time (and not by the client/browser)

### Example Usage

This documentation from aiken:

```rust
/// #[g^{z} = g^{r +c \cdot x} = g^{r} g^{x \cdot c} = g^{r} (g^{x})^{c} = g^{r} u^{c}]#
/// #[\blacksquare]#
```

will show:

$$ 
g^{z} = g^{r + c \cdot x} = g^{r} g^{x \cdot c} = g^{r} (g^{x})^{c} = g^{r} u^{c} 
$$

$$
\blacksquare
$$

I'm open to any suggestions about the delimiters or the approach for rendering the formulas. 🚀