### PR TITLE
Return an EvalResult alongside the redeemer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## unreleased - 2025-MM-DD
+
+### Changed
+
+- **uplc**: `eval_phase_two` and related functions now return an EvalResult @Quantumplation
+
+  In order to allow consuming tools provide better tooling experiences, the various `eval_phase_two`
+  functions provide an `EvalResult`, which includes the final term, the remaining budget, and the traces.
+  This means you can display or work with the traces of a script even if it succeeds.
+
 ## v1.1.11 - 2025-02-11
 
 ### Added

--- a/crates/aiken-lang/src/test_framework.rs
+++ b/crates/aiken-lang/src/test_framework.rs
@@ -222,7 +222,7 @@ unsafe impl Send for UnitTest {}
 
 impl UnitTest {
     pub fn run(self, plutus_version: &PlutusVersion) -> UnitTestResult<(Constant, Rc<Type>)> {
-        let mut eval_result = Program::<NamedDeBruijn>::try_from(self.program.clone())
+        let eval_result = Program::<NamedDeBruijn>::try_from(self.program.clone())
             .unwrap()
             .eval_version(ExBudget::max(), &plutus_version.into());
 
@@ -384,7 +384,7 @@ impl PropertyTest {
             .sample(&self.fuzzer.program)?
             .expect("A seeded PRNG returned 'None' which indicates a fuzzer is ill-formed and implemented wrongly; please contact library's authors.");
 
-        let mut result = self.eval(&value, plutus_version);
+        let result = self.eval(&value, plutus_version);
 
         for label in result.labels() {
             // NOTE: There may be other log outputs that interefere with labels. So *by
@@ -536,7 +536,7 @@ impl Benchmark {
 
                 Ok(Some((new_prng, value))) => {
                     prng = new_prng;
-                    let mut result = self.eval(&value, plutus_version);
+                    let result = self.eval(&value, plutus_version);
                     match result.result() {
                         Ok(_) => measures.push((size, result.cost())),
                         Err(uplc_error) => {
@@ -664,7 +664,7 @@ impl Prng {
         fuzzer: &Program<Name>,
     ) -> Result<Option<(Prng, PlutusData)>, FuzzerError> {
         let program = Program::<NamedDeBruijn>::try_from(fuzzer.apply_data(self.uplc())).unwrap();
-        let mut result = program.eval(ExBudget::max());
+        let result = program.eval(ExBudget::max());
         result
             .result()
             .map_err(|uplc_error| FuzzerError {

--- a/crates/aiken-lang/src/test_framework.rs
+++ b/crates/aiken-lang/src/test_framework.rs
@@ -338,16 +338,11 @@ impl PropertyTest {
         ) {
             Ok(None) => (Vec::new(), Ok(None), n),
             Ok(Some(counterexample)) => (
-                self.eval(&counterexample.value, plutus_version)
-                    .logs(),
+                self.eval(&counterexample.value, plutus_version).logs(),
                 Ok(Some(counterexample.value)),
                 n - remaining,
             ),
-            Err(FuzzerError { logs, uplc_error }) => (
-                logs,
-                Err(uplc_error),
-                n - remaining + 1,
-            ),
+            Err(FuzzerError { logs, uplc_error }) => (logs, Err(uplc_error), n - remaining + 1),
         };
 
         PropertyTestResult {
@@ -495,8 +490,9 @@ pub enum BenchmarkError {
 impl BenchmarkError {
     pub fn logs(&self) -> &[String] {
         match self {
-            BenchmarkError::SamplerError { logs, .. }
-            | BenchmarkError::BenchError { logs, .. } => logs.as_slice(),
+            BenchmarkError::SamplerError { logs, .. } | BenchmarkError::BenchError { logs, .. } => {
+                logs.as_slice()
+            }
         }
     }
 }

--- a/crates/aiken-project/src/telemetry/json.rs
+++ b/crates/aiken-project/src/telemetry/json.rs
@@ -129,8 +129,8 @@ fn fmt_test_json(result: &TestResult<UntypedExpr, UntypedExpr>) -> serde_json::V
         TestResult::BenchmarkResult(_) => unreachable!("benchmark returned in JSON output"),
     }
 
-    if !result.traces().is_empty() {
-        test["traces"] = json!(result.traces());
+    if !result.logs().is_empty() {
+        test["traces"] = json!(result.logs());
     }
 
     test

--- a/crates/aiken-project/src/telemetry/terminal.rs
+++ b/crates/aiken-project/src/telemetry/terminal.rs
@@ -584,12 +584,12 @@ fn fmt_test(
     }
 
     // Traces
-    if !result.traces().is_empty() {
+    if !result.logs().is_empty() {
         test = format!(
             "{test}\n{title}\n{traces}",
             title = "· with traces".if_supports_color(Stderr, |s| s.bold()),
             traces = result
-                .traces()
+                .logs()
                 .iter()
                 .map(|line| { format!("| {line}",) })
                 .collect::<Vec<_>>()

--- a/crates/aiken-project/src/tests/gen_uplc.rs
+++ b/crates/aiken-project/src/tests/gen_uplc.rs
@@ -78,7 +78,7 @@ fn assert_uplc(source_code: &str, expected: Term<Name>, should_fail: bool, verbo
                 pretty_expected,
             );
 
-            let mut eval = debruijn_program.eval(ExBudget::default());
+            let eval = debruijn_program.eval(ExBudget::default());
 
             assert_eq!(
                 eval.failed(false),

--- a/crates/aiken/src/cmd/tx/simulate.rs
+++ b/crates/aiken/src/cmd/tx/simulate.rs
@@ -137,7 +137,7 @@ pub fn exec(
                 // this should allow N scripts to be
                 let total_budget_used: Vec<ExBudget> = redeemers
                     .iter()
-                    .map(|curr| ExBudget {
+                    .map(|(curr, _)| ExBudget {
                         mem: curr.ex_units.mem as i64,
                         cpu: curr.ex_units.steps as i64,
                     })

--- a/crates/aiken/src/cmd/uplc/eval.rs
+++ b/crates/aiken/src/cmd/uplc/eval.rs
@@ -77,7 +77,7 @@ pub fn exec(
 
     let program = Program::<NamedDeBruijn>::try_from(program).into_diagnostic()?;
 
-    let mut eval_result = if debug {
+    let eval_result = if debug {
         program.eval_debug(ExBudget::default(), &Language::PlutusV3)
     } else {
         program.eval(budget)

--- a/crates/uplc/src/ast.rs
+++ b/crates/uplc/src/ast.rs
@@ -856,7 +856,7 @@ impl Program<NamedDeBruijn> {
             term,
             machine.ex_budget,
             initial_budget,
-            machine.logs,
+            machine.traces,
             machine.spend_counter.map(|i| i.into()),
         )
     }
@@ -871,7 +871,7 @@ impl Program<NamedDeBruijn> {
             term,
             machine.ex_budget,
             initial_budget,
-            machine.logs,
+            machine.traces,
             machine.spend_counter.map(|i| i.into()),
         )
     }
@@ -897,7 +897,7 @@ impl Program<NamedDeBruijn> {
             term,
             machine.ex_budget,
             budget,
-            machine.logs,
+            machine.traces,
             machine.spend_counter.map(|i| i.into()),
         )
     }
@@ -916,7 +916,7 @@ impl Program<NamedDeBruijn> {
             term,
             machine.ex_budget,
             initial_budget,
-            machine.logs,
+            machine.traces,
             machine.spend_counter.map(|i| i.into()),
         )
     }

--- a/crates/uplc/src/machine.rs
+++ b/crates/uplc/src/machine.rs
@@ -1,4 +1,4 @@
-use std::rc::Rc;
+use std::{fmt::Display, rc::Rc};
 
 use crate::ast::{Constant, NamedDeBruijn, Term, Type};
 
@@ -51,14 +51,16 @@ pub enum Trace {
     Label(String),
 }
 
-impl Trace {
-    pub fn to_string(&self) -> String {
+impl Display for Trace {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            Trace::Log(log) => log.clone(),
-            Trace::Label(label) => label.clone(),
+            Trace::Log(log) => f.write_str(log),
+            Trace::Label(label) => f.write_str(label),
         }
     }
+}
 
+impl Trace {
     pub fn unwrap_log(self) -> Option<String> {
         match self {
             Trace::Log(log) => Some(log),

--- a/crates/uplc/src/machine/eval_result.rs
+++ b/crates/uplc/src/machine/eval_result.rs
@@ -3,11 +3,11 @@ use crate::ast::{Constant, NamedDeBruijn, Term};
 
 #[derive(Debug)]
 pub struct EvalResult {
-    result: Result<Term<NamedDeBruijn>, Error>,
-    remaining_budget: ExBudget,
-    initial_budget: ExBudget,
-    traces: Vec<Trace>,
-    debug_cost: Option<Vec<i64>>,
+    pub result: Result<Term<NamedDeBruijn>, Error>,
+    pub remaining_budget: ExBudget,
+    pub initial_budget: ExBudget,
+    pub traces: Vec<Trace>,
+    pub debug_cost: Option<Vec<i64>>,
 }
 
 impl EvalResult {

--- a/crates/uplc/src/machine/eval_result.rs
+++ b/crates/uplc/src/machine/eval_result.rs
@@ -31,20 +31,22 @@ impl EvalResult {
         self.initial_budget - self.remaining_budget
     }
 
-    pub fn traces(&mut self) -> Vec<Trace> {
-        std::mem::take(&mut self.traces)
+    pub fn traces(&self) -> Vec<Trace> {
+        self.traces.clone()
     }
 
-    pub fn logs(&mut self) -> Vec<String> {
-        std::mem::take(&mut self.traces)
-            .into_iter()
+    pub fn logs(&self) -> Vec<String> {
+        self.traces
+            .iter()
+            .cloned()
             .filter_map(Trace::unwrap_log)
             .collect()
     }
 
-    pub fn labels(&mut self) -> Vec<String> {
-        std::mem::take(&mut self.traces)
-            .into_iter()
+    pub fn labels(&self) -> Vec<String> {
+        self.traces
+            .iter()
+            .cloned()
             .filter_map(Trace::unwrap_label)
             .collect()
     }

--- a/crates/uplc/src/machine/runtime.rs
+++ b/crates/uplc/src/machine/runtime.rs
@@ -1,5 +1,7 @@
 use super::{
-    cost_model::{BuiltinCosts, ExBudget}, value::{from_pallas_bigint, to_pallas_bigint}, Error, Trace, Value
+    cost_model::{BuiltinCosts, ExBudget},
+    value::{from_pallas_bigint, to_pallas_bigint},
+    Error, Trace, Value,
 };
 use crate::{
     ast::{Constant, Data, Type},

--- a/crates/uplc/src/tx/error.rs
+++ b/crates/uplc/src/tx/error.rs
@@ -1,5 +1,5 @@
 use crate::{
-    machine::{self, cost_model::ExBudget},
+    machine::{self, cost_model::ExBudget, Trace},
     TransactionInput,
 };
 use pallas_primitives::conway::Language;
@@ -15,6 +15,7 @@ pub enum Error {
     #[error("{0}")]
     FragmentDecode(#[from] pallas_primitives::Error),
     #[error("{}{}", .0, .2.iter()
+        .map(|trace| trace.to_string())
         .map(|trace| {
             format!(
                 "\n{:>13} {}",
@@ -42,7 +43,7 @@ pub enum Error {
         .join("")
         .as_str()
     )]
-    Machine(machine::Error, ExBudget, Vec<String>),
+    Machine(machine::Error, ExBudget, Vec<Trace>),
 
     #[error("native script can't be executed in phase-two")]
     NativeScriptPhaseTwo,

--- a/crates/uplc/src/tx/eval.rs
+++ b/crates/uplc/src/tx/eval.rs
@@ -49,7 +49,7 @@ pub fn eval_redeemer(
             ScriptContext::V3 { .. } => program.apply_data(script_context.to_plutus_data()),
         };
 
-        let mut eval_result = if let Some(costs) = cost_mdl_opt {
+        let eval_result = if let Some(costs) = cost_mdl_opt {
             program.eval_as(lang, costs, Some(initial_budget))
         } else {
             program.eval_version(ExBudget::default(), lang)

--- a/crates/uplc/src/tx/tests.rs
+++ b/crates/uplc/src/tx/tests.rs
@@ -254,7 +254,7 @@ fn test_eval_0() {
 
             let total_budget_used: Vec<ExBudget> = redeemers
                 .iter()
-                .map(|curr| ExBudget {
+                .map(|(curr, _)| ExBudget {
                     mem: curr.ex_units.mem as i64,
                     cpu: curr.ex_units.steps as i64,
                 })
@@ -527,7 +527,7 @@ fn test_eval_1() {
 
             let total_budget_used: Vec<ExBudget> = redeemers
                 .iter()
-                .map(|curr| ExBudget {
+                .map(|(curr, _)| ExBudget {
                     mem: curr.ex_units.mem as i64,
                     cpu: curr.ex_units.steps as i64,
                 })
@@ -638,7 +638,7 @@ fn test_eval_2() {
 
             let total_budget_used: Vec<ExBudget> = redeemers
                 .iter()
-                .map(|curr| ExBudget {
+                .map(|(curr, _)| ExBudget {
                     mem: curr.ex_units.mem as i64,
                     cpu: curr.ex_units.steps as i64,
                 })
@@ -908,7 +908,7 @@ fn test_eval_3() {
 
             let total_budget_used: Vec<ExBudget> = redeemers
                 .iter()
-                .map(|curr| ExBudget {
+                .map(|(curr, _)| ExBudget {
                     mem: curr.ex_units.mem as i64,
                     cpu: curr.ex_units.steps as i64,
                 })
@@ -1101,7 +1101,7 @@ fn test_eval_5() {
 
             let total_budget_used: Vec<ExBudget> = redeemers
                 .iter()
-                .map(|curr| ExBudget {
+                .map(|(curr, _)| ExBudget {
                     mem: curr.ex_units.mem as i64,
                     cpu: curr.ex_units.steps as i64,
                 })
@@ -1211,7 +1211,7 @@ fn test_eval_6() {
 
             let total_budget_used: Vec<ExBudget> = redeemers
                 .iter()
-                .map(|curr| ExBudget {
+                .map(|(curr, _)| ExBudget {
                     mem: curr.ex_units.mem as i64,
                     cpu: curr.ex_units.steps as i64,
                 })
@@ -1321,7 +1321,7 @@ fn test_eval_7() {
 
             let total_budget_used: Vec<ExBudget> = redeemers
                 .iter()
-                .map(|curr| ExBudget {
+                .map(|(curr, _)| ExBudget {
                     mem: curr.ex_units.mem as i64,
                     cpu: curr.ex_units.steps as i64,
                 })
@@ -1582,7 +1582,7 @@ fn test_eval_8() {
 
             let total_budget_used: Vec<ExBudget> = redeemers
                 .iter()
-                .map(|curr| ExBudget {
+                .map(|(curr, _)| ExBudget {
                     mem: curr.ex_units.mem as i64,
                     cpu: curr.ex_units.steps as i64,
                 })


### PR DESCRIPTION
This refactors things so that eval_phase_two can expose logs even when the script succeeds.

It also enriches traces to be either Logs or Labels, so that we can tell the difference between the two when inspecting the traces.

I was kind of changing things mechanistically, so let me know if you'd prefer anything changed!

I'm also not familiar with the changelog convention, so if someone could help me write a good changelog entry that would be helpful!