### PR TITLE
disable '--version' flag on sub-commands

### DIFF
--- a/crates/aiken/src/cmd/benchmark.rs
+++ b/crates/aiken/src/cmd/benchmark.rs
@@ -14,6 +14,7 @@ use std::{
 };
 
 #[derive(clap::Args)]
+#[clap(disable_version_flag(true))]
 /// Benchmark an Aiken project
 pub struct Args {
     /// Path to project

--- a/crates/aiken/src/cmd/blueprint/address.rs
+++ b/crates/aiken/src/cmd/blueprint/address.rs
@@ -3,6 +3,7 @@ use std::path::PathBuf;
 
 /// Compute a validator's address.
 #[derive(clap::Args)]
+#[clap(disable_version_flag(true))]
 pub struct Args {
     /// Path to project
     directory: Option<PathBuf>,

--- a/crates/aiken/src/cmd/blueprint/apply.rs
+++ b/crates/aiken/src/cmd/blueprint/apply.rs
@@ -18,6 +18,7 @@ use uplc::ast::Data as UplcData;
 
 /// Apply a parameter to a parameterized validator.
 #[derive(clap::Args)]
+#[clap(disable_version_flag(true))]
 pub struct Args {
     /// The parameter, as a Plutus Data (CBOR, hex-encoded).
     ///

--- a/crates/aiken/src/cmd/blueprint/convert.rs
+++ b/crates/aiken/src/cmd/blueprint/convert.rs
@@ -9,6 +9,7 @@ use std::{env, fs::File, io::BufReader, path::PathBuf, process};
 
 /// Convert a blueprint into other formats.
 #[derive(clap::Args)]
+#[clap(disable_version_flag(true))]
 pub struct Args {
     /// Path to project
     directory: Option<PathBuf>,

--- a/crates/aiken/src/cmd/blueprint/hash.rs
+++ b/crates/aiken/src/cmd/blueprint/hash.rs
@@ -3,6 +3,7 @@ use std::path::PathBuf;
 
 /// Compute a validator's hash
 #[derive(clap::Args)]
+#[clap(disable_version_flag(true))]
 pub struct Args {
     /// Path to project
     directory: Option<PathBuf>,

--- a/crates/aiken/src/cmd/blueprint/mod.rs
+++ b/crates/aiken/src/cmd/blueprint/mod.rs
@@ -8,6 +8,7 @@ use clap::Subcommand;
 
 /// Commands for working with Plutus blueprints
 #[derive(Subcommand)]
+#[clap(disable_version_flag(true))]
 pub enum Cmd {
     Address(address::Args),
     Policy(policy::Args),

--- a/crates/aiken/src/cmd/blueprint/policy.rs
+++ b/crates/aiken/src/cmd/blueprint/policy.rs
@@ -3,6 +3,7 @@ use std::path::PathBuf;
 
 /// Compute a minting scripts Policy ID
 #[derive(clap::Args)]
+#[clap(disable_version_flag(true))]
 pub struct Args {
     /// Path to project
     directory: Option<PathBuf>,

--- a/crates/aiken/src/cmd/build.rs
+++ b/crates/aiken/src/cmd/build.rs
@@ -6,6 +6,7 @@ use clap::builder::{MapValueParser, PossibleValuesParser, TypedValueParser};
 use std::{path::PathBuf, process};
 
 #[derive(clap::Args)]
+#[clap(disable_version_flag(true))]
 /// Build an Aiken project
 pub struct Args {
     /// Path to project

--- a/crates/aiken/src/cmd/check.rs
+++ b/crates/aiken/src/cmd/check.rs
@@ -17,6 +17,7 @@ use std::{
 };
 
 #[derive(clap::Args)]
+#[clap(disable_version_flag(true))]
 #[command(
     verbatim_doc_comment,
     about = color_print::cstr!(r#"

--- a/crates/aiken/src/cmd/completion/mod.rs
+++ b/crates/aiken/src/cmd/completion/mod.rs
@@ -5,6 +5,7 @@ use clap_complete::Shell;
 
 /// Get completion scripts for various shells
 #[derive(Subcommand)]
+#[clap(disable_version_flag(true))]
 pub enum Cmd {
     Bash(shell::Args),
     Zsh(shell::Args),

--- a/crates/aiken/src/cmd/completion/shell.rs
+++ b/crates/aiken/src/cmd/completion/shell.rs
@@ -10,6 +10,7 @@ use std::{
 
 /// Generates shell completion scripts
 #[derive(clap::Args)]
+#[clap(disable_version_flag(true))]
 pub struct Args {
     /// Install the completion scripts
     #[arg(short, long, default_value_t = false)]

--- a/crates/aiken/src/cmd/docs.rs
+++ b/crates/aiken/src/cmd/docs.rs
@@ -2,6 +2,7 @@ use aiken_project::watch::{self, watch_project, with_project};
 use std::{path::PathBuf, process};
 
 #[derive(clap::Args)]
+#[clap(disable_version_flag(true))]
 /// Build the documentation for an Aiken project
 pub struct Args {
     /// Path to project

--- a/crates/aiken/src/cmd/export.rs
+++ b/crates/aiken/src/cmd/export.rs
@@ -6,6 +6,7 @@ use aiken_project::{options::Options, watch::with_project};
 use std::path::PathBuf;
 
 #[derive(clap::Args)]
+#[clap(disable_version_flag(true))]
 /// Export a function as a standalone UPLC program. Arguments to the function can be applied using
 /// `aiken apply`.
 pub struct Args {

--- a/crates/aiken/src/cmd/fmt.rs
+++ b/crates/aiken/src/cmd/fmt.rs
@@ -1,4 +1,5 @@
 #[derive(clap::Args)]
+#[clap(disable_version_flag(true))]
 /// Format an Aiken project
 pub struct Args {
     /// Files to format

--- a/crates/aiken/src/cmd/lsp.rs
+++ b/crates/aiken/src/cmd/lsp.rs
@@ -1,6 +1,7 @@
 use miette::IntoDiagnostic;
 
 #[derive(clap::Args)]
+#[clap(disable_version_flag(true))]
 /// Start the Aiken language server
 pub struct Args {
     /// Run on stdio

--- a/crates/aiken/src/cmd/new.rs
+++ b/crates/aiken/src/cmd/new.rs
@@ -12,6 +12,7 @@ use std::{
 };
 
 #[derive(clap::Args)]
+#[clap(disable_version_flag(true))]
 /// Create a new Aiken project
 pub struct Args {
     /// Project name

--- a/crates/aiken/src/cmd/packages/add.rs
+++ b/crates/aiken/src/cmd/packages/add.rs
@@ -9,6 +9,7 @@ use owo_colors::{OwoColorize, Stream::Stderr};
 use std::{path::PathBuf, process, str::FromStr};
 
 #[derive(clap::Args)]
+#[clap(disable_version_flag(true))]
 /// Add a new project package as dependency
 pub struct Args {
     /// Package name, in the form of {owner}/{repository}.

--- a/crates/aiken/src/cmd/packages/mod.rs
+++ b/crates/aiken/src/cmd/packages/mod.rs
@@ -6,6 +6,7 @@ use clap::Subcommand;
 
 /// Managing project dependencies
 #[derive(Subcommand)]
+#[clap(disable_version_flag(true))]
 pub enum Cmd {
     /// Add a new package dependency
     Add(add::Args),

--- a/crates/aiken/src/cmd/packages/upgrade.rs
+++ b/crates/aiken/src/cmd/packages/upgrade.rs
@@ -1,6 +1,7 @@
 use super::add;
 
 #[derive(clap::Args)]
+#[clap(disable_version_flag(true))]
 /// Change the version of an installed dependency
 pub struct Args {
     /// Package name, in the form of {owner}/{repository}.

--- a/crates/aiken/src/cmd/tx/mod.rs
+++ b/crates/aiken/src/cmd/tx/mod.rs
@@ -4,6 +4,7 @@ use clap::Subcommand;
 
 /// Commands for working with transactions
 #[derive(Subcommand)]
+#[clap(disable_version_flag(true))]
 pub enum Cmd {
     Simulate(simulate::Args),
 }

--- a/crates/aiken/src/cmd/tx/simulate.rs
+++ b/crates/aiken/src/cmd/tx/simulate.rs
@@ -15,6 +15,7 @@ use uplc::{
 };
 
 #[derive(clap::Args)]
+#[clap(disable_version_flag(true))]
 /// Simulate a transaction by evaluating it's script
 pub struct Args {
     /// A file containing cbor hex for a transaction

--- a/crates/aiken/src/cmd/uplc/decode.rs
+++ b/crates/aiken/src/cmd/uplc/decode.rs
@@ -5,6 +5,7 @@ use uplc::ast::{DeBruijn, Name, NamedDeBruijn, Program};
 use super::Format;
 
 #[derive(clap::Args)]
+#[clap(disable_version_flag(true))]
 /// Decode flat bytes to textual Untyped Plutus Core
 pub struct Args {
     /// Flat encoded Untyped Plutus Core file

--- a/crates/aiken/src/cmd/uplc/encode.rs
+++ b/crates/aiken/src/cmd/uplc/encode.rs
@@ -13,6 +13,7 @@ use super::Format;
 
 /// Encode textual Untyped Plutus Core to flat bytes
 #[derive(clap::Args)]
+#[clap(disable_version_flag(true))]
 pub struct Args {
     /// Textual Untyped Plutus Core file
     input: PathBuf,

--- a/crates/aiken/src/cmd/uplc/eval.rs
+++ b/crates/aiken/src/cmd/uplc/eval.rs
@@ -16,6 +16,7 @@ use uplc::{
 };
 
 #[derive(clap::Args)]
+#[clap(disable_version_flag(true))]
 /// Evaluate an Untyped Plutus Core program
 pub struct Args {
     script: PathBuf,

--- a/crates/aiken/src/cmd/uplc/fmt.rs
+++ b/crates/aiken/src/cmd/uplc/fmt.rs
@@ -3,6 +3,7 @@ use std::{fs, path::PathBuf};
 use uplc::parser;
 
 #[derive(clap::Args)]
+#[clap(disable_version_flag(true))]
 /// Format an Untyped Plutus Core program
 pub struct Args {
     /// Textual Untyped Plutus Core file

--- a/crates/aiken/src/cmd/uplc/mod.rs
+++ b/crates/aiken/src/cmd/uplc/mod.rs
@@ -15,6 +15,7 @@ pub(super) enum Format {
 
 /// Commands for working with untyped Plutus-core
 #[derive(Subcommand)]
+#[clap(disable_version_flag(true))]
 pub enum Cmd {
     Fmt(fmt::Args),
     Eval(eval::Args),

--- a/crates/aiken/src/cmd/uplc/shrink.rs
+++ b/crates/aiken/src/cmd/uplc/shrink.rs
@@ -1,11 +1,14 @@
 use miette::IntoDiagnostic;
 use std::path::PathBuf;
-use uplc::ast::{DeBruijn, Name, NamedDeBruijn, Program};
-use uplc::optimize::aiken_optimize_and_intern;
+use uplc::{
+    ast::{DeBruijn, Name, NamedDeBruijn, Program},
+    optimize::aiken_optimize_and_intern,
+};
 
 use super::{Format, encode};
 
 #[derive(clap::Args)]
+#[clap(disable_version_flag(true))]
 /// Shrink / Optimize UPLC code using a variety of optimization steps
 pub struct Args {
     /// Flat encoded Untyped Plutus Core file


### PR DESCRIPTION
Somehow, recent clap versions are now automatically adding a `--version` flag to all commands and sub-commands. On top of that, there's a debug assertion that makes the compiler crash should we use the `add` or `package upgrade` commands.

  ```
   /Users/ktorz/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/clap_builder-4.5.27/src/builder/debug_asserts.rs:86:13

       Command add: Argument names must be unique, but 'version' is in use by more than one argument or group (call `cmd.disable_version_flag(true)` to remove the auto-generated `--version`)
  ```

Note that it's only a `debug_assert!`, and so the latest release is _fine_. But the behaviour is odd and the extra --version flag not really meaningful. So I've dropped it from all commands and sub-commands so that only the top-level binary has a version flag:

  ```
  aiken --version
  ```