### PR TITLE
Fix blueprint pairs schema generation

### DIFF
--- a/crates/aiken-project/src/blueprint/schema.rs
+++ b/crates/aiken-project/src/blueprint/schema.rs
@@ -346,8 +346,6 @@ impl Annotated<Schema> {
                                     annotated: Schema::Pair(left, right),
                                     ..
                                 }) => {
-                                    definitions.remove(&generic);
-
                                     let left = left.map(|inner| match inner {
                                         Schema::Data(data) => data,
                                         _ => panic!("impossible: left inhabitant of pair isn't Data but: {inner:#?}"),

--- a/crates/aiken-project/src/blueprint/snapshots/aiken_project__blueprint__validator__tests__map_in_map.snap
+++ b/crates/aiken-project/src/blueprint/snapshots/aiken_project__blueprint__validator__tests__map_in_map.snap
@@ -1,0 +1,73 @@
+---
+source: crates/aiken-project/src/blueprint/validator.rs
+description: "Code:\n\npub type OuterMap =\n    List<Pair<Int, InnerMap>>\n\npub type InnerMap =\n    List<Pair<Int, Bool>>\n\nvalidator placeholder {\n  spend(_datum: Option<Void>, _redeemer: OuterMap, _utxo: Data, _self: Data,) {\n    True\n  }\n}\n"
+---
+{
+  "title": "test_module.placeholder.spend",
+  "datum": {
+    "title": "_datum",
+    "schema": {
+      "$ref": "#/definitions/Void"
+    }
+  },
+  "redeemer": {
+    "title": "_redeemer",
+    "schema": {
+      "$ref": "#/definitions/OuterMap"
+    }
+  },
+  "compiledCode": "<redacted>",
+  "hash": "<redacted>",
+  "definitions": {
+    "Bool": {
+      "title": "Bool",
+      "anyOf": [
+        {
+          "title": "False",
+          "dataType": "constructor",
+          "index": 0,
+          "fields": []
+        },
+        {
+          "title": "True",
+          "dataType": "constructor",
+          "index": 1,
+          "fields": []
+        }
+      ]
+    },
+    "InnerMap": {
+      "title": "InnerMap",
+      "dataType": "map",
+      "keys": {
+        "$ref": "#/definitions/Int"
+      },
+      "values": {
+        "$ref": "#/definitions/Bool"
+      }
+    },
+    "Int": {
+      "dataType": "integer"
+    },
+    "OuterMap": {
+      "title": "OuterMap",
+      "dataType": "map",
+      "keys": {
+        "$ref": "#/definitions/Int"
+      },
+      "values": {
+        "$ref": "#/definitions/InnerMap"
+      }
+    },
+    "Void": {
+      "title": "Unit",
+      "anyOf": [
+        {
+          "dataType": "constructor",
+          "index": 0,
+          "fields": []
+        }
+      ]
+    }
+  }
+}

--- a/crates/aiken-project/src/blueprint/snapshots/aiken_project__blueprint__validator__tests__pair_in_pair.snap
+++ b/crates/aiken-project/src/blueprint/snapshots/aiken_project__blueprint__validator__tests__pair_in_pair.snap
@@ -1,0 +1,72 @@
+---
+source: crates/aiken-project/src/blueprint/validator.rs
+description: "Code:\n\npub type MyPair =\n  Pair<Int, InnerPair>\n\npub type InnerPair =\n    Pair<Int, Bool>\n\nvalidator placeholder {\n  spend(_datum: Option<Void>, _redeemer: List<MyPair>, _utxo: Data, _self: Data,) {\n    True\n  }\n}\n"
+---
+{
+  "title": "test_module.placeholder.spend",
+  "datum": {
+    "title": "_datum",
+    "schema": {
+      "$ref": "#/definitions/Void"
+    }
+  },
+  "redeemer": {
+    "title": "_redeemer",
+    "schema": {
+      "$ref": "#/definitions/List$MyPair"
+    }
+  },
+  "compiledCode": "<redacted>",
+  "hash": "<redacted>",
+  "definitions": {
+    "Bool": {
+      "title": "Bool",
+      "anyOf": [
+        {
+          "title": "False",
+          "dataType": "constructor",
+          "index": 0,
+          "fields": []
+        },
+        {
+          "title": "True",
+          "dataType": "constructor",
+          "index": 1,
+          "fields": []
+        }
+      ]
+    },
+    "InnerPair": {
+      "title": "InnerPair",
+      "dataType": "#pair",
+      "left": {
+        "$ref": "#/definitions/Int"
+      },
+      "right": {
+        "$ref": "#/definitions/Bool"
+      }
+    },
+    "Int": {
+      "dataType": "integer"
+    },
+    "List$MyPair": {
+      "dataType": "map",
+      "keys": {
+        "$ref": "#/definitions/Int"
+      },
+      "values": {
+        "$ref": "#/definitions/InnerPair"
+      }
+    },
+    "Void": {
+      "title": "Unit",
+      "anyOf": [
+        {
+          "dataType": "constructor",
+          "index": 0,
+          "fields": []
+        }
+      ]
+    }
+  }
+}

--- a/crates/aiken-project/src/blueprint/snapshots/aiken_project__blueprint__validator__tests__pair_used_after_map.snap
+++ b/crates/aiken-project/src/blueprint/snapshots/aiken_project__blueprint__validator__tests__pair_used_after_map.snap
@@ -1,0 +1,75 @@
+---
+source: crates/aiken-project/src/blueprint/validator.rs
+description: "Code:\n\npub type MyPair =\n  Pair<Int, Int>\n\npub type MyDatum {\n  pairs: List<MyPair>,\n  pair: MyPair,\n}\n\nvalidator placeholder {\n  spend(_datum: Option<MyDatum>, _redeemer: Void, _utxo: Data, _self: Data,) {\n    True\n  }\n}\n"
+---
+{
+  "title": "test_module.placeholder.spend",
+  "datum": {
+    "title": "_datum",
+    "schema": {
+      "$ref": "#/definitions/test_module~1MyDatum"
+    }
+  },
+  "redeemer": {
+    "title": "_redeemer",
+    "schema": {
+      "$ref": "#/definitions/Void"
+    }
+  },
+  "compiledCode": "<redacted>",
+  "hash": "<redacted>",
+  "definitions": {
+    "Int": {
+      "dataType": "integer"
+    },
+    "List$MyPair": {
+      "dataType": "map",
+      "keys": {
+        "$ref": "#/definitions/Int"
+      },
+      "values": {
+        "$ref": "#/definitions/Int"
+      }
+    },
+    "MyPair": {
+      "title": "MyPair",
+      "dataType": "#pair",
+      "left": {
+        "$ref": "#/definitions/Int"
+      },
+      "right": {
+        "$ref": "#/definitions/Int"
+      }
+    },
+    "Void": {
+      "title": "Unit",
+      "anyOf": [
+        {
+          "dataType": "constructor",
+          "index": 0,
+          "fields": []
+        }
+      ]
+    },
+    "test_module/MyDatum": {
+      "title": "MyDatum",
+      "anyOf": [
+        {
+          "title": "MyDatum",
+          "dataType": "constructor",
+          "index": 0,
+          "fields": [
+            {
+              "title": "pairs",
+              "$ref": "#/definitions/List$MyPair"
+            },
+            {
+              "title": "pair",
+              "$ref": "#/definitions/MyPair"
+            }
+          ]
+        }
+      ]
+    }
+  }
+}

--- a/crates/aiken-project/src/blueprint/snapshots/aiken_project__blueprint__validator__tests__pair_used_before_map.snap
+++ b/crates/aiken-project/src/blueprint/snapshots/aiken_project__blueprint__validator__tests__pair_used_before_map.snap
@@ -1,0 +1,75 @@
+---
+source: crates/aiken-project/src/blueprint/validator.rs
+description: "Code:\n\npub type MyPair =\n  Pair<Int, Int>\n\npub type MyDatum {\n  pair: MyPair,\n  pairs: List<MyPair>,\n}\n\nvalidator placeholder {\n  spend(_datum: Option<MyDatum>, _redeemer: Void, _utxo: Data, _self: Data,) {\n    True\n  }\n}\n"
+---
+{
+  "title": "test_module.placeholder.spend",
+  "datum": {
+    "title": "_datum",
+    "schema": {
+      "$ref": "#/definitions/test_module~1MyDatum"
+    }
+  },
+  "redeemer": {
+    "title": "_redeemer",
+    "schema": {
+      "$ref": "#/definitions/Void"
+    }
+  },
+  "compiledCode": "<redacted>",
+  "hash": "<redacted>",
+  "definitions": {
+    "Int": {
+      "dataType": "integer"
+    },
+    "List$MyPair": {
+      "dataType": "map",
+      "keys": {
+        "$ref": "#/definitions/Int"
+      },
+      "values": {
+        "$ref": "#/definitions/Int"
+      }
+    },
+    "MyPair": {
+      "title": "MyPair",
+      "dataType": "#pair",
+      "left": {
+        "$ref": "#/definitions/Int"
+      },
+      "right": {
+        "$ref": "#/definitions/Int"
+      }
+    },
+    "Void": {
+      "title": "Unit",
+      "anyOf": [
+        {
+          "dataType": "constructor",
+          "index": 0,
+          "fields": []
+        }
+      ]
+    },
+    "test_module/MyDatum": {
+      "title": "MyDatum",
+      "anyOf": [
+        {
+          "title": "MyDatum",
+          "dataType": "constructor",
+          "index": 0,
+          "fields": [
+            {
+              "title": "pair",
+              "$ref": "#/definitions/MyPair"
+            },
+            {
+              "title": "pairs",
+              "$ref": "#/definitions/List$MyPair"
+            }
+          ]
+        }
+      ]
+    }
+  }
+}

--- a/crates/aiken-project/src/blueprint/validator.rs
+++ b/crates/aiken-project/src/blueprint/validator.rs
@@ -122,7 +122,7 @@ impl Validator {
                     ),
                 })
             })
-            .collect::<Result<_, _>>()?;
+            .collect::<Result<Vec<_>, _>>()?;
 
         let (datum, redeemer) = if func.name == well_known::VALIDATOR_ELSE {
             (None, None)
@@ -201,6 +201,14 @@ impl Validator {
             title: None,
             schema: Declaration::Inline(Box::new(Schema::Data(Data::Opaque))),
         }));
+
+        definitions.prune_orphan_pairs(
+            parameters
+                .iter()
+                .chain(redeemer.as_ref().map(|x| vec![x]).unwrap_or_default())
+                .chain(datum.as_ref().map(|x| vec![x]).unwrap_or_default())
+                .collect::<Vec<&Parameter>>(),
+        );
 
         Ok(Validator {
             title: format!("{}.{}.{}", &module.name, &def.name, &func.name,),
@@ -729,6 +737,67 @@ mod tests {
 
             validator recursive_types {
               spend(datum: Option<MyDatum>, redeemer: MyRedeemer<Asset>, output_reference: Data, transaction: Data) {
+                True
+              }
+            }
+            "#
+        );
+    }
+
+    #[test]
+    fn pair_used_after_map() {
+        assert_validator!(
+            r#"
+            pub type MyPair =
+              Pair<Int, Int>
+
+            pub type MyDatum {
+              pairs: List<MyPair>,
+              pair: MyPair,
+            }
+
+            validator placeholder {
+              spend(_datum: Option<MyDatum>, _redeemer: Void, _utxo: Data, _self: Data,) {
+                True
+              }
+            }
+            "#
+        );
+    }
+
+    #[test]
+    fn pair_used_before_map() {
+        assert_validator!(
+            r#"
+            pub type MyPair =
+              Pair<Int, Int>
+
+            pub type MyDatum {
+              pair: MyPair,
+              pairs: List<MyPair>,
+            }
+
+            validator placeholder {
+              spend(_datum: Option<MyDatum>, _redeemer: Void, _utxo: Data, _self: Data,) {
+                True
+              }
+            }
+            "#
+        );
+    }
+
+    #[test]
+    fn map_in_map() {
+        assert_validator!(
+            r#"
+            pub type OuterMap =
+                List<Pair<Int, InnerMap>>
+
+            pub type InnerMap =
+                List<Pair<Int, Bool>>
+
+            validator placeholder {
+              spend(_datum: Option<Void>, _redeemer: OuterMap, _utxo: Data, _self: Data,) {
                 True
               }
             }


### PR DESCRIPTION
This ensures that we only prune unnecessary schema definitions from the blueprint when they truly are unnecessary. The first commit fixes #1086, but as we discussed internally, there's another problem we should find a resolution for (which I wish to include in this PR): currently, we generate schema for pairs as `#pairs`; which translates to a UPLC Term (not serializable as Data).  

So my first reaction was to simply forbid the presence of pairs in the contract ABI, but @MicroProofs pointed that part of the validator wrapper code includes conversion from lists of 2 elements to pairs (if types require it). Which means that pairs are _technically allowed_ in the contract ABI, but serialized as Data::List of two elements. 

Hence, the generated schema should reflect that; but only when pairs are present in datums / redeemers. When present as _parameters_, they are expected to be UPLC terms.