### PR TITLE
Types as namespaces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Added
 
 - **aiken**: New `-S` flag on `check` and `build` that blocks the printing of warnings but it still shows the total warning count. @rvcas
+- **aiken-lang**: Allow types to be used as namespaces for constructors. Importing each constructor variants independently is no longer required in neither pattern-matches nor value construction. One can simply use the type name as a prefix/namespace now. @KtorZ
 
 ### Changed
 

--- a/crates/aiken-lang/Cargo.toml
+++ b/crates/aiken-lang/Cargo.toml
@@ -11,7 +11,7 @@ authors = [
     "Kasey White <kwhitemsg@gmail.com>",
     "KtorZ <matthias.benkort@gmail.com>",
 ]
-rust-version = "1.70.0"
+rust-version = "1.80.0"
 build = "build.rs"
 
 [dependencies]

--- a/crates/aiken-lang/src/ast.rs
+++ b/crates/aiken-lang/src/ast.rs
@@ -1656,7 +1656,7 @@ impl TypedPattern {
 #[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
 pub enum Namespace {
     Module(String),
-    Type(String),
+    Type(Option<String>, String),
 }
 
 #[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]

--- a/crates/aiken-lang/src/ast.rs
+++ b/crates/aiken-lang/src/ast.rs
@@ -1535,8 +1535,8 @@ impl BinOp {
     }
 }
 
-pub type UntypedPattern = Pattern<(), ()>;
-pub type TypedPattern = Pattern<PatternConstructor, Rc<Type>>;
+pub type UntypedPattern = Pattern<(), (), Namespace>;
+pub type TypedPattern = Pattern<PatternConstructor, Rc<Type>, String>;
 
 impl TypedPattern {
     pub fn var(name: &str) -> Self {
@@ -1654,7 +1654,13 @@ impl TypedPattern {
 }
 
 #[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
-pub enum Pattern<Constructor, Type> {
+pub enum Namespace {
+    Module(String),
+    Type(String),
+}
+
+#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
+pub enum Pattern<Constructor, Type, NamespaceKind> {
     Int {
         location: Span,
         value: String,
@@ -1707,7 +1713,7 @@ pub enum Pattern<Constructor, Type> {
         location: Span,
         name: String,
         arguments: Vec<CallArg<Self>>,
-        module: Option<String>,
+        module: Option<NamespaceKind>,
         constructor: Constructor,
         spread_location: Option<Span>,
         tipo: Type,
@@ -1725,7 +1731,7 @@ pub enum Pattern<Constructor, Type> {
     },
 }
 
-impl<A, B> Pattern<A, B> {
+impl<A, B, C> Pattern<A, B, C> {
     pub fn location(&self) -> Span {
         match self {
             Pattern::Assign { pattern, .. } => pattern.location(),
@@ -2201,22 +2207,23 @@ impl<T: Default> AssignmentKind<T> {
     }
 }
 
-pub type MultiPattern<PatternConstructor, Type> = Vec<Pattern<PatternConstructor, Type>>;
+pub type MultiPattern<PatternConstructor, Type, NamespaceKind> =
+    Vec<Pattern<PatternConstructor, Type, NamespaceKind>>;
 
-pub type UntypedMultiPattern = MultiPattern<(), ()>;
-pub type TypedMultiPattern = MultiPattern<PatternConstructor, Rc<Type>>;
+pub type UntypedMultiPattern = MultiPattern<(), (), Namespace>;
+pub type TypedMultiPattern = MultiPattern<PatternConstructor, Rc<Type>, String>;
 
 #[derive(Debug, Clone, PartialEq)]
 pub struct UntypedClause {
     pub location: Span,
-    pub patterns: Vec1<Pattern<(), ()>>,
+    pub patterns: Vec1<UntypedPattern>,
     pub then: UntypedExpr,
 }
 
 #[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
 pub struct TypedClause {
     pub location: Span,
-    pub pattern: Pattern<PatternConstructor, Rc<Type>>,
+    pub pattern: TypedPattern,
     pub then: TypedExpr,
 }
 

--- a/crates/aiken-lang/src/builtins.rs
+++ b/crates/aiken-lang/src/builtins.rs
@@ -12,6 +12,7 @@ use crate::{
     },
     IdGenerator,
 };
+use std::{collections::BTreeSet, sync::LazyLock};
 
 use indexmap::IndexMap;
 use std::{collections::HashMap, rc::Rc};
@@ -24,6 +25,16 @@ use uplc::{
 
 pub const PRELUDE: &str = "aiken";
 pub const BUILTIN: &str = "aiken/builtin";
+
+pub static INTERNAL_FUNCTIONS: LazyLock<BTreeSet<&'static str>> = LazyLock::new(|| {
+    let mut set = BTreeSet::new();
+    set.insert("diagnostic");
+    set.insert("do_from_int");
+    set.insert("encode_base16");
+    set.insert("enumerate");
+    set.insert("from_int");
+    set
+});
 
 /// Build a prelude that can be injected
 /// into a compiler pipeline

--- a/crates/aiken-lang/src/expr.rs
+++ b/crates/aiken-lang/src/expr.rs
@@ -2,16 +2,15 @@ pub(crate) use crate::{
     ast::{
         self, Annotation, ArgBy, ArgName, AssignmentKind, AssignmentPattern, BinOp, Bls12_381Point,
         ByteArrayFormatPreference, CallArg, Curve, DataType, DataTypeKey, DefinitionLocation,
-        Located, LogicalOpChainKind, ParsedCallArg, Pattern, RecordConstructorArg,
-        RecordUpdateSpread, Span, TraceKind, TypedArg, TypedAssignmentKind, TypedClause,
-        TypedDataType, TypedIfBranch, TypedPattern, TypedRecordUpdateArg, UnOp, UntypedArg,
-        UntypedAssignmentKind, UntypedClause, UntypedIfBranch, UntypedRecordUpdateArg,
+        Located, LogicalOpChainKind, ParsedCallArg, RecordConstructorArg, RecordUpdateSpread, Span,
+        TraceKind, TypedArg, TypedAssignmentKind, TypedClause, TypedDataType, TypedIfBranch,
+        TypedPattern, TypedRecordUpdateArg, UnOp, UntypedArg, UntypedAssignmentKind, UntypedClause,
+        UntypedIfBranch, UntypedRecordUpdateArg,
     },
     parser::token::Base,
     tipo::{
         check_replaceable_opaque_type, convert_opaque_type, lookup_data_type_by_tipo,
-        ModuleValueConstructor, PatternConstructor, Type, TypeVar, ValueConstructor,
-        ValueConstructorVariant,
+        ModuleValueConstructor, Type, TypeVar, ValueConstructor, ValueConstructorVariant,
     },
 };
 use indexmap::IndexMap;
@@ -109,7 +108,7 @@ pub enum TypedExpr {
         location: Span,
         tipo: Rc<Type>,
         value: Box<Self>,
-        pattern: Pattern<PatternConstructor, Rc<Type>>,
+        pattern: TypedPattern,
         kind: TypedAssignmentKind,
     },
 

--- a/crates/aiken-lang/src/format.rs
+++ b/crates/aiken-lang/src/format.rs
@@ -2,7 +2,7 @@ use crate::{
     ast::{
         Annotation, ArgBy, ArgName, ArgVia, AssignmentKind, AssignmentPattern, BinOp,
         ByteArrayFormatPreference, CallArg, CurveType, DataType, Definition, Function,
-        LogicalOpChainKind, ModuleConstant, OnTestFailure, Pattern, RecordConstructor,
+        LogicalOpChainKind, ModuleConstant, Namespace, OnTestFailure, Pattern, RecordConstructor,
         RecordConstructorArg, RecordUpdateSpread, Span, TraceKind, TypeAlias, TypedArg,
         TypedValidator, UnOp, UnqualifiedImport, UntypedArg, UntypedArgVia, UntypedAssignmentKind,
         UntypedClause, UntypedDefinition, UntypedFunction, UntypedIfBranch, UntypedModule,
@@ -1202,7 +1202,7 @@ impl<'comments> Formatter<'comments> {
         &mut self,
         name: &'a str,
         args: &'a [CallArg<UntypedPattern>],
-        module: &'a Option<String>,
+        module: &'a Option<Namespace>,
         spread_location: Option<Span>,
         is_record: bool,
     ) -> Document<'a> {
@@ -1217,7 +1217,9 @@ impl<'comments> Formatter<'comments> {
         }
 
         let name = match module {
-            Some(m) => m.to_doc().append(".").append(name),
+            Some(Namespace::Module(m)) | Some(Namespace::Type(m)) => {
+                m.to_doc().append(".").append(name)
+            }
             None => name.to_doc(),
         };
 

--- a/crates/aiken-lang/src/format.rs
+++ b/crates/aiken-lang/src/format.rs
@@ -1217,9 +1217,15 @@ impl<'comments> Formatter<'comments> {
         }
 
         let name = match module {
-            Some(Namespace::Module(m)) | Some(Namespace::Type(m)) => {
+            Some(Namespace::Module(m)) | Some(Namespace::Type(None, m)) => {
                 m.to_doc().append(".").append(name)
             }
+            Some(Namespace::Type(Some(m), c)) => m
+                .to_doc()
+                .append(".")
+                .append(c.as_str())
+                .append(".")
+                .append(name),
             None => name.to_doc(),
         };
 

--- a/crates/aiken-lang/src/parser/chain/field_access.rs
+++ b/crates/aiken-lang/src/parser/chain/field_access.rs
@@ -1,5 +1,6 @@
 use super::Chain;
 use crate::{
+    ast::well_known,
     expr::UntypedExpr,
     parser::{token::Token, ParseError},
 };
@@ -8,7 +9,7 @@ use chumsky::prelude::*;
 pub(crate) fn parser() -> impl Parser<Token, Chain, Error = ParseError> {
     just(Token::Dot)
         .ignore_then(choice((
-            select! { Token::Else => "else".to_string() },
+            select! { Token::Else => well_known::VALIDATOR_ELSE.to_string() },
             select! { Token::Name { name } => name, },
         )))
         .map_with_span(Chain::FieldAccess)

--- a/crates/aiken-lang/src/parser/chain/field_access.rs
+++ b/crates/aiken-lang/src/parser/chain/field_access.rs
@@ -1,7 +1,6 @@
 use super::Chain;
 use crate::{
     ast::well_known,
-    expr::UntypedExpr,
     parser::{token::Token, ParseError},
 };
 use chumsky::prelude::*;
@@ -11,23 +10,9 @@ pub(crate) fn parser() -> impl Parser<Token, Chain, Error = ParseError> {
         .ignore_then(choice((
             select! { Token::Else => well_known::VALIDATOR_ELSE.to_string() },
             select! { Token::Name { name } => name, },
+            select! { Token::UpName { name } => name, },
         )))
         .map_with_span(Chain::FieldAccess)
-}
-
-pub(crate) fn constructor() -> impl Parser<Token, UntypedExpr, Error = ParseError> {
-    select! {Token::Name { name } => name}
-        .map_with_span(|module, span| (module, span))
-        .then_ignore(just(Token::Dot))
-        .then(select! {Token::UpName { name } => name})
-        .map_with_span(|((module, m_span), name), span| UntypedExpr::FieldAccess {
-            location: span,
-            label: name,
-            container: Box::new(UntypedExpr::Var {
-                location: m_span,
-                name: module,
-            }),
-        })
 }
 
 #[cfg(test)]

--- a/crates/aiken-lang/src/parser/chain/mod.rs
+++ b/crates/aiken-lang/src/parser/chain/mod.rs
@@ -4,6 +4,7 @@ pub(crate) mod call;
 pub(crate) mod field_access;
 pub(crate) mod tuple_index;
 
+#[derive(Debug)]
 pub(crate) enum Chain {
     Call(Vec<ParsedCallArg>, Span),
     FieldAccess(String, Span),

--- a/crates/aiken-lang/src/parser/expr/chained.rs
+++ b/crates/aiken-lang/src/parser/expr/chained.rs
@@ -53,7 +53,6 @@ pub fn chain_start<'a>(
         pair(expression.clone()),
         record_update(expression.clone()),
         record(expression.clone()),
-        field_access::constructor(),
         and_or_chain(expression.clone()),
         var(),
         tuple(expression.clone()),

--- a/crates/aiken-lang/src/parser/pattern/constructor.rs
+++ b/crates/aiken-lang/src/parser/pattern/constructor.rs
@@ -1,29 +1,51 @@
 use chumsky::prelude::*;
 
 use crate::{
-    ast::{CallArg, Span, UntypedPattern},
+    ast::{CallArg, Namespace, Span, UntypedPattern},
     parser::{error::ParseError, token::Token},
 };
 
 pub fn parser(
     pattern: Recursive<'_, Token, UntypedPattern, ParseError>,
 ) -> impl Parser<Token, UntypedPattern, Error = ParseError> + '_ {
-    select! {Token::UpName { name } => name}
-        .then(args(pattern))
-        .map_with_span(
-            |(name, (arguments, spread_location, is_record)), location| {
-                UntypedPattern::Constructor {
-                    is_record,
-                    location,
-                    name,
-                    arguments,
-                    module: None,
-                    constructor: (),
-                    spread_location,
-                    tipo: (),
-                }
-            },
-        )
+    choice((
+        select! { Token::UpName { name } => name }
+            .then(
+                just(Token::Dot).ignore_then(
+                    select! {Token::UpName { name } => name}.then(args(pattern.clone())),
+                ),
+            )
+            .map_with_span(
+                |(namespace, (name, (arguments, spread_location, is_record))), span| {
+                    UntypedPattern::Constructor {
+                        is_record,
+                        location: span,
+                        name,
+                        arguments,
+                        module: Some(Namespace::Type(namespace)),
+                        constructor: (),
+                        spread_location,
+                        tipo: (),
+                    }
+                },
+            ),
+        select! {Token::UpName { name } => name}
+            .then(args(pattern))
+            .map_with_span(
+                |(name, (arguments, spread_location, is_record)), location| {
+                    UntypedPattern::Constructor {
+                        is_record,
+                        location,
+                        name,
+                        arguments,
+                        module: None,
+                        constructor: (),
+                        spread_location,
+                        tipo: (),
+                    }
+                },
+            ),
+    ))
 }
 
 pub(crate) fn args(
@@ -101,5 +123,10 @@ mod tests {
     #[test]
     fn constructor_module_select() {
         assert_pattern!("module.Foo");
+    }
+
+    #[test]
+    fn constructor_type_select() {
+        assert_pattern!("Foo.Bar");
     }
 }

--- a/crates/aiken-lang/src/parser/pattern/mod.rs
+++ b/crates/aiken-lang/src/parser/pattern/mod.rs
@@ -27,9 +27,9 @@ pub use var::parser as var;
 pub fn parser() -> impl Parser<Token, UntypedPattern, Error = ParseError> {
     recursive(|pattern| {
         choice((
-            var(pattern.clone()),
             pair(pattern.clone()),
             constructor(pattern.clone()),
+            var(pattern.clone()),
             discard(),
             int(),
             bytearray(),

--- a/crates/aiken-lang/src/parser/pattern/snapshots/constructor_module_select.snap
+++ b/crates/aiken-lang/src/parser/pattern/snapshots/constructor_module_select.snap
@@ -8,7 +8,9 @@ Constructor {
     name: "Foo",
     arguments: [],
     module: Some(
-        "module",
+        Module(
+            "module",
+        ),
     ),
     constructor: (),
     spread_location: None,

--- a/crates/aiken-lang/src/parser/pattern/snapshots/constructor_type_select.snap
+++ b/crates/aiken-lang/src/parser/pattern/snapshots/constructor_type_select.snap
@@ -1,0 +1,18 @@
+---
+source: crates/aiken-lang/src/parser/pattern/constructor.rs
+description: "Code:\n\nFoo.Bar"
+---
+Constructor {
+    is_record: false,
+    location: 0..7,
+    name: "Bar",
+    arguments: [],
+    module: Some(
+        Type(
+            "Foo",
+        ),
+    ),
+    constructor: (),
+    spread_location: None,
+    tipo: (),
+}

--- a/crates/aiken-lang/src/parser/pattern/snapshots/constructor_type_select.snap
+++ b/crates/aiken-lang/src/parser/pattern/snapshots/constructor_type_select.snap
@@ -9,6 +9,7 @@ Constructor {
     arguments: [],
     module: Some(
         Type(
+            None,
             "Foo",
         ),
     ),

--- a/crates/aiken-lang/src/parser/pattern/var.rs
+++ b/crates/aiken-lang/src/parser/pattern/var.rs
@@ -9,31 +9,33 @@ use crate::{
 pub fn parser(
     expression: Recursive<'_, Token, UntypedPattern, ParseError>,
 ) -> impl Parser<Token, UntypedPattern, Error = ParseError> + '_ {
-    select! { Token::Name {name} => name }
-        .then(
-            just(Token::Dot)
-                .ignore_then(
-                    select! {Token::UpName { name } => name}.then(constructor::args(expression)),
-                )
-                .or_not(),
-        )
-        .map_with_span(|(name, opt_pattern), span| {
-            if let Some((c_name, (arguments, spread_location, is_record))) = opt_pattern {
-                UntypedPattern::Constructor {
-                    is_record,
-                    location: span,
-                    name: c_name,
-                    arguments,
-                    module: Some(name),
-                    constructor: (),
-                    spread_location,
-                    tipo: (),
-                }
-            } else {
-                UntypedPattern::Var {
-                    location: span,
-                    name,
-                }
+    select! {
+        Token::Name {name} => name,
+    }
+    .then(
+        just(Token::Dot)
+            .ignore_then(
+                select! { Token::UpName { name } => name }.then(constructor::args(expression)),
+            )
+            .or_not(),
+    )
+    .map_with_span(|(name, opt_pattern), span| {
+        if let Some((c_name, (arguments, spread_location, is_record))) = opt_pattern {
+            UntypedPattern::Constructor {
+                is_record,
+                location: span,
+                name: c_name,
+                arguments,
+                module: Some(crate::ast::Namespace::Module(name)),
+                constructor: (),
+                spread_location,
+                tipo: (),
             }
-        })
+        } else {
+            UntypedPattern::Var {
+                location: span,
+                name,
+            }
+        }
+    })
 }

--- a/crates/aiken-lang/src/tests/check.rs
+++ b/crates/aiken-lang/src/tests/check.rs
@@ -2725,6 +2725,64 @@ fn use_non_imported_module_as_namespace() {
 }
 
 #[test]
+fn invalid_type_field_access_chain() {
+    let dependency = r#"
+        pub type Foo {
+          I(Int)
+          B(Bool)
+        }
+    "#;
+
+    let source_code = r#"
+        use foo.{Foo}
+
+        test my_test() {
+          trace Foo.I.Int(42)
+          Void
+        }
+    "#;
+
+    let result = check_with_deps(parse(source_code), vec![(parse_as(dependency, "foo"))]);
+
+    assert!(
+        matches!(
+            &result,
+            Err((warnings, Error::InvalidFieldAccess { .. })) if warnings.is_empty(),
+        ),
+        "{result:#?}"
+    );
+}
+
+#[test]
+fn invalid_type_field_access_chain_2() {
+    let dependency = r#"
+        pub type Foo {
+          I(Int)
+          B(Bool)
+        }
+    "#;
+
+    let source_code = r#"
+        use foo.{Foo}
+
+        test my_test() {
+          trace Foo.i(42)
+          Void
+        }
+    "#;
+
+    let result = check_with_deps(parse(source_code), vec![(parse_as(dependency, "foo"))]);
+
+    assert!(
+        matches!(
+            &result,
+            Err((warnings, Error::UnknownTypeConstructor { .. })) if warnings.is_empty(),
+        ),
+        "{result:#?}"
+    );
+}
+
+#[test]
 fn forbid_importing_or_using_opaque_constructors() {
     let dependency = r#"
         pub opaque type Thing {

--- a/crates/aiken-lang/src/tests/check.rs
+++ b/crates/aiken-lang/src/tests/check.rs
@@ -2307,7 +2307,7 @@ fn use_imported_type_as_namespace_for_patterns() {
 fn use_type_as_namespace_for_patterns() {
     let dependency = r#"
         pub type Foo {
-          A
+          A { a: Int }
           B
         }
     "#;
@@ -2317,7 +2317,7 @@ fn use_type_as_namespace_for_patterns() {
 
         fn bar(foo: Foo) {
           when foo is {
-            Foo.A -> True
+            Foo.A { a } -> a > 10
             Foo.B -> False
           }
         }
@@ -2332,7 +2332,7 @@ fn use_type_as_namespace_for_patterns() {
 fn use_nested_type_as_namespace_for_patterns() {
     let dependency = r#"
         pub type Foo {
-          A
+          A { a: Int }
           B
         }
     "#;
@@ -2342,7 +2342,7 @@ fn use_nested_type_as_namespace_for_patterns() {
 
         fn bar(x: Foo) {
           when x is {
-            foo.Foo.A -> True
+            foo.Foo.A { a } -> a > 10
             foo.Foo.B -> False
           }
         }
@@ -2357,7 +2357,7 @@ fn use_nested_type_as_namespace_for_patterns() {
 fn use_opaque_type_as_namespace_for_patterns_fails() {
     let dependency = r#"
         pub opaque type Foo {
-          A
+          A { a: Int }
           B
         }
     "#;
@@ -2367,7 +2367,7 @@ fn use_opaque_type_as_namespace_for_patterns_fails() {
 
         fn bar(foo: Foo) {
           when foo is {
-            Foo.A -> True
+            Foo.A { a } -> a > 10
             Foo.B -> False
           }
         }
@@ -2388,7 +2388,7 @@ fn use_opaque_type_as_namespace_for_patterns_fails() {
 fn use_wrong_type_as_namespace_for_patterns_fails() {
     let dependency = r#"
         pub type Foo {
-          A
+          A { a: Int }
           B
         }
 
@@ -2403,7 +2403,7 @@ fn use_wrong_type_as_namespace_for_patterns_fails() {
 
         fn bar(foo: Foo) {
           when foo is {
-            Foo.A -> True
+            Foo.A { .. } -> True
             Foo.D -> False
           }
         }
@@ -2424,7 +2424,7 @@ fn use_wrong_type_as_namespace_for_patterns_fails() {
 fn use_type_as_namespace_for_constructors() {
     let dependency = r#"
         pub type Foo {
-          I(Int)
+          I { i: Int }
           B(Bool)
         }
     "#;
@@ -2434,7 +2434,7 @@ fn use_type_as_namespace_for_constructors() {
 
         test my_test() {
           and {
-            Foo.I(42) == foo.I(42),
+            Foo.I { i: 42 } == foo.I(42),
             foo.B(True) == Foo.B(True),
           }
         }
@@ -2449,7 +2449,7 @@ fn use_type_as_namespace_for_constructors() {
 fn use_type_as_nested_namespace_for_constructors() {
     let dependency = r#"
         pub type Foo {
-          I(Int)
+          I { i: Int }
           B(Bool)
         }
     "#;
@@ -2458,7 +2458,8 @@ fn use_type_as_nested_namespace_for_constructors() {
         use foo
 
         test my_test() {
-          trace foo.Foo.I(42)
+          trace foo.Foo.I { i: 42 }
+          trace foo.Foo.B(False)
           Void
         }
     "#;
@@ -2472,7 +2473,7 @@ fn use_type_as_nested_namespace_for_constructors() {
 fn use_type_as_nested_namespace_for_constructors_from_multi_level_module() {
     let dependency = r#"
         pub type Foo {
-          I(Int)
+          I { i: Int }
           B(Bool)
         }
     "#;
@@ -2481,7 +2482,8 @@ fn use_type_as_nested_namespace_for_constructors_from_multi_level_module() {
         use foo/bar
 
         test my_test() {
-          trace bar.Foo.I(42)
+          trace bar.Foo.I { i: 42 }
+          trace bar.Foo.B(True)
           Void
         }
     "#;
@@ -2495,7 +2497,7 @@ fn use_type_as_nested_namespace_for_constructors_from_multi_level_module() {
 fn use_type_as_nested_namespace_for_constructors_from_module_alias() {
     let dependency = r#"
         pub type Foo {
-          I(Int)
+          I { i: Int }
           B(Bool)
         }
     "#;
@@ -2504,7 +2506,8 @@ fn use_type_as_nested_namespace_for_constructors_from_module_alias() {
         use foo as bar
 
         test my_test() {
-          trace bar.Foo.I(42)
+          trace bar.Foo.I { i: 42 }
+          trace bar.Foo.B(True)
           Void
         }
     "#;
@@ -2518,7 +2521,7 @@ fn use_type_as_nested_namespace_for_constructors_from_module_alias() {
 fn use_type_as_namespace_unknown_constructor() {
     let dependency = r#"
         pub type Foo {
-          I(Int)
+          I { i: Int }
           B(Bool)
         }
     "#;
@@ -2527,7 +2530,7 @@ fn use_type_as_namespace_unknown_constructor() {
         use foo.{Foo}
 
         test my_test() {
-          Foo.A == Foo.I(42)
+          Foo.I(42) == Foo.A
         }
     "#;
 
@@ -2546,12 +2549,12 @@ fn use_type_as_namespace_unknown_constructor() {
 fn use_wrong_type_as_namespace() {
     let dependency = r#"
         pub type Foo {
-          I(Int)
+          I { i: Int }
           B(Bool)
         }
 
         pub type Bar {
-          S(String)
+          S { s: String }
           L(List<Int>)
         }
     "#;
@@ -2580,12 +2583,12 @@ fn use_wrong_type_as_namespace() {
 fn use_wrong_nested_type_as_namespace() {
     let dependency = r#"
         pub type Foo {
-          I(Int)
+          I { i: Int }
           B(Bool)
         }
 
         pub type Bar {
-          S(String)
+          S { s: String }
           L(List<Int>)
         }
     "#;
@@ -2614,7 +2617,7 @@ fn use_wrong_nested_type_as_namespace() {
 fn use_private_type_as_nested_namespace_fails() {
     let dependency = r#"
         type Foo {
-          I(Int)
+          I { i: Int }
           B(Bool)
         }
     "#;
@@ -2623,7 +2626,7 @@ fn use_private_type_as_nested_namespace_fails() {
         use foo
 
         test my_test() {
-          trace foo.Foo.I(42)
+          trace foo.Foo.I { i: 42 }
           Void
         }
     "#;
@@ -2643,7 +2646,7 @@ fn use_private_type_as_nested_namespace_fails() {
 fn use_opaque_type_as_namespace_for_constructors_fails() {
     let dependency = r#"
         pub opaque type Foo {
-          I(Int)
+          I { i: Int }
           B(Bool)
         }
     "#;
@@ -2672,7 +2675,7 @@ fn use_opaque_type_as_namespace_for_constructors_fails() {
 fn use_opaque_type_as_nested_namespace_for_constructors_fails() {
     let dependency = r#"
         pub opaque type Foo {
-          I(Int)
+          I { i: Int }
           B(Bool)
         }
     "#;

--- a/crates/aiken-lang/src/tests/check.rs
+++ b/crates/aiken-lang/src/tests/check.rs
@@ -2329,6 +2329,31 @@ fn use_type_as_namespace_for_patterns() {
 }
 
 #[test]
+fn use_nested_type_as_namespace_for_patterns() {
+    let dependency = r#"
+        pub type Foo {
+          A
+          B
+        }
+    "#;
+
+    let source_code = r#"
+        use foo.{Foo}
+
+        fn bar(x: Foo) {
+          when x is {
+            foo.Foo.A -> True
+            foo.Foo.B -> False
+          }
+        }
+    "#;
+
+    let result = check_with_deps(parse(source_code), vec![(parse_as(dependency, "foo"))]);
+
+    assert!(matches!(result, Ok(..)), "{result:#?}");
+}
+
+#[test]
 fn use_opaque_type_as_namespace_for_patterns_fails() {
     let dependency = r#"
         pub opaque type Foo {

--- a/crates/aiken-lang/src/tests/format.rs
+++ b/crates/aiken-lang/src/tests/format.rs
@@ -1449,3 +1449,26 @@ fn capture_right_hand_side_assign() {
         "#
     );
 }
+
+#[test]
+fn types_as_namespace() {
+    assert_format!(
+        r#"
+        use foo.{ Foo }
+
+        fn predicate(val) {
+          when val is {
+            Foo.I(n) -> n >= 14
+            foo.Foo.B(bytes) -> bytes == "aiken"
+          }
+        }
+
+        test my_test() {
+          and {
+            predicate(foo.Foo.I(42)),
+            predicate(Foo.b("aiken"))
+          }
+        }
+        "#
+    );
+}

--- a/crates/aiken-lang/src/tests/snapshots/types_as_namespace.snap
+++ b/crates/aiken-lang/src/tests/snapshots/types_as_namespace.snap
@@ -1,0 +1,19 @@
+---
+source: crates/aiken-lang/src/tests/format.rs
+description: "Code:\n\nuse foo.{ Foo }\n\nfn predicate(val) {\n  when val is {\n    Foo.I(n) -> n >= 14\n    foo.Foo.B(bytes) -> bytes == \"aiken\"\n  }\n}\n\ntest my_test() {\n  and {\n    predicate(foo.Foo.I(42)),\n    predicate(Foo.b(\"aiken\"))\n  }\n}\n"
+---
+use foo.{Foo}
+
+fn predicate(val) {
+  when val is {
+    Foo.I(n) -> n >= 14
+    foo.Foo.B(bytes) -> bytes == "aiken"
+  }
+}
+
+test my_test() {
+  and {
+    predicate(foo.Foo.I(42)),
+    predicate(Foo.b("aiken")),
+  }
+}

--- a/crates/aiken-lang/src/tipo/environment.rs
+++ b/crates/aiken-lang/src/tipo/environment.rs
@@ -378,7 +378,7 @@ impl<'a> Environment<'a> {
         name: &str,
         location: Span,
     ) -> Result<&mut TypeConstructor, Error> {
-        let types = self.module_types.keys().map(|t| t.to_string()).collect();
+        let types = self.known_type_names();
 
         let constructor = self
             .module_types
@@ -407,7 +407,7 @@ impl<'a> Environment<'a> {
                 .ok_or_else(|| Error::UnknownType {
                     location,
                     name: name.to_string(),
-                    types: self.module_types.keys().map(|t| t.to_string()).collect(),
+                    types: self.known_type_names(),
                 }),
 
             Some(m) => {
@@ -457,8 +457,42 @@ impl<'a> Environment<'a> {
                     constructors: self.local_constructor_names(),
                 }),
 
-            Some(Namespace::Type(..)) => {
-                todo!()
+            Some(Namespace::Type(t)) => {
+                let parent_type = self.module_types.get(t).ok_or_else(|| Error::UnknownType {
+                    location,
+                    name: t.to_string(),
+                    types: self.known_type_names(),
+                })?;
+
+                let (_, module) =
+                    self.imported_modules
+                        .get(&parent_type.module)
+                        .ok_or_else(|| Error::UnknownModule {
+                            name: parent_type.module.to_string(),
+                            known_modules: self
+                                .importable_modules
+                                .keys()
+                                .map(|t| t.to_string())
+                                .collect(),
+                            location,
+                        })?;
+
+                self.unused_modules.remove(&parent_type.module);
+
+                let empty_vec = vec![];
+                let constructors = module.types_constructors.get(t).unwrap_or(&empty_vec);
+
+                let unknown_type_constructor = || Error::UnknownTypeConstructor {
+                    location,
+                    name: name.to_string(),
+                    constructors: constructors.clone(),
+                };
+
+                if !constructors.iter().any(|constructor| constructor == name) {
+                    return Err(unknown_type_constructor());
+                }
+
+                module.values.get(name).ok_or_else(unknown_type_constructor)
             }
 
             Some(Namespace::Module(m)) => {
@@ -730,6 +764,22 @@ impl<'a> Environment<'a> {
                 alias.clone(),
             ),
         }
+    }
+
+    /// Get a list of known type names, for suggestions in errors.
+    pub fn known_type_names(&self) -> Vec<String> {
+        self.module_types
+            .keys()
+            .filter_map(|t| {
+                // Avoid leaking special internal types such as __ScriptContext or
+                // __ScriptPurpose.
+                if t.starts_with("__") {
+                    None
+                } else {
+                    Some(t.to_string())
+                }
+            })
+            .collect()
     }
 
     pub fn local_value_names(&self) -> Vec<String> {
@@ -1820,7 +1870,7 @@ impl<'a> Environment<'a> {
                 .get(name)
                 .ok_or_else(|| Error::UnknownType {
                     name: name.to_string(),
-                    types: self.module_types.keys().map(|t| t.to_string()).collect(),
+                    types: self.known_type_names(),
                     location,
                 })?
                 .iter()

--- a/crates/aiken-lang/src/tipo/environment.rs
+++ b/crates/aiken-lang/src/tipo/environment.rs
@@ -8,9 +8,9 @@ use super::{
 use crate::{
     ast::{
         self, Annotation, CallArg, DataType, Definition, Function, ModuleConstant, ModuleKind,
-        RecordConstructor, RecordConstructorArg, Span, TypeAlias, TypedDefinition, TypedFunction,
-        TypedPattern, TypedValidator, UnqualifiedImport, UntypedArg, UntypedDefinition,
-        UntypedFunction, Use, Validator, PIPE_VARIABLE,
+        Namespace, RecordConstructor, RecordConstructorArg, Span, TypeAlias, TypedDefinition,
+        TypedFunction, TypedPattern, TypedValidator, UnqualifiedImport, UntypedArg,
+        UntypedDefinition, UntypedFunction, Use, Validator, PIPE_VARIABLE,
     },
     tipo::{fields::FieldMap, TypeAliasAnnotation},
     IdGenerator,
@@ -443,7 +443,7 @@ impl<'a> Environment<'a> {
     #[allow(clippy::result_large_err)]
     pub fn get_value_constructor(
         &mut self,
-        module: Option<&String>,
+        module: Option<&Namespace>,
         name: &str,
         location: Span,
     ) -> Result<&ValueConstructor, Error> {
@@ -457,7 +457,11 @@ impl<'a> Environment<'a> {
                     constructors: self.local_constructor_names(),
                 }),
 
-            Some(m) => {
+            Some(Namespace::Type(..)) => {
+                todo!()
+            }
+
+            Some(Namespace::Module(m)) => {
                 let (_, module) =
                     self.imported_modules
                         .get(m)

--- a/crates/aiken-lang/src/tipo/environment.rs
+++ b/crates/aiken-lang/src/tipo/environment.rs
@@ -505,8 +505,10 @@ impl<'a> Environment<'a> {
                 }),
 
             Some(Namespace::Type(t)) => {
+                let type_location = location.map(|start, _| (start, start + t.len()));
+
                 let parent_type = self.module_types.get(t).ok_or_else(|| Error::UnknownType {
-                    location,
+                    location: type_location,
                     name: t.to_string(),
                     types: self.known_type_names(),
                 })?;
@@ -514,8 +516,8 @@ impl<'a> Environment<'a> {
                 self.unused_modules.remove(&parent_type.module);
 
                 self.get_fully_qualified_value_constructor(
-                    (parent_type.module.as_str(), location),
-                    (t, location),
+                    (parent_type.module.as_str(), type_location),
+                    (t, type_location),
                     (name, location.map(|start, end| (start + t.len() + 1, end))),
                 )
             }

--- a/crates/aiken-lang/src/tipo/error.rs
+++ b/crates/aiken-lang/src/tipo/error.rs
@@ -1,6 +1,9 @@
 use super::Type;
 use crate::{
-    ast::{Annotation, BinOp, CallArg, LogicalOpChainKind, Span, UntypedFunction, UntypedPattern},
+    ast::{
+        Annotation, BinOp, CallArg, LogicalOpChainKind, Namespace, Span, UntypedFunction,
+        UntypedPattern,
+    },
     error::ExtraData,
     expr::{self, AssignmentPattern, UntypedAssignmentKind, UntypedExpr},
     format::Formatter,
@@ -395,7 +398,7 @@ From there, you can define 'increment', a function that takes a single argument 
         expected: usize,
         given: Vec<CallArg<UntypedPattern>>,
         name: String,
-        module: Option<String>,
+        module: Option<Namespace>,
         is_record: bool,
     },
 
@@ -718,7 +721,7 @@ Perhaps, try the following:
         label: String,
         name: String,
         args: Vec<CallArg<UntypedPattern>>,
-        module: Option<String>,
+        module: Option<Namespace>,
         spread_location: Option<Span>,
     },
 
@@ -1274,7 +1277,7 @@ fn suggest_pattern(
     expected: usize,
     name: &str,
     given: &[CallArg<UntypedPattern>],
-    module: &Option<String>,
+    module: &Option<Namespace>,
     is_record: bool,
 ) -> Option<String> {
     if expected > given.len() {
@@ -1309,7 +1312,7 @@ fn suggest_generic(name: &str, expected: usize) -> String {
 fn suggest_constructor_pattern(
     name: &str,
     args: &[CallArg<UntypedPattern>],
-    module: &Option<String>,
+    module: &Option<Namespace>,
     spread_location: Option<Span>,
 ) -> String {
     let fixed_args = args

--- a/crates/aiken-lang/src/tipo/error.rs
+++ b/crates/aiken-lang/src/tipo/error.rs
@@ -1079,7 +1079,7 @@ The best thing to do from here is to remove it."#))]
         available_purposes: Vec<String>,
     },
 
-    #[error("I could not find an appropriate handler in the validator definition\n")]
+    #[error("I could not find an appropriate handler in the validator definition.\n")]
     #[diagnostic(code("unknown::handler"))]
     #[diagnostic(help(
         "When referring to a validator handler via record access, you must refer to one of the declared handlers{}{}",
@@ -1095,7 +1095,7 @@ The best thing to do from here is to remove it."#))]
         available_handlers: Vec<String>,
     },
 
-    #[error("I caught an extraneous fallback handler in an already exhaustive validator\n")]
+    #[error("I caught an extraneous fallback handler in an already exhaustive validator.\n")]
     #[diagnostic(code("extraneous::fallback"))]
     #[diagnostic(help(
         "Validator handlers must be exhaustive and either cover all purposes, or provide a fallback handler. Here, you have successfully covered all script purposes with your handler, but left an extraneous fallback branch. I cannot let that happen, but removing it for you would probably be deemed rude. So please, remove the fallback."
@@ -1103,6 +1103,16 @@ The best thing to do from here is to remove it."#))]
     UnexpectedValidatorFallback {
         #[label("redundant fallback handler")]
         fallback: Span,
+    },
+
+    #[error("I was stopped by a suspicious field access chain.\n")]
+    #[diagnostic(code("invalid::field_access"))]
+    #[diagnostic(help(
+        "It seems like you've got things mixed up a little here? You can only access fields exported by modules or, by types within those modules. Double-check the culprit field access chain, there's likely something wrong about it."
+    ))]
+    InvalidFieldAccess {
+        #[label("invalid field access")]
+        location: Span,
     },
 }
 
@@ -1166,7 +1176,8 @@ impl ExtraData for Error {
             | Error::UnknownValidatorHandler { .. }
             | Error::UnexpectedValidatorFallback { .. }
             | Error::IncorrectBenchmarkArity { .. }
-            | Error::MustInferFirst { .. } => None,
+            | Error::MustInferFirst { .. }
+            | Error::InvalidFieldAccess { .. } => None,
 
             Error::UnknownType { name, .. }
             | Error::UnknownTypeConstructor { name, .. }

--- a/crates/aiken-lang/src/tipo/error.rs
+++ b/crates/aiken-lang/src/tipo/error.rs
@@ -808,7 +808,7 @@ Perhaps, try the following:
     },
 
     #[error(
-        "I looked for '{}' in '{}' but couldn't find it.\n",
+        "I looked for '{}' in module '{}' but couldn't find it.\n",
         name.if_supports_color(Stdout, |s| s.purple()),
         module_name.if_supports_color(Stdout, |s| s.purple())
     )]
@@ -822,7 +822,7 @@ Perhaps, try the following:
         )
     ))]
     UnknownModuleType {
-        #[label("unknown import")]
+        #[label("not exported?")]
         location: Span,
         name: String,
         module_name: String,
@@ -1529,14 +1529,15 @@ fn suggest_import_constructor() -> String {
              ┍━ aiken/pet.ak ━    ==>   ┍━ foo.ak ━━━━━━━━━━━━━━━━
              │ {keyword_pub} {keyword_type} {type_Pet} {{           │ {keyword_use} aiken/pet.{{{type_Pet}, {variant_Dog}}}
              │   {variant_Cat}                    │
-             │   {variant_Dog}                    │ {keyword_fn} foo(pet : {type_Pet}) {{
-             │ }}                        │   {keyword_when} pet {keyword_is} {{
-                                        │     pet.{variant_Cat} -> // ...
+             │   {variant_Dog}                    │ {keyword_fn} foo(pet: {type_Pet}) {{
+             │   {variant_Fox}                    │   {keyword_when} pet {keyword_is} {{
+             │ }}                        │     pet.{variant_Cat} -> // ...
                                         │     {variant_Dog} -> // ...
+                                        │     {type_Pet}.{variant_Fox} -> // ...
                                         │   }}
                                         │ }}
 
-           You must import its constructors explicitly to use them, or prefix them with the module's name.
+           You must import its constructors explicitly to use them, or prefix them with the module or type's name.
         "#
         , keyword_fn =  "fn".if_supports_color(Stdout, |s| s.yellow())
         , keyword_is = "is".if_supports_color(Stdout, |s| s.yellow())
@@ -1551,6 +1552,9 @@ fn suggest_import_constructor() -> String {
             .if_supports_color(Stdout, |s| s.bright_blue())
             .if_supports_color(Stdout, |s| s.bold())
         , variant_Dog = "Dog"
+            .if_supports_color(Stdout, |s| s.bright_blue())
+            .if_supports_color(Stdout, |s| s.bold())
+        , variant_Fox = "Fox"
             .if_supports_color(Stdout, |s| s.bright_blue())
             .if_supports_color(Stdout, |s| s.bold())
     }

--- a/crates/aiken-lang/src/tipo/expr.rs
+++ b/crates/aiken-lang/src/tipo/expr.rs
@@ -1107,15 +1107,9 @@ impl<'a, 'b> ExprTyper<'a, 'b> {
                         .environment
                         .imported_modules
                         .get(module_name)
-                        .ok_or_else(|| Error::UnknownModule {
-                            location: *module_location,
-                            name: module_name.to_string(),
-                            known_modules: self
-                                .environment
-                                .importable_modules
-                                .keys()
-                                .map(|t| t.to_string())
-                                .collect(),
+                        .ok_or_else(|| {
+                            self.environment
+                                .err_unknown_module(module_name.to_string(), *module_location)
                         })?;
 
                     return self.infer_inner_type_constructor_access(
@@ -1175,15 +1169,9 @@ impl<'a, 'b> ExprTyper<'a, 'b> {
                 .environment
                 .imported_modules
                 .get(module_alias)
-                .ok_or_else(|| Error::UnknownModule {
-                    name: module_alias.to_string(),
-                    location: *module_location,
-                    known_modules: self
-                        .environment
-                        .importable_modules
-                        .keys()
-                        .map(|t| t.to_string())
-                        .collect(),
+                .ok_or_else(|| {
+                    self.environment
+                        .err_unknown_module(module_alias.to_string(), *module_location)
                 })?;
 
             let constructor =
@@ -2683,15 +2671,9 @@ impl<'a, 'b> ExprTyper<'a, 'b> {
                     .environment
                     .imported_modules
                     .get(module_name)
-                    .ok_or_else(|| Error::UnknownModule {
-                        location: *location,
-                        name: module_name.to_string(),
-                        known_modules: self
-                            .environment
-                            .importable_modules
-                            .keys()
-                            .map(|t| t.to_string())
-                            .collect(),
+                    .ok_or_else(|| {
+                        self.environment
+                            .err_unknown_module(module_name.to_string(), *location)
                     })?;
 
                 module

--- a/crates/aiken-lang/src/tipo/expr.rs
+++ b/crates/aiken-lang/src/tipo/expr.rs
@@ -1095,6 +1095,12 @@ impl<'a, 'b> ExprTyper<'a, 'b> {
                     location: module_location,
                 } = type_container.as_ref()
                 {
+                    if TypeConstructor::might_be(module_name) {
+                        return Err(Error::InvalidFieldAccess {
+                            location: access_location,
+                        });
+                    }
+
                     // Lookup the module using the declared name (which may have been rebind with
                     // 'as'), to obtain its _full unambiguous name_.
                     let (_, module) = self

--- a/crates/aiken-lang/src/tipo/expr.rs
+++ b/crates/aiken-lang/src/tipo/expr.rs
@@ -11,11 +11,11 @@ use super::{
 use crate::{
     ast::{
         self, Annotation, ArgName, AssignmentKind, AssignmentPattern, BinOp, Bls12_381Point,
-        ByteArrayFormatPreference, CallArg, Curve, Function, IfBranch, LogicalOpChainKind, Pattern,
-        RecordUpdateSpread, Span, TraceKind, TraceLevel, Tracing, TypedArg, TypedCallArg,
-        TypedClause, TypedIfBranch, TypedPattern, TypedRecordUpdateArg, TypedValidator, UnOp,
-        UntypedArg, UntypedAssignmentKind, UntypedClause, UntypedFunction, UntypedIfBranch,
-        UntypedPattern, UntypedRecordUpdateArg,
+        ByteArrayFormatPreference, CallArg, Curve, Function, IfBranch, LogicalOpChainKind,
+        Namespace, Pattern, RecordUpdateSpread, Span, TraceKind, TraceLevel, Tracing, TypedArg,
+        TypedCallArg, TypedClause, TypedIfBranch, TypedPattern, TypedRecordUpdateArg,
+        TypedValidator, UnOp, UntypedArg, UntypedAssignmentKind, UntypedClause, UntypedFunction,
+        UntypedIfBranch, UntypedPattern, UntypedRecordUpdateArg,
     },
     builtins::{from_default_function, BUILTIN},
     expr::{FnStyle, TypedExpr, UntypedExpr},
@@ -404,7 +404,7 @@ impl<'a, 'b> ExprTyper<'a, 'b> {
                 module_alias,
                 label,
                 ..
-            } => (Some(module_alias), label),
+            } => (Some(Namespace::Module(module_alias.to_string())), label),
 
             TypedExpr::Var { name, .. } => (None, name),
 
@@ -413,7 +413,7 @@ impl<'a, 'b> ExprTyper<'a, 'b> {
 
         Ok(self
             .environment
-            .get_value_constructor(module, name, location)?
+            .get_value_constructor(module.as_ref(), name, location)?
             .field_map())
     }
 
@@ -792,12 +792,12 @@ impl<'a, 'b> ExprTyper<'a, 'b> {
         args: Vec<UntypedRecordUpdateArg>,
         location: Span,
     ) -> Result<TypedExpr, Error> {
-        let (module, name): (Option<String>, String) = match self.infer(constructor.clone())? {
+        let (module, name): (Option<Namespace>, String) = match self.infer(constructor.clone())? {
             TypedExpr::ModuleSelect {
                 module_alias,
                 label,
                 ..
-            } => (Some(module_alias), label),
+            } => (Some(Namespace::Module(module_alias)), label),
 
             TypedExpr::Var { name, .. } => (None, name),
 

--- a/crates/aiken-lang/src/tipo/infer.rs
+++ b/crates/aiken-lang/src/tipo/infer.rs
@@ -17,7 +17,12 @@ use crate::{
     tipo::{expr::infer_function, Span, Type, TypeVar},
     IdGenerator,
 };
-use std::{borrow::Borrow, collections::HashMap, ops::Deref, rc::Rc};
+use std::{
+    borrow::Borrow,
+    collections::{BTreeSet, HashMap},
+    ops::Deref,
+    rc::Rc,
+};
 
 impl UntypedModule {
     #[allow(clippy::too_many_arguments)]
@@ -116,7 +121,13 @@ impl UntypedModule {
             .module_types
             .retain(|_, info| info.public && info.module == module_name);
 
+        let own_types = environment.module_types.keys().collect::<BTreeSet<_>>();
+
         environment.module_values.retain(|_, info| info.public);
+
+        environment
+            .module_types_constructors
+            .retain(|k, _| own_types.contains(k));
 
         environment
             .accessors

--- a/crates/aiken-lang/src/tipo/pattern.rs
+++ b/crates/aiken-lang/src/tipo/pattern.rs
@@ -573,7 +573,7 @@ impl<'a, 'b> PatternTyper<'a, 'b> {
                                 // NOTE:
                                 // Type namespaces are completely erased during type-check.
                                 module: match module {
-                                    None | Some(Namespace::Type(_)) => None,
+                                    None | Some(Namespace::Type(..)) => None,
                                     Some(Namespace::Module(m)) => Some(m),
                                 },
                                 name,
@@ -609,7 +609,7 @@ impl<'a, 'b> PatternTyper<'a, 'b> {
                                 // NOTE:
                                 // Type namespaces are completely erased during type-check.
                                 module: match module {
-                                    None | Some(Namespace::Type(_)) => None,
+                                    None | Some(Namespace::Type(..)) => None,
                                     Some(Namespace::Module(m)) => Some(m),
                                 },
                                 name,

--- a/crates/aiken-lang/src/tipo/pattern.rs
+++ b/crates/aiken-lang/src/tipo/pattern.rs
@@ -6,7 +6,7 @@ use super::{
     hydrator::Hydrator,
     PatternConstructor, Type, ValueConstructorVariant,
 };
-use crate::ast::{CallArg, Pattern, Span, TypedPattern, UntypedPattern};
+use crate::ast::{CallArg, Namespace, Pattern, Span, TypedPattern, UntypedPattern};
 use itertools::Itertools;
 use std::{
     collections::{HashMap, HashSet},
@@ -570,7 +570,12 @@ impl<'a, 'b> PatternTyper<'a, 'b> {
 
                             Ok(Pattern::Constructor {
                                 location,
-                                module,
+                                // NOTE:
+                                // Type namespaces are completely erased during type-check.
+                                module: match module {
+                                    None | Some(Namespace::Type(_)) => None,
+                                    Some(Namespace::Module(m)) => Some(m),
+                                },
                                 name,
                                 arguments: pattern_args,
                                 constructor,
@@ -601,7 +606,12 @@ impl<'a, 'b> PatternTyper<'a, 'b> {
 
                             Ok(Pattern::Constructor {
                                 location,
-                                module,
+                                // NOTE:
+                                // Type namespaces are completely erased during type-check.
+                                module: match module {
+                                    None | Some(Namespace::Type(_)) => None,
+                                    Some(Namespace::Module(m)) => Some(m),
+                                },
                                 name,
                                 arguments: vec![],
                                 constructor,

--- a/crates/aiken-project/src/error.rs
+++ b/crates/aiken-project/src/error.rs
@@ -731,7 +731,7 @@ impl Warning {
 
 impl Debug for Warning {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        default_miette_handler(0)
+        default_miette_handler(1)
             .debug(
                 &DisplayWarning {
                     title: &self.to_string(),


### PR DESCRIPTION
Introduces support for using types as namespaces to access constructors in patterns and value construction. This simplifies the import management; especially for types with many constructors. It can get quite cumbersome to have to import each constructor independently. 

Note however that **this change does NOT introduce a proper _name scoping_** for constructor variants. So we're still bound to requiring unique variant names per module, even if they belong to different types. Doing so requires another set of changes which I am not necessarily willing to explore now (as they're much more _risky_ and spans over more areas, unfortunately). Yet, this changes certainly paves the way for this if we want to later. 

## TODOs

- [ ] Drop a few lines in the user manual
- [ ] Perhaps adjust some of the LSP quickfixes to also suggests this new syntax instead of a new constructor-variant import when possible. 

## Example

<img width="354" alt="Screenshot 2025-03-16 at 13 14 31" src="https://github.com/user-attachments/assets/9498de5f-11ee-43a5-af46-b7c20e4f2bb6" />

## Error handling

<img width="548" alt="Screenshot 2025-03-16 at 13 11 09" src="https://github.com/user-attachments/assets/b1edd3a8-9292-4d05-abe7-25fd164d3660" />
<img width="374" alt="Screenshot 2025-03-16 at 13 11 35" src="https://github.com/user-attachments/assets/c21b4447-2bb9-4e06-a314-a04b9cac7fde" />
<img width="497" alt="Screenshot 2025-03-16 at 13 12 18" src="https://github.com/user-attachments/assets/22d62d67-bb6f-4da1-8e30-b6526950630b" />
<img width="496" alt="Screenshot 2025-03-16 at 13 12 39" src="https://github.com/user-attachments/assets/bd0e1da9-c7cd-41fe-848a-86e084d085ed" />
<img width="504" alt="Screenshot 2025-03-16 at 13 14 59" src="https://github.com/user-attachments/assets/c6ee8ee1-867f-45e3-b40b-79747b0e0a09" />

