### PR TITLE
Fix hint when suggesting to use named fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 ### Fixed
 
 - **aiken-lang**: Formatter was removing comments from function type annotation args @rvcas
+- **aiken-lang**: Fix hint when suggesting to use named fields, wrongly suggesting args in lexicographical order instead of definition order. @KtorZ
 
 ## v1.1.13 - 2025-02-26
 

--- a/crates/aiken-lang/src/tests/check.rs
+++ b/crates/aiken-lang/src/tests/check.rs
@@ -3701,3 +3701,56 @@ fn unused_record_fields_4() {
         }
     );
 }
+
+#[test]
+fn unused_record_fields_5() {
+    let source_code = r#"
+        pub type Foo {
+          b_is_before_a: Bool,
+          a_is_after_b: Bool,
+        }
+
+        test confusing() {
+          let Foo(a, b) = Foo(True, True)
+          a || b
+        }
+    "#;
+
+    let result = check_validator(parse(source_code));
+    assert!(result.is_ok());
+
+    let (warnings, _) = result.unwrap();
+    assert_eq!(
+        warnings[0],
+        Warning::UnusedRecordFields {
+            location: Span::create(137, 9),
+            suggestion: UntypedPattern::Constructor {
+                is_record: true,
+                location: Span::create(137, 9),
+                name: "Foo".to_string(),
+                arguments: vec![
+                    CallArg {
+                        label: Some("b_is_before_a".to_string()),
+                        location: Span::create(141, 13),
+                        value: Pattern::Var {
+                            location: Span::create(141, 1),
+                            name: "a".to_string()
+                        }
+                    },
+                    CallArg {
+                        label: Some("a_is_after_b".to_string()),
+                        location: Span::create(144, 12),
+                        value: Pattern::Var {
+                            location: Span::create(144, 1),
+                            name: "b".to_string()
+                        }
+                    }
+                ],
+                module: None,
+                constructor: (),
+                spread_location: None,
+                tipo: ()
+            }
+        }
+    );
+}

--- a/crates/aiken-lang/src/tipo/pattern.rs
+++ b/crates/aiken-lang/src/tipo/pattern.rs
@@ -467,7 +467,7 @@ impl<'a, 'b> PatternTyper<'a, 'b> {
                         let arguments = field_map
                             .fields
                             .iter()
-                            .sorted_by(|(a, _), (b, _)| a.cmp(b))
+                            .sorted_by(|(_, (a, _)), (_, (b, _))| a.cmp(b))
                             .zip(pattern_args.iter())
                             .filter_map(|((field, (_, _)), arg)| {
                                 if arg.value.is_discard() {


### PR DESCRIPTION
  Wrongly suggesting args in lexicographical order instead of definition order... The tests were unfortunately only examplifying situations where the fields where also defined in lexicographical order... thus never really showing the issue. It came up in the real world, though. Whoopsie.