### PR TITLE
new workflow to tag releases

### DIFF
--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -1,0 +1,41 @@
+name: Create Release Tag
+
+on:
+  workflow_dispatch:
+    inputs:
+      bump:
+        description: 'Version bump type (major, minor, patch)'
+        required: true
+        default: 'patch'
+        type: choice
+        options:
+          - major
+          - minor
+          - patch
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+        
+      - name: Set up Rust
+        uses: Swatinem/rust-cache@v2
+        
+      - name: Install cargo-release
+        run: cargo install cargo-release
+        
+      - name: Configure Git
+        run: |
+          git config --global user.name "GitHub Action"
+          git config --global user.email "action@github.com"
+          
+      - name: Run cargo release
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_TOKEN }}
+        run: |
+          cargo release ${{ github.event.inputs.bump }} --execute


### PR DESCRIPTION
pretty simple github action that installs cargo release and then runs it

the workflow is expected to be manually dispatched and capture what kind of `bump` to use with the cargo release command