### PR TITLE
Add support for stake registration certificates

### DIFF
--- a/crates/uplc/src/tx/script_context.rs
+++ b/crates/uplc/src/tx/script_context.rs
@@ -874,6 +874,8 @@ pub fn find_script(
             .ok_or(Error::MissingScriptForRedeemer)
             .and_then(|cert| match cert {
                 Certificate::StakeDeregistration(stake_credential)
+                | Certificate::StakeRegistration(stake_credential)
+                | Certificate::Reg(stake_credential, _)
                 | Certificate::UnReg(stake_credential, _)
                 | Certificate::VoteDeleg(stake_credential, _)
                 | Certificate::VoteRegDeleg(stake_credential, _, _)
@@ -889,10 +891,9 @@ pub fn find_script(
                     StakeCredential::ScriptHash(hash) => Ok(hash),
                     _ => Err(Error::NonScriptStakeCredential),
                 },
-                Certificate::StakeRegistration { .. }
-                | Certificate::PoolRetirement { .. }
-                | Certificate::Reg { .. }
-                | Certificate::PoolRegistration { .. } => Err(Error::UnsupportedCertificateType),
+                Certificate::PoolRetirement { .. } | Certificate::PoolRegistration { .. } => {
+                    Err(Error::UnsupportedCertificateType)
+                }
             })
             .and_then(lookup_script),
 


### PR DESCRIPTION
I just moved both stake reg certificates to the handled branches instead of the unsupported one. Not sure if that’s the only thing necessary, but in my case, it was enough to have the VM run successfully.