### PR TITLE
remove textplot fork for now

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -648,7 +648,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "117725a109d387c937a1533ce01b450cbde6b88abceea8473c4d7a85853cda3c"
 dependencies = [
  "lazy_static",
- "windows-sys 0.48.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1043,7 +1043,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "33d852cb9b869c2a9b3df2f71a3074817f01e1844f839a144f5fcef059a4eb5d"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2888,7 +2888,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3202,7 +3202,7 @@ dependencies = [
  "cfg-if",
  "libc",
  "psm",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3362,7 +3362,7 @@ dependencies = [
  "getrandom 0.3.1",
  "once_cell",
  "rustix",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3377,8 +3377,9 @@ dependencies = [
 
 [[package]]
 name = "textplots"
-version = "0.9.6"
-source = "git+https://github.com/aiken-lang/textplots-rs.git?rev=030ba441c2c630eb1ebd16430c724c33d3408f8d#030ba441c2c630eb1ebd16430c724c33d3408f8d"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f59b64803118dbff62f92842b3154a2c802dfd8e18660132bbcbfb141c637ae3"
 dependencies = [
  "drawille",
  "rgb",
@@ -3917,7 +3918,7 @@ version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/crates/aiken-project/Cargo.toml
+++ b/crates/aiken-project/Cargo.toml
@@ -47,7 +47,7 @@ semver = { version = "1.0.23", features = ["serde"] }
 serde = { version = "1.0.152", features = ["derive"] }
 serde_json = { version = "1.0.94", features = ["preserve_order"] }
 strip-ansi-escapes = "0.1.1"
-textplots = { git = "https://github.com/aiken-lang/textplots-rs.git", rev = "030ba441c2c630eb1ebd16430c724c33d3408f8d", version = "0.9.6" }
+textplots = "0.8.6"
 thiserror = "1.0.39"
 tokio = { version = "1.26.0", features = ["full"] }
 toml = "0.7.2"

--- a/crates/aiken-project/src/telemetry/terminal.rs
+++ b/crates/aiken-project/src/telemetry/terminal.rs
@@ -629,7 +629,8 @@ fn plot(color: &RGB8, points: Vec<(f32, f32)>, max_size: usize) -> String {
     let mut chart = Chart::new(80, 50, 1.0, max_size as f32);
     let plot = Shape::Lines(&points);
     let chart = chart.linecolorplot(&plot, *color);
-    chart.borders();
+    // TODO: reintroduce this after this is merged - https://github.com/loony-bean/textplots-rs/pull/57
+    // chart.borders();
     chart.axis();
     chart.figures();
     chart.to_string()


### PR DESCRIPTION
this puts us in a situation where releasing incremental small changes is going to require much more special care than we should have.

WE MUST do it the same every time leaning on `cargo release` and allowing things to be uploaded to crates. We should not sacrifice this status quo for minor aesthetics. The bench feature is probably not wildly used at the moment anyways.

We also do not know when the upstream changes are going to be merged for textplot and I refuse to be in this broken release state for a long period of time. Any admin should be able to blindly run `cargo release` with no hand holding.

I have commented out the `.borders` call for now and left a todo comment reminding us to reintroduce the call once the pull request is merged and the crate is updated on crates.io