### PR TITLE
Allow type reification to pierce through list-like Data aliases (e.g. Redeemer)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Fixed
 
 - **aiken-lang**: Correctly infer Fuzzer & Sampler via type annotations when referring to foreign types. @KtorZ
+- **aiken-lang**: Allow type reification to pierce through Data aliases (e.g. Redeemer) holding lists, tuples or pairs, instead of crashing the compiler. @KtorZ
 
 ## v1.1.16 - 2025-04-14
 

--- a/crates/aiken-lang/src/test_framework.rs
+++ b/crates/aiken-lang/src/test_framework.rs
@@ -1184,12 +1184,12 @@ impl UnitTestResult<(Constant, Rc<Type>)> {
                 Some(Assertion {
                     bin_op: assertion.bin_op,
                     head: assertion.head.map(|(cst, tipo)| {
-                        UntypedExpr::reify_constant(data_types, cst, &tipo)
+                        UntypedExpr::reify_constant(data_types, cst, tipo)
                             .expect("failed to reify assertion operand?")
                     }),
                     tail: assertion.tail.map(|xs| {
                         xs.mapped(|(cst, tipo)| {
-                            UntypedExpr::reify_constant(data_types, cst, &tipo)
+                            UntypedExpr::reify_constant(data_types, cst, tipo)
                                 .expect("failed to reify assertion operand?")
                         })
                     }),
@@ -1218,8 +1218,12 @@ impl PropertyTestResult<PlutusData> {
         PropertyTestResult {
             counterexample: self.counterexample.map(|ok| {
                 ok.map(|counterexample| {
-                    UntypedExpr::reify_data(data_types, counterexample, &self.test.fuzzer.type_info)
-                        .expect("failed to reify counterexample?")
+                    UntypedExpr::reify_data(
+                        data_types,
+                        counterexample,
+                        self.test.fuzzer.type_info.clone(),
+                    )
+                    .expect("failed to reify counterexample?")
                 })
             }),
             iterations: self.iterations,

--- a/crates/aiken-lang/src/tipo.rs
+++ b/crates/aiken-lang/src/tipo.rs
@@ -22,8 +22,6 @@ mod pattern;
 mod pipe;
 pub mod pretty;
 
-pub use environment::collapse_links;
-
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub struct TypeAliasAnnotation {
     pub module: Option<String>,
@@ -163,6 +161,15 @@ impl PartialEq for Type {
 }
 
 impl Type {
+    pub fn collapse_links(t: Rc<Self>) -> Rc<Self> {
+        if let Type::Var { tipo, alias } = t.deref() {
+            if let TypeVar::Link { tipo } = tipo.borrow().deref() {
+                return Type::with_alias(tipo.clone(), alias.clone());
+            }
+        }
+        t
+    }
+
     pub fn alias(&self) -> Option<Rc<TypeAliasAnnotation>> {
         match self {
             Type::App { alias, .. }

--- a/crates/aiken-lang/src/tipo/environment.rs
+++ b/crates/aiken-lang/src/tipo/environment.rs
@@ -2161,15 +2161,6 @@ pub(super) fn assert_no_labeled_arguments<A>(args: &[CallArg<A>]) -> Option<(Spa
     None
 }
 
-pub fn collapse_links(t: Rc<Type>) -> Rc<Type> {
-    if let Type::Var { tipo, alias } = t.deref() {
-        if let TypeVar::Link { tipo } = tipo.borrow().deref() {
-            return Type::with_alias(tipo.clone(), alias.clone());
-        }
-    }
-    t
-}
-
 /// Returns the fields that have the same label and type across all variants of
 /// the given type.
 fn get_compatible_record_fields<A>(

--- a/crates/aiken-lang/src/tipo/expr.rs
+++ b/crates/aiken-lang/src/tipo/expr.rs
@@ -1,8 +1,6 @@
 use super::{
     RecordAccessor, Type, ValueConstructor, ValueConstructorVariant,
-    environment::{
-        EntityKind, Environment, assert_no_labeled_arguments, collapse_links, generalise,
-    },
+    environment::{EntityKind, Environment, assert_no_labeled_arguments, generalise},
     error::{Error, Warning},
     hydrator::Hydrator,
     pattern::PatternTyper,
@@ -1313,7 +1311,7 @@ impl<'a, 'b> ExprTyper<'a, 'b> {
         };
 
         // Check to see if it's a Type that can have accessible fields
-        let accessors = match collapse_links(record.tipo()).as_ref() {
+        let accessors = match Type::collapse_links(record.tipo()).as_ref() {
             // A type in the current module which may have fields
             Type::App { module, name, .. } if module == self.environment.current_module => {
                 self.environment.accessors.get(name)
@@ -1640,7 +1638,7 @@ impl<'a, 'b> ExprTyper<'a, 'b> {
         value: UntypedExpr,
         tipo: Rc<Type>,
     ) -> Result<TypedExpr, Error> {
-        let tipo = collapse_links(tipo);
+        let tipo = Type::collapse_links(tipo);
 
         let value = match (&*tipo, value) {
             // If the argument is expected to be a function and we are passed a
@@ -2459,7 +2457,7 @@ impl<'a, 'b> ExprTyper<'a, 'b> {
     ) -> Result<TypedExpr, Error> {
         let tuple_or_pair = self.infer(tuple_or_pair)?;
 
-        let tipo = match *collapse_links(tuple_or_pair.tipo()) {
+        let tipo = match *Type::collapse_links(tuple_or_pair.tipo()) {
             Type::Tuple {
                 ref elems,
                 alias: _,

--- a/crates/aiken-project/src/blueprint/validator.rs
+++ b/crates/aiken-project/src/blueprint/validator.rs
@@ -10,7 +10,7 @@ use aiken_lang::{
     ast::{Annotation, TypedArg, TypedFunction, TypedValidator, well_known},
     gen_uplc::CodeGenerator,
     plutus_version::PlutusVersion,
-    tipo::{Type, collapse_links},
+    tipo::Type,
 };
 use miette::NamedSource;
 use serde;
@@ -243,7 +243,7 @@ impl Validator {
 }
 
 pub fn tipo_or_annotation<'a>(module: &'a CheckedModule, arg: &'a TypedArg) -> &'a Type {
-    match collapse_links(arg.tipo.clone()).borrow() {
+    match Type::collapse_links(arg.tipo.clone()).borrow() {
         Type::App {
             module: module_name,
             name: type_name,

--- a/crates/aiken-project/src/test_framework.rs
+++ b/crates/aiken-project/src/test_framework.rs
@@ -205,8 +205,9 @@ mod test {
 
                 let reify = move |counterexample| {
                     let data_type_refs = utils::indexmap::as_ref_values(&data_types);
-                    let expr = UntypedExpr::reify_data(&data_type_refs, counterexample, &type_info)
-                        .expect("Failed to reify value.");
+                    let expr =
+                        UntypedExpr::reify_data(&data_type_refs, counterexample, type_info.clone())
+                            .expect("Failed to reify value.");
                     Formatter::new().expr(&expr, false).to_pretty_string(70)
                 };
 

--- a/examples/acceptance_tests/122/aiken.toml
+++ b/examples/acceptance_tests/122/aiken.toml
@@ -1,0 +1,9 @@
+name = "aiken-lang/122"
+version = "0.0.0"
+license = "Apache-2.0"
+description = "Aiken contracts for project 'aiken-lang/122'"
+
+[repository]
+user = "aiken-lang"
+project = "122"
+platform = "github"

--- a/examples/acceptance_tests/122/lib/tests.ak
+++ b/examples/acceptance_tests/122/lib/tests.ak
@@ -1,0 +1,31 @@
+const some_pair = Pair(1, 2)
+
+pub type Redeemer =
+  Data
+
+pub type Transaction {
+  redeemers: Pairs<ByteArray, Redeemer>,
+}
+
+pub fn as_data(data: Data) -> Data {
+  data
+}
+
+pub fn arbitrary_transaction(redeemer: Data) -> Fuzzer<Transaction> {
+  fn(prng) { Some((prng, Transaction { redeemers: [Pair("foo", redeemer)] })) }
+}
+
+test pierce_list(tx via arbitrary_transaction([42])) fail once {
+  expect [redeemer] = tx.redeemers
+  redeemer.2nd == as_data([14])
+}
+
+test pierce_tuple(tx via arbitrary_transaction((1, 2))) fail once {
+  expect [redeemer] = tx.redeemers
+  redeemer.2nd == as_data((3, 4))
+}
+
+test pierce_pair(tx via arbitrary_transaction(some_pair)) fail once {
+  expect [redeemer] = tx.redeemers
+  redeemer.2nd == as_data(Pair(3, 4))
+}


### PR DESCRIPTION
  The problem occurs for linked vars holding lists, tuples or pairs. Before this commit, the compiler will panic with:

   ```
   crates/aiken-lang/src/test_framework.rs:1222:26

       failed to reify counterexample?: "invalid type annotation. expected List but got: App { public: true, contains_opaque: false, module: \"\", name: \"Data\", args: [], alias: Some(TypeAliasAnnotation { module: Some(\"tests\"), alias: \"Redeemer\", parameters: [], annotation: Constructor { location: 52..56, module: None, name: \"Data\", arguments: [] } }) }"
   ```