### PR TITLE
Introduce as_data in prelude

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## v1.1.17 - UNRELEASED
 
+### Added
+
+- **aiken-lang**: New prelude function to conveniently upcast any serialisable type into `Data` in places where the compiler cannot do it implicitly.
+
+  ```aiken
+  pub fn as_data(data: Data) -> Data
+  ```
+
 ### Fixed
 
 - **aiken-lang**: Correctly infer Fuzzer & Sampler via type annotations when referring to foreign types. @KtorZ

--- a/crates/aiken-lang/src/builtins.rs
+++ b/crates/aiken-lang/src/builtins.rs
@@ -285,6 +285,22 @@ pub fn prelude(id_gen: &IdGenerator) -> TypeInfo {
         ),
     );
 
+    // as_data
+    prelude.values.insert(
+        "as_data".to_string(),
+        ValueConstructor::public(
+            Type::function(vec![Type::data()], Type::data()),
+            ValueConstructorVariant::ModuleFn {
+                name: "as_data".to_string(),
+                field_map: None,
+                module: "".to_string(),
+                arity: 1,
+                location: Span::empty(),
+                builtin: None,
+            },
+        ),
+    );
+
     // enumerate
     let enumerate_a = Type::generic_var(id_gen.next());
     let enumerate_b = Type::generic_var(id_gen.next());
@@ -1193,6 +1209,53 @@ pub fn prelude_functions(
             function_name: "unconstr_fields".to_string(),
         },
         unconstr_fields_func,
+    );
+
+    functions.insert(
+        FunctionAccessKey {
+            module_name: "".to_string(),
+            function_name: "as_data".to_string(),
+        },
+        Function {
+            arguments: vec![TypedArg {
+                arg_name: ArgName::Named {
+                    name: "data".to_string(),
+                    label: "data".to_string(),
+                    location: Span::empty(),
+                },
+                is_validator_param: false,
+                location: Span::empty(),
+                annotation: None,
+                doc: None,
+                tipo: Type::data(),
+            }],
+            on_test_failure: OnTestFailure::FailImmediately,
+            body: TypedExpr::Var {
+                location: Span::empty(),
+                constructor: ValueConstructor {
+                    public: true,
+                    tipo: Type::data(),
+                    variant: ValueConstructorVariant::LocalVariable {
+                        location: Span::empty(),
+                    },
+                },
+                name: "data".to_string(),
+            },
+            doc: Some(
+                indoc::indoc! {
+                    r#"
+                    A function for explicitly upcasting any serialisable type into `Data`.
+                    "#
+                }
+                .to_string(),
+            ),
+            location: Span::empty(),
+            name: "as_data".to_string(),
+            public: true,
+            return_annotation: None,
+            return_type: Type::data(),
+            end_position: 0,
+        },
     );
 
     // /// Negate the argument. Useful for map/fold and pipelines.

--- a/crates/aiken-lang/src/tests/check.rs
+++ b/crates/aiken-lang/src/tests/check.rs
@@ -4310,3 +4310,22 @@ fn unused_record_fields_5() {
         }
     );
 }
+
+#[test]
+fn as_data() {
+    let source_code = r#"
+        type Foo {
+            foo: Int
+        }
+
+        type Bar {
+            bar: Int
+        }
+
+        test foo() {
+            [as_data(Foo(14)), as_data(Bar(42))] != []
+        }
+    "#;
+
+    assert!(matches!(check_validator(parse(source_code)), Ok(..)))
+}

--- a/crates/aiken-project/src/tests/gen_uplc.rs
+++ b/crates/aiken-project/src/tests/gen_uplc.rs
@@ -6449,3 +6449,37 @@ fn dangling_trace_expect_in_trace() {
 
     assert_uplc(src, program, false, true)
 }
+
+#[test]
+fn as_data() {
+    let src = r#"
+        type Foo {
+            foo: Int
+        }
+
+        type Bar {
+            bar: Int
+        }
+
+        test foo() {
+            [as_data(Foo(14)), as_data(Bar(42))] != []
+        }
+    "#;
+
+    let program = Term::equals_data()
+        .apply(
+            Term::list_data().apply(
+                Term::mk_cons()
+                    .apply(Term::data(Data::constr(0, vec![Data::integer(14.into())])))
+                    .apply(
+                        Term::mk_cons()
+                            .apply(Term::data(Data::constr(0, vec![Data::integer(42.into())])))
+                            .apply(Term::empty_list()),
+                    ),
+            ),
+        )
+        .apply(Term::data(Data::list(vec![])))
+        .if_then_else(Term::bool(false), Term::bool(true));
+
+    assert_uplc(src, program, false, true)
+}


### PR DESCRIPTION
New prelude function to conveniently upcast any serialisable type into `Data` in places where the compiler cannot do it implicitly.

See also: https://github.com/aiken-lang/prelude/pull/11

> [!NOTE]
> I fancied for a second introducing a new language syntax for this, like:
>
> ```aiken
>  type Foo {
>      foo: Int
>  }
>  type Bar {
>     bar: Int
>  }
>
>  test foo() {
>    [~Foo(14), ~Bar(42)] != []
>  }
> ```
> 
> But that felt a bit overkill on top of making the language more complex. The `as_data` function is already fully erase at build time, so it has the same effects anyway.