### PR TITLE
Implement Type Decorators

### DIFF
--- a/crates/aiken-lang/src/ast.rs
+++ b/crates/aiken-lang/src/ast.rs
@@ -407,6 +407,7 @@ impl From<TypedTest> for TypedFunction {
 
 #[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
 pub struct TypeAlias<T> {
+    pub decorators: Vec<Decorator>,
     pub alias: String,
     pub annotation: Annotation,
     pub doc: Option<String>,
@@ -438,6 +439,7 @@ impl TypedDataType {
 
     pub fn known_data_type(name: &str, constructors: &[RecordConstructor<Rc<Type>>]) -> Self {
         Self {
+            decorators: vec![],
             name: name.to_string(),
             constructors: constructors.to_vec(),
             location: Span::empty(),
@@ -464,7 +466,21 @@ impl TypedDataType {
 }
 
 #[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
+pub enum Decorator {
+    Tag { value: String, base: Base },
+    Len { value: String, base: Base },
+    Encoding(DecoratorEncoding),
+}
+
+#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
+pub enum DecoratorEncoding {
+    Constr,
+    List,
+}
+
+#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
 pub struct DataType<T> {
+    pub decorators: Vec<Decorator>,
     pub constructors: Vec<RecordConstructor<T>>,
     pub doc: Option<String>,
     pub location: Span,
@@ -983,6 +999,7 @@ impl CallArg<TypedPattern> {
 
 #[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
 pub struct RecordConstructor<T> {
+    pub decorators: Vec<Decorator>,
     pub location: Span,
     pub name: String,
     pub arguments: Vec<RecordConstructorArg<T>>,
@@ -1002,6 +1019,7 @@ where
         names
             .iter()
             .map(|name| RecordConstructor {
+                decorators: vec![],
                 location: Span::empty(),
                 name: name.to_string(),
                 arguments: vec![],
@@ -1013,6 +1031,7 @@ where
 
     pub fn known_record(name: &str, args: &[RecordConstructorArg<A>]) -> Self {
         RecordConstructor {
+            decorators: vec![],
             location: Span::empty(),
             name: name.to_string(),
             arguments: args.to_vec(),
@@ -1024,6 +1043,7 @@ where
 
 #[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
 pub struct RecordConstructorArg<T> {
+    pub decorators: Vec<Decorator>,
     pub label: Option<String>,
     // ast
     pub annotation: Annotation,

--- a/crates/aiken-lang/src/builtins.rs
+++ b/crates/aiken-lang/src/builtins.rs
@@ -1859,6 +1859,7 @@ impl TypedDataType {
 
     pub fn prng() -> Self {
         let bytearray_arg = |label: &str| RecordConstructorArg {
+            decorators: vec![],
             label: Some(label.to_string()),
             doc: None,
             annotation: Annotation::bytearray(Span::empty()),
@@ -1867,6 +1868,7 @@ impl TypedDataType {
         };
 
         let int_arg = |label: &str| RecordConstructorArg {
+            decorators: vec![],
             label: Some(label.to_string()),
             doc: None,
             annotation: Annotation::int(Span::empty()),
@@ -1895,11 +1897,14 @@ impl TypedDataType {
 
     pub fn option(tipo: Rc<Type>) -> Self {
         DataType {
+            decorators: vec![],
             constructors: vec![
                 RecordConstructor {
+                    decorators: vec![],
                     location: Span::empty(),
                     name: well_known::OPTION_CONSTRUCTORS[0].to_string(),
                     arguments: vec![RecordConstructorArg {
+                        decorators: vec![],
                         label: None,
                         annotation: Annotation::Var {
                             location: Span::empty(),
@@ -1913,6 +1918,7 @@ impl TypedDataType {
                     sugar: false,
                 },
                 RecordConstructor {
+                    decorators: vec![],
                     location: Span::empty(),
                     name: well_known::OPTION_CONSTRUCTORS[1].to_string(),
                     arguments: vec![],

--- a/crates/aiken-lang/src/parser/definition/data_type.rs
+++ b/crates/aiken-lang/src/parser/definition/data_type.rs
@@ -4,9 +4,37 @@ use crate::{
 };
 use chumsky::prelude::*;
 
+pub fn decorators() -> impl Parser<Token, Vec<ast::Decorator>, Error = ParseError> {
+    let tag_value = select! { Token::Int { value, base } => ast::Decorator::Tag { value, base } };
+    let len_value = select! { Token::Int { value, base } => ast::Decorator::Len { value, base } };
+    let encoding_value = select! {
+        Token::Name { name } if name == "list" => ast::DecoratorEncoding::List,
+        Token::Name { name } if name == "constr" => ast::DecoratorEncoding::Constr
+    }
+    .map(ast::Decorator::Encoding);
+
+    just(Token::At)
+        .ignore_then(choice((
+            select! { Token::Name { name } if name == "tag" => name }.ignore_then(
+                tag_value.delimited_by(just(Token::LeftParen), just(Token::RightParen)),
+            ),
+            select! { Token::Name { name } if name == "len" => name }.ignore_then(
+                len_value.delimited_by(just(Token::LeftParen), just(Token::RightParen)),
+            ),
+            select! { Token::Name { name } if name == "encoding" => name }.ignore_then(
+                encoding_value.delimited_by(just(Token::LeftParen), just(Token::RightParen)),
+            ),
+        )))
+        .repeated()
+        .or_not()
+        .map(|t| t.unwrap_or_default())
+}
+
 pub fn parser() -> impl Parser<Token, ast::UntypedDefinition, Error = ParseError> {
-    let unlabeled_constructor_type_args = annotation()
-        .map_with_span(|annotation, span| ast::RecordConstructorArg {
+    let unlabeled_constructor_type_args = decorators()
+        .then(annotation())
+        .map_with_span(|(d, annotation), span| ast::RecordConstructorArg {
+            decorators: d,
             label: None,
             annotation,
             tipo: (),
@@ -17,15 +45,11 @@ pub fn parser() -> impl Parser<Token, ast::UntypedDefinition, Error = ParseError
         .allow_trailing()
         .delimited_by(just(Token::LeftParen), just(Token::RightParen));
 
-    let constructors = select! {Token::UpName { name } => name}
-        .then(
-            choice((
-                labeled_constructor_type_args(),
-                unlabeled_constructor_type_args,
-            ))
-            .or_not(),
-        )
-        .map_with_span(|(name, arguments), span| ast::RecordConstructor {
+    let constructors = decorators()
+        .then(select! {Token::UpName { name } => name})
+        .then(choice((labeled_args(), unlabeled_constructor_type_args)).or_not())
+        .map_with_span(|((d, name), arguments), span| ast::RecordConstructor {
+            decorators: d,
             location: span,
             arguments: arguments.unwrap_or_default(),
             name,
@@ -35,8 +59,9 @@ pub fn parser() -> impl Parser<Token, ast::UntypedDefinition, Error = ParseError
         .repeated()
         .delimited_by(just(Token::LeftBrace), just(Token::RightBrace));
 
-    let record_sugar = labeled_constructor_type_args().map_with_span(|arguments, span| {
+    let record_sugar = labeled_args().map_with_span(|arguments, span| {
         vec![ast::RecordConstructor {
+            decorators: vec![],
             location: span,
             arguments,
             doc: None,
@@ -45,16 +70,19 @@ pub fn parser() -> impl Parser<Token, ast::UntypedDefinition, Error = ParseError
         }]
     });
 
-    utils::optional_flag(Token::Pub)
+    decorators()
+        .then(utils::optional_flag(Token::Pub))
         .then(utils::optional_flag(Token::Opaque))
         .then(utils::type_name_with_args())
         .then(choice((constructors, record_sugar)))
         .map_with_span(
-            |(((public, opaque), (name, parameters)), constructors), span| {
+            |((((d, public), opaque), (name, parameters)), constructors), span| {
                 ast::UntypedDefinition::DataType(ast::DataType {
+                    decorators: d.clone(),
                     location: span,
                     constructors: if constructors.is_empty() {
                         vec![ast::RecordConstructor {
+                            decorators: d,
                             location: span,
                             arguments: vec![],
                             doc: None,
@@ -67,6 +95,7 @@ pub fn parser() -> impl Parser<Token, ast::UntypedDefinition, Error = ParseError
                             .map(|mut constructor| {
                                 if constructor.sugar {
                                     constructor.name.clone_from(&name);
+                                    constructor.decorators = d.clone();
                                 }
 
                                 constructor
@@ -84,12 +113,13 @@ pub fn parser() -> impl Parser<Token, ast::UntypedDefinition, Error = ParseError
         )
 }
 
-fn labeled_constructor_type_args(
-) -> impl Parser<Token, Vec<ast::RecordConstructorArg<()>>, Error = ParseError> {
-    select! {Token::Name {name} => name}
+fn labeled_args() -> impl Parser<Token, Vec<ast::RecordConstructorArg<()>>, Error = ParseError> {
+    decorators()
+        .then(select! {Token::Name {name} => name})
         .then_ignore(just(Token::Colon))
         .then(annotation())
-        .map_with_span(|(name, annotation), span| ast::RecordConstructorArg {
+        .map_with_span(|((d, name), annotation), span| ast::RecordConstructorArg {
+            decorators: d,
             label: Some(name),
             annotation,
             tipo: (),
@@ -145,6 +175,52 @@ mod tests {
         assert_definition!(
             r#"
             pub type Foo {
+            }
+            "#
+        );
+    }
+
+    #[test]
+    fn decorators_record_and_fields() {
+        assert_definition!(
+            r#"
+            @tag(12)
+            pub type User {
+              @len(32)
+              name: ByteArray
+            }
+            "#
+        );
+    }
+
+    #[test]
+    fn decorators_record_encoding() {
+        assert_definition!(
+            r#"
+            @encoding(list)
+            pub type Thing {
+              name: ByteArray
+            }
+            "#
+        );
+    }
+
+    #[test]
+    fn decorators_enum() {
+        assert_definition!(
+            r#"
+            pub type L2Datum {
+              @tag(117)
+              Inactive
+
+              @tag(118)
+              BatchTxs(List<ByteArray>)
+
+              @tag(1170)
+              Committed(Bool, List<ByteArray>)
+
+              @tag(1171)
+              Withdrawn(Bool, @len(32) ByteArray)
             }
             "#
         );

--- a/crates/aiken-lang/src/parser/definition/snapshots/decorators_enum.snap
+++ b/crates/aiken-lang/src/parser/definition/snapshots/decorators_enum.snap
@@ -1,0 +1,167 @@
+---
+source: crates/aiken-lang/src/parser/definition/data_type.rs
+description: "Code:\n\npub type L2Datum {\n  @tag(117)\n  Inactive\n\n  @tag(118)\n  BatchTxs(List<ByteArray>)\n\n  @tag(1170)\n  Committed(Bool, List<ByteArray>)\n\n  @tag(1171)\n  Withdrawn(Bool, @len(32) ByteArray)\n}\n"
+---
+DataType(
+    DataType {
+        decorators: [],
+        constructors: [
+            RecordConstructor {
+                decorators: [
+                    Tag {
+                        value: "117",
+                        base: Decimal {
+                            numeric_underscore: false,
+                        },
+                    },
+                ],
+                location: 21..41,
+                name: "Inactive",
+                arguments: [],
+                doc: None,
+                sugar: false,
+            },
+            RecordConstructor {
+                decorators: [
+                    Tag {
+                        value: "118",
+                        base: Decimal {
+                            numeric_underscore: false,
+                        },
+                    },
+                ],
+                location: 45..82,
+                name: "BatchTxs",
+                arguments: [
+                    RecordConstructorArg {
+                        decorators: [],
+                        label: None,
+                        annotation: Constructor {
+                            location: 66..81,
+                            module: None,
+                            name: "List",
+                            arguments: [
+                                Constructor {
+                                    location: 71..80,
+                                    module: None,
+                                    name: "ByteArray",
+                                    arguments: [],
+                                },
+                            ],
+                        },
+                        location: 66..81,
+                        tipo: (),
+                        doc: None,
+                    },
+                ],
+                doc: None,
+                sugar: false,
+            },
+            RecordConstructor {
+                decorators: [
+                    Tag {
+                        value: "1170",
+                        base: Decimal {
+                            numeric_underscore: false,
+                        },
+                    },
+                ],
+                location: 86..131,
+                name: "Committed",
+                arguments: [
+                    RecordConstructorArg {
+                        decorators: [],
+                        label: None,
+                        annotation: Constructor {
+                            location: 109..113,
+                            module: None,
+                            name: "Bool",
+                            arguments: [],
+                        },
+                        location: 109..113,
+                        tipo: (),
+                        doc: None,
+                    },
+                    RecordConstructorArg {
+                        decorators: [],
+                        label: None,
+                        annotation: Constructor {
+                            location: 115..130,
+                            module: None,
+                            name: "List",
+                            arguments: [
+                                Constructor {
+                                    location: 120..129,
+                                    module: None,
+                                    name: "ByteArray",
+                                    arguments: [],
+                                },
+                            ],
+                        },
+                        location: 115..130,
+                        tipo: (),
+                        doc: None,
+                    },
+                ],
+                doc: None,
+                sugar: false,
+            },
+            RecordConstructor {
+                decorators: [
+                    Tag {
+                        value: "1171",
+                        base: Decimal {
+                            numeric_underscore: false,
+                        },
+                    },
+                ],
+                location: 135..183,
+                name: "Withdrawn",
+                arguments: [
+                    RecordConstructorArg {
+                        decorators: [],
+                        label: None,
+                        annotation: Constructor {
+                            location: 158..162,
+                            module: None,
+                            name: "Bool",
+                            arguments: [],
+                        },
+                        location: 158..162,
+                        tipo: (),
+                        doc: None,
+                    },
+                    RecordConstructorArg {
+                        decorators: [
+                            Len {
+                                value: "32",
+                                base: Decimal {
+                                    numeric_underscore: false,
+                                },
+                            },
+                        ],
+                        label: None,
+                        annotation: Constructor {
+                            location: 173..182,
+                            module: None,
+                            name: "ByteArray",
+                            arguments: [],
+                        },
+                        location: 164..182,
+                        tipo: (),
+                        doc: None,
+                    },
+                ],
+                doc: None,
+                sugar: false,
+            },
+        ],
+        doc: None,
+        location: 0..185,
+        name: "L2Datum",
+        opaque: false,
+        parameters: [],
+        public: true,
+        typed_parameters: [],
+    },
+)

--- a/crates/aiken-lang/src/parser/definition/snapshots/decorators_record_and_fields.snap
+++ b/crates/aiken-lang/src/parser/definition/snapshots/decorators_record_and_fields.snap
@@ -1,0 +1,63 @@
+---
+source: crates/aiken-lang/src/parser/definition/data_type.rs
+description: "Code:\n\n@tag(12)\npub type User {\n  @len(32)\n  name: ByteArray\n}\n"
+---
+DataType(
+    DataType {
+        decorators: [
+            Tag {
+                value: "12",
+                base: Decimal {
+                    numeric_underscore: false,
+                },
+            },
+        ],
+        constructors: [
+            RecordConstructor {
+                decorators: [
+                    Tag {
+                        value: "12",
+                        base: Decimal {
+                            numeric_underscore: false,
+                        },
+                    },
+                ],
+                location: 23..55,
+                name: "User",
+                arguments: [
+                    RecordConstructorArg {
+                        decorators: [
+                            Len {
+                                value: "32",
+                                base: Decimal {
+                                    numeric_underscore: false,
+                                },
+                            },
+                        ],
+                        label: Some(
+                            "name",
+                        ),
+                        annotation: Constructor {
+                            location: 44..53,
+                            module: None,
+                            name: "ByteArray",
+                            arguments: [],
+                        },
+                        location: 27..53,
+                        tipo: (),
+                        doc: None,
+                    },
+                ],
+                doc: None,
+                sugar: true,
+            },
+        ],
+        doc: None,
+        location: 0..55,
+        name: "User",
+        opaque: false,
+        parameters: [],
+        public: true,
+        typed_parameters: [],
+    },
+)

--- a/crates/aiken-lang/src/parser/definition/snapshots/decorators_record_encoding.snap
+++ b/crates/aiken-lang/src/parser/definition/snapshots/decorators_record_encoding.snap
@@ -1,0 +1,50 @@
+---
+source: crates/aiken-lang/src/parser/definition/data_type.rs
+description: "Code:\n\n@encoding(list)\npub type Thing {\n  name: ByteArray\n}\n"
+---
+DataType(
+    DataType {
+        decorators: [
+            Encoding(
+                List,
+            ),
+        ],
+        constructors: [
+            RecordConstructor {
+                decorators: [
+                    Encoding(
+                        List,
+                    ),
+                ],
+                location: 31..52,
+                name: "Thing",
+                arguments: [
+                    RecordConstructorArg {
+                        decorators: [],
+                        label: Some(
+                            "name",
+                        ),
+                        annotation: Constructor {
+                            location: 41..50,
+                            module: None,
+                            name: "ByteArray",
+                            arguments: [],
+                        },
+                        location: 35..50,
+                        tipo: (),
+                        doc: None,
+                    },
+                ],
+                doc: None,
+                sugar: true,
+            },
+        ],
+        doc: None,
+        location: 0..52,
+        name: "Thing",
+        opaque: false,
+        parameters: [],
+        public: true,
+        typed_parameters: [],
+    },
+)

--- a/crates/aiken-lang/src/parser/definition/type_alias.rs
+++ b/crates/aiken-lang/src/parser/definition/type_alias.rs
@@ -5,13 +5,17 @@ use crate::{
     parser::{annotation, error::ParseError, token::Token, utils},
 };
 
+use super::data_type::decorators;
+
 pub fn parser() -> impl Parser<Token, ast::UntypedDefinition, Error = ParseError> {
-    utils::optional_flag(Token::Pub)
+    decorators()
+        .then(utils::optional_flag(Token::Pub))
         .then(utils::type_name_with_args())
         .then_ignore(just(Token::Equal))
         .then(annotation())
-        .map_with_span(|((public, (alias, parameters)), annotation), span| {
+        .map_with_span(|(((d, public), (alias, parameters)), annotation), span| {
             ast::UntypedDefinition::TypeAlias(ast::TypeAlias {
+                decorators: d,
                 alias,
                 annotation,
                 doc: None,

--- a/crates/aiken-lang/src/parser/lexer.rs
+++ b/crates/aiken-lang/src/parser/lexer.rs
@@ -299,7 +299,15 @@ pub fn lexer() -> impl Parser<char, Vec<(Token, Span)>, Error = ParseError> {
         comment_parser(Token::DocComment),
         comment_parser(Token::Comment),
         choice((
-            ordinal, keyword, int, op, newlines, grouping, bytestring, string,
+            ordinal,
+            keyword,
+            int,
+            op,
+            newlines,
+            grouping,
+            bytestring,
+            string,
+            just('@').to(Token::At),
         ))
         .or(any().map(Token::Error).validate(|t, span, emit| {
             emit(ParseError::expected_input_found(

--- a/crates/aiken-lang/src/parser/token.rs
+++ b/crates/aiken-lang/src/parser/token.rs
@@ -50,6 +50,7 @@ pub enum Token {
     Hash,     // '#'
     Bang,     // '!'
     Question, // '?'
+    At,       // '@'
     Equal,
     EqualEqual,  // '=='
     NotEqual,    // '!='
@@ -144,6 +145,7 @@ impl fmt::Display for Token {
             Token::Bang => "!",
             Token::Equal => "=",
             Token::Question => "?",
+            Token::At => "@",
             Token::EqualEqual => "==",
             Token::NotEqual => "!=",
             Token::Vbar => "|",

--- a/crates/aiken-lang/src/tipo/environment.rs
+++ b/crates/aiken-lang/src/tipo/environment.rs
@@ -1092,6 +1092,7 @@ impl<'a> Environment<'a> {
                 parameters,
                 location,
                 constructors,
+                decorators,
                 doc: _,
                 typed_parameters: _,
             }) => {
@@ -1137,6 +1138,7 @@ impl<'a> Environment<'a> {
             Definition::TypeAlias(TypeAlias {
                 location,
                 public,
+                decorators,
                 parameters: args,
                 alias: name,
                 annotation: resolved_type,
@@ -1436,6 +1438,7 @@ impl<'a> Environment<'a> {
                 location: _,
                 parameters: _,
                 typed_parameters: _,
+                decorators: _,
             }) => {
                 let mut hydrator = hydrators
                     .remove(name)
@@ -1480,6 +1483,7 @@ impl<'a> Environment<'a> {
                             location,
                             tipo: _,
                             doc: _,
+                            decorators: _,
                         },
                     ) in constructor.arguments.iter().enumerate()
                     {

--- a/crates/aiken-lang/src/tipo/infer.rs
+++ b/crates/aiken-lang/src/tipo/infer.rs
@@ -467,6 +467,7 @@ fn infer_definition(
             alias,
             parameters,
             annotation,
+            decorators,
             tipo: _,
         }) => {
             let tipo = environment
@@ -475,6 +476,8 @@ fn infer_definition(
                 .tipo
                 .clone();
 
+            todo!("check decorators");
+
             Ok(Definition::TypeAlias(TypeAlias {
                 doc,
                 location,
@@ -482,6 +485,7 @@ fn infer_definition(
                 alias,
                 parameters,
                 annotation,
+                decorators,
                 tipo,
             }))
         }
@@ -493,9 +497,12 @@ fn infer_definition(
             opaque,
             name,
             parameters,
+            decorators,
             constructors: untyped_constructors,
             typed_parameters: _,
         }) => {
+            todo!("check decorators");
+
             let constructors = untyped_constructors
                 .into_iter()
                 .map(|constructor| {
@@ -504,6 +511,8 @@ fn infer_definition(
                         .expect("Could not find preregistered type for function");
 
                     let preregistered_type = preregistered_fn.tipo.clone();
+
+                    todo!("check decorators");
 
                     let args = preregistered_type.function_types().map_or(
                         Ok(vec![]),
@@ -533,7 +542,10 @@ fn infer_definition(
                                         Rc::make_mut(&mut parent.tipo).set_opaque(true)
                                     }
 
+                                    todo!("check decorators");
+
                                     Ok(RecordConstructorArg {
+                                        decorators: arg.decorators,
                                         label: arg.label,
                                         annotation: arg.annotation,
                                         location: arg.location,
@@ -549,6 +561,7 @@ fn infer_definition(
                         location: constructor.location,
                         name: constructor.name,
                         arguments: args,
+                        decorators: constructor.decorators,
                         doc: constructor.doc,
                         sugar: constructor.sugar,
                     })
@@ -569,6 +582,7 @@ fn infer_definition(
                 name,
                 parameters,
                 constructors,
+                decorators,
                 typed_parameters,
             };
 
@@ -579,6 +593,7 @@ fn infer_definition(
                     doc: _,
                     label: _,
                     annotation: _,
+                    decorators: _,
                 } in &constr.arguments
                 {
                     if tipo.is_function() {


### PR DESCRIPTION
For a while now people have been asking for a way to modify certain aspects of their types. Some examples include controlling the underlying `Constr` tag for type constructors or enforcing that a `ByteArray` field is of a specific length.

We also plan on supporting `encoding` such that you can ask for a type to be treated as a `PlutusData::List` instead of a `Constr`. But code gen support for this will come later.

There are certain rules that will be enforced during typechecking like which tags can combine with which and whether or not they are being used improperly. The parser is left fairly liberal in this regard, it just accumulates as many tags as it sees and assumes the type checker will sort out what is right or wrong to use where.

Ex:

### Custom tags

```
pub type Thing {
  @tag(420)
  Yes
  @tag(69)
  No
}
```

### Enforcing Length

```
pub Wow {
  @len(32)
  address: ByteArray
}
```