### PR TITLE
LSP Fixes 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## v1.1.15 - UNRELEASED
+
+### Changed
+
+- **aiken-lang**: fixed `UnknownTypeConstructor` wrongly reported as `UnknownVariable` (then messing up with LSP quickfix suggestions). @KtorZ
+
 ## v1.1.14 - 2025-02-21
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## v1.1.15 - UNRELEASED
 
+### Added
+
+- **aiken-lsp**: an additional code action to use constructors or identifiers from qualified imports is now offered on missing constructor or identifier. @KtorZ
+
 ### Changed
 
 - **aiken-lang**: fixed `UnknownTypeConstructor` wrongly reported as `UnknownVariable` (then messing up with LSP quickfix suggestions). @KtorZ

--- a/crates/aiken-lang/src/tipo.rs
+++ b/crates/aiken-lang/src/tipo.rs
@@ -1357,6 +1357,10 @@ impl TypeConstructor {
             public: true,
         }
     }
+
+    pub fn might_be(name: &str) -> bool {
+        name.chars().next().unwrap().is_uppercase()
+    }
 }
 
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]

--- a/crates/aiken-lang/src/tipo/error.rs
+++ b/crates/aiken-lang/src/tipo/error.rs
@@ -898,7 +898,7 @@ Perhaps, try the following:
     #[diagnostic(code("unknown::type_constructor"))]
     #[diagnostic(help(
         "{}",
-        suggest_neighbor(name, constructors.iter(), "Did you forget to import it?")
+        suggest_neighbor(name, constructors.iter(), &suggest_import_constructor())
     ))]
     UnknownTypeConstructor {
         #[label("unknown constructor")]
@@ -1527,29 +1527,23 @@ fn suggest_import_constructor() -> String {
 
            Data-type constructors are not automatically imported, even if their type is imported. So, if a module 'aiken/pet' defines the following type:
 
-             ┍━ aiken/pet.ak ━━━━━━━━
-             │ {keyword_pub} {keyword_type} {type_Pet} {{
-             │   {variant_Cat}
-             │   {variant_Dog}
-             │ }}
+             ┍━ aiken/pet.ak ━    ==>   ┍━ foo.ak ━━━━━━━━━━━━━━━━
+             │ {keyword_pub} {keyword_type} {type_Pet} {{           │ {keyword_use} aiken/pet.{{{type_Pet}, {variant_Dog}}}
+             │   {variant_Cat}                    │
+             │   {variant_Dog}                    │ {keyword_fn} foo(pet : {type_Pet}) {{
+             │ }}                        │   {keyword_when} pet {keyword_is} {{
+                                        │     pet.{variant_Cat} -> // ...
+                                        │     {variant_Dog} -> // ...
+                                        │   }}
+                                        │ }}
 
            You must import its constructors explicitly to use them, or prefix them with the module's name.
-
-             ┍━ foo.ak ━━━━━━━━
-             │ {keyword_use} aiken/pet.{{{type_Pet}, {variant_Dog}}}
-             │
-             │ {keyword_fn} foo(pet : {type_Pet}) {{
-             │   {keyword_when} pet {keyword_is} {{
-             │     pet.{variant_Cat} -> // ...
-             │     {variant_Dog} -> // ...
-             │   }}
-             │ }}
         "#
         , keyword_fn =  "fn".if_supports_color(Stdout, |s| s.yellow())
         , keyword_is = "is".if_supports_color(Stdout, |s| s.yellow())
-        , keyword_pub = "pub".if_supports_color(Stdout, |s| s.bright_blue())
-        , keyword_type = "type".if_supports_color(Stdout, |s| s.bright_blue())
-        , keyword_use = "use".if_supports_color(Stdout, |s| s.bright_blue())
+        , keyword_pub = "pub".if_supports_color(Stdout, |s| s.bright_purple())
+        , keyword_type = "type".if_supports_color(Stdout, |s| s.purple())
+        , keyword_use = "use".if_supports_color(Stdout, |s| s.bright_purple())
         , keyword_when = "when".if_supports_color(Stdout, |s| s.yellow())
         , type_Pet = "Pet"
             .if_supports_color(Stdout, |s| s.bright_blue())

--- a/crates/aiken-lang/src/tipo/error.rs
+++ b/crates/aiken-lang/src/tipo/error.rs
@@ -914,11 +914,7 @@ Perhaps, try the following:
         suggest_neighbor(
             name,
             variables.iter(),
-            &if name.chars().next().unwrap().is_uppercase() {
-                suggest_import_constructor()
-            } else {
-                "Did you forget to import it?".to_string()
-            }
+            "Did you forget to import it?",
         )
     ))]
     UnknownVariable {

--- a/crates/aiken-lsp/src/lib.rs
+++ b/crates/aiken-lsp/src/lib.rs
@@ -9,7 +9,7 @@ mod edits;
 pub mod error;
 mod quickfix;
 pub mod server;
-mod utils;
+pub mod utils;
 
 #[allow(clippy::result_large_err)]
 pub fn start() -> Result<(), Error> {

--- a/crates/aiken-lsp/src/server.rs
+++ b/crates/aiken-lsp/src/server.rs
@@ -638,7 +638,7 @@ impl Server {
         self.send_work_done_notification(
             connection,
             lsp_types::WorkDoneProgress::Begin(lsp_types::WorkDoneProgressBegin {
-                title: "Compiling Aiken".into(),
+                title: "Compiling Aiken project".into(),
                 cancellable: Some(false),
                 message: None,
                 percentage: None,

--- a/crates/aiken-lsp/src/utils.rs
+++ b/crates/aiken-lsp/src/utils.rs
@@ -1,12 +1,25 @@
 use crate::error::Error;
 use aiken_lang::{ast::Span, line_numbers::LineNumbers};
 use itertools::Itertools;
-use lsp_types::TextEdit;
+use lsp_types::{notification::Notification, TextEdit};
 use std::path::{Path, PathBuf};
 use urlencoding::decode;
 
 pub const COMPILING_PROGRESS_TOKEN: &str = "compiling-aiken";
 pub const CREATE_COMPILING_PROGRESS_TOKEN: &str = "create-compiling-progress-token";
+
+/// Trace some information from the server.
+pub fn debug(connection: &lsp_server::Connection, message: impl serde::ser::Serialize) {
+    connection
+        .sender
+        .send(lsp_server::Message::Notification(
+            lsp_server::Notification {
+                method: lsp_types::notification::LogTrace::METHOD.to_string(),
+                params: serde_json::json! {{ "message": message }},
+            },
+        ))
+        .expect("failed to send notification");
+}
 
 pub fn text_edit_replace(new_text: String) -> TextEdit {
     TextEdit {


### PR DESCRIPTION
- :round_pushpin: **Use less vertical space for type-constructor hint;**
    Also, show it actually for UnknownTypeConstructor, and not UnknownVariable. There's currently an error that wrongly assign an 'UnknownVariable' in place where it should be an 'UnknownTypeConstructor'. Fix coming in the next commit.

- :round_pushpin: **Fix wrong use of 'UnknownVariable' instead of 'UnknownTypeConstructor'**
    While the feedback for human users is mostly the same, it does in fact matter for the LSP since the quickfix will be different depending on whether we look for a top-level identifier or if we look for a constructor.
 
   The typical case we see in the stdlib is the `VerificationKey` and `Script` constructors for `Credential`, often being mixed with their types counterparts in aiken/crypto!

- :round_pushpin: **Tweak progress line title in LSP**
    Has somewhat always been bothering me that it says 'compiling Aiken', which means kind of nothing in this context.

- :round_pushpin: **Add utility to print trace line in LSP server output.**

- :round_pushpin: **Also suggest qualified imports as quickfix when relevant.**