### PR TITLE
Better Error Logging

### DIFF
--- a/crates/uplc/src/tx.rs
+++ b/crates/uplc/src/tx.rs
@@ -100,8 +100,8 @@ pub fn eval_phase_two_raw(
     with_redeemer: fn(&Redeemer) -> (),
 ) -> Result<Vec<Vec<u8>>, Error> {
     let multi_era_tx = MultiEraTx::decode_for_era(Era::Conway, tx_bytes)
-        .or_else(|_| MultiEraTx::decode_for_era(Era::Babbage, tx_bytes))
-        .or_else(|_| MultiEraTx::decode_for_era(Era::Alonzo, tx_bytes))?;
+        .or_else(|e| MultiEraTx::decode_for_era(Era::Babbage, tx_bytes).map_err(|_| e))
+        .or_else(|e| MultiEraTx::decode_for_era(Era::Alonzo, tx_bytes).map_err(|_| e))?;
 
     let cost_mdls = cost_mdls_bytes
         .map(CostModels::decode_fragment)


### PR DESCRIPTION
This PR adds updates to the `body_tx` decoding by era, so that the failing era's error get's passed down to the end result. Props to @SupernaviX for helping me through the code and debugging.