### PR TITLE
Provide better errors when failing to match validators in blueprint apply.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,12 +14,10 @@
 - **aiken-lang**: Change default placeholder for `trace` to `Void` instead of `todo`. @KtorZ
 - **aiken-lang**: Disallow (parse error) dangling colon `:` in traces. See [#1113](https://github.com/aiken-lang/aiken/issues/1113). @KtorZ
 - **aiken-lang**: Fix `aiken blueprint apply` wrongly overriding all validators handlers names & ABI to the mint's one. See [#1099](https://github.com/aiken-lang/aiken/issues/1099). @KtorZ
-
-### Fixed
-
 - **aiken-lang**: Formatter was removing comments from function type annotation args @rvcas
 - **aiken-lang**: Parser wrongly merged two adjacent sequences together, effectively fusioning scopes. @KtorZ
 - **aiken-lang**: Fix hint when suggesting to use named fields, wrongly suggesting args in lexicographical order instead of definition order. @KtorZ
+- **aiken-project**: Better errors on `blueprint apply` when matching multiple or no validators. See [#1127](https://github.com/aiken-lang/aiken/issues/1127) @KtorZ
 
 ## v1.1.13 - 2025-02-26
 

--- a/crates/aiken-project/src/blueprint/validator.rs
+++ b/crates/aiken-project/src/blueprint/validator.rs
@@ -46,6 +46,20 @@ pub struct Validator {
 }
 
 impl Validator {
+    pub fn get_module_and_name(&self) -> (&str, &str) {
+        let mut split = self.title.split('.');
+
+        let known_module_name = split
+            .next()
+            .expect("validator's name must have two dot-separated components.");
+
+        let known_validator_name = split
+            .next()
+            .expect("validator's name must have two dot-separated components.");
+
+        (known_module_name, known_validator_name)
+    }
+
     pub fn from_checked_module(
         modules: &CheckedModules,
         generator: &mut CodeGenerator,

--- a/crates/aiken-project/src/error.rs
+++ b/crates/aiken-project/src/error.rs
@@ -15,6 +15,7 @@ use owo_colors::{
     Stream::{Stderr, Stdout},
 };
 use std::{
+    collections::BTreeSet,
     fmt::{self, Debug, Display},
     io,
     path::{Path, PathBuf},
@@ -137,10 +138,14 @@ pub enum Error {
     },
 
     #[error("I didn't find any validator matching your criteria.")]
-    NoValidatorNotFound { known_validators: Vec<String> },
+    NoValidatorNotFound {
+        known_validators: BTreeSet<(String, String, bool)>,
+    },
 
     #[error("I found multiple suitable validators and I need you to tell me which one to pick.")]
-    MoreThanOneValidatorFound { known_validators: Vec<String> },
+    MoreThanOneValidatorFound {
+        known_validators: BTreeSet<(String, String, bool)>,
+    },
 
     #[error("I couldn't find any exportable function named '{name}' in module '{module}'.")]
     ExportNotFound { module: String, name: String },
@@ -423,27 +428,13 @@ impl Diagnostic for Error {
                     None => String::new(),
                 }
             ))),
-            Error::NoValidatorNotFound { known_validators } => Some(Box::new(format!(
-                "Here's a list of all validators I've found in your project. Please double-check this list against the options that you've provided:\n\n{}",
-                known_validators
-                    .iter()
-                    .map(|title| format!(
-                        "→ {title}",
-                        title = title.if_supports_color(Stdout, |s| s.purple())
-                    ))
-                    .collect::<Vec<String>>()
-                    .join("\n")
+            Error::NoValidatorNotFound { known_validators } => Some(Box::new(hint_validators(
+                known_validators,
+                "Here's a list of all validators I've found in your project.\nPlease double-check this list against the options that you've provided."
             ))),
-            Error::MoreThanOneValidatorFound { known_validators } => Some(Box::new(format!(
-                "Here's a list of all validators I've found in your project. Select one of them using the appropriate options:\n\n{}",
-                known_validators
-                    .iter()
-                    .map(|title| format!(
-                        "→ {title}",
-                        title = title.if_supports_color(Stdout, |s| s.purple())
-                    ))
-                    .collect::<Vec<String>>()
-                    .join("\n")
+            Error::MoreThanOneValidatorFound { known_validators } => Some(Box::new(hint_validators(
+                known_validators,
+                "Here's a list of matching validators I've found in your project.\nPlease narrow the selection using additional options.",
             ))),
             Error::Module(e) => e.help(),
         }
@@ -808,4 +799,54 @@ fn default_miette_handler(context_lines: usize) -> MietteHandler {
         .terminal_links(true)
         .context_lines(context_lines)
         .build()
+}
+
+fn hint_validators(known_validators: &BTreeSet<(String, String, bool)>, hint: &str) -> String {
+    let (pad_module, pad_validator) = known_validators.iter().fold(
+        (9, 12),
+        |(module_len, validator_len), (module, validator, _)| {
+            (
+                module_len.max(module.len()),
+                validator_len.max(validator.len()),
+            )
+        },
+    );
+
+    format!(
+        "{hint}\n\n\
+         {:<pad_module$}   {:<pad_validator$}\n\
+         {:─<pad_module$}┒ ┎{:─<pad_validator$}\n\
+         {}\n\nFor convenience, I have highlighted in {bold_green} suitable candidates that {has_params}.",
+        "module(s)",
+        "validator(s)",
+        "─",
+        "─",
+        {
+            known_validators
+                .iter()
+                .map(|(module, validator, has_params)|  {
+                    let title = format!(
+                        "{:>pad_module$} . {:<pad_validator$}",
+                        module,
+                        validator,
+                    );
+                    if *has_params {
+                        title
+                            .if_supports_color(Stderr, |s| s.bold())
+                            .if_supports_color(Stderr, |s| s.green())
+                            .to_string()
+                    } else {
+                        title
+                    }
+                })
+                .collect::<Vec<String>>()
+                .join("\n")
+        },
+        bold_green = "bold green"
+            .if_supports_color(Stderr, |s| s.bold())
+            .if_supports_color(Stderr, |s| s.green()),
+        has_params = "can take parameters"
+            .if_supports_color(Stderr, |s| s.bold())
+            .if_supports_color(Stderr, |s| s.green()),
+    )
 }


### PR DESCRIPTION
This needed some revamp after the Plutus V3 updates; the error was noisy and unhelpful. 

## NoValidatorNotFound 

### Before

<img width="1118" alt="image" src="https://github.com/user-attachments/assets/a3038007-8867-453a-9bdc-715ad6224159" />

### After

<img width="825" alt="image" src="https://github.com/user-attachments/assets/91639459-01aa-4f12-aa53-d509e21496db" />

> [!NOTE]
> 
> - [x] Only show validators, not handlers; 
> - [x] Better formatting making the matching options more apparent;
> - [x] Highlight those which can take parameters;

## MoreThanOneValidatorFound

### Before

<img width="942" alt="image" src="https://github.com/user-attachments/assets/68b3e3a9-8440-491c-91ce-a090812a2515" />

### After

<img width="829" alt="image" src="https://github.com/user-attachments/assets/17103a00-f78a-488c-809f-4b8196cd14e1" />

> [!NOTE]
> 
> - [x] Only show matched validators.
> - [x] Also improved formatting & highlight those which can take parameters
