### PR TITLE
New `--property-coverage` flag to the `check` command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,22 @@
   pub fn as_data(data: Data) -> Data
   ```
 
+- **aiken**: New `--property-coverage` flag to the `check` command, to switch the coverage denominator between the number of iterations and the total number of labels. @KtorZ
+
+  ```
+  -P, --property-coverage <COVERAGE_MODE>
+          Display options for the coverage.
+            - relative-to-labels:
+                Ratio of each label over the total number of labels.
+                Better when labels are mutually-exclusive and present in each test.
+
+            - relative-to-tests:
+                Ratio of each label over the total number of tests/iterations.
+                Better when labels are occasional and non-exclusive per test.
+
+          [default: relative-to-labels]
+  ```
+
 ### Fixed
 
 - **aiken-lang**: Correctly infer Fuzzer & Sampler via type annotations when referring to foreign types. @KtorZ

--- a/crates/aiken-lsp/src/server/lsp_project.rs
+++ b/crates/aiken-lsp/src/server/lsp_project.rs
@@ -1,6 +1,7 @@
 use aiken_lang::{ast::Tracing, line_numbers::LineNumbers, test_framework::PropertyTest};
 use aiken_project::{
     Project, config::ProjectConfig, error::Error as ProjectError, module::CheckedModule,
+    telemetry::CoverageMode,
 };
 use std::{collections::HashMap, path::PathBuf};
 
@@ -38,6 +39,7 @@ impl LspProject {
             false,
             u32::default(),
             PropertyTest::DEFAULT_MAX_SUCCESS,
+            CoverageMode::default(),
             Tracing::verbose(),
             None,
         );

--- a/crates/aiken-project/src/lib.rs
+++ b/crates/aiken-project/src/lib.rs
@@ -28,7 +28,7 @@ use crate::{
     config::ProjectConfig,
     error::{Error, Warning},
     module::{CheckedModule, CheckedModules, ParsedModule, ParsedModules},
-    telemetry::Event,
+    telemetry::{CoverageMode, Event},
 };
 use aiken_lang::{
     IdGenerator,
@@ -275,6 +275,7 @@ where
         exact_match: bool,
         seed: u32,
         property_max_success: usize,
+        coverage_mode: CoverageMode,
         tracing: Tracing,
         env: Option<String>,
     ) -> Result<(), Vec<Error>> {
@@ -290,6 +291,7 @@ where
                     exact_match,
                     seed,
                     property_max_success,
+                    coverage_mode,
                 }
             },
             blueprint_path: self.blueprint_path(None),
@@ -426,6 +428,7 @@ where
                 exact_match,
                 seed,
                 property_max_success,
+                coverage_mode,
             } => {
                 let tests =
                     self.collect_tests(verbose, match_tests, exact_match, options.tracing)?;
@@ -458,8 +461,11 @@ where
                     })
                     .collect();
 
-                self.event_listener
-                    .handle_event(Event::FinishedTests { seed, tests });
+                self.event_listener.handle_event(Event::FinishedTests {
+                    seed,
+                    coverage_mode,
+                    tests,
+                });
 
                 if !errors.is_empty() {
                     Err(errors)

--- a/crates/aiken-project/src/options.rs
+++ b/crates/aiken-project/src/options.rs
@@ -1,6 +1,6 @@
-use std::path::PathBuf;
-
+use crate::telemetry::CoverageMode;
 use aiken_lang::ast::Tracing;
+use std::path::PathBuf;
 
 pub struct Options {
     pub code_gen_mode: CodeGenMode,
@@ -27,6 +27,7 @@ pub enum CodeGenMode {
         exact_match: bool,
         seed: u32,
         property_max_success: usize,
+        coverage_mode: CoverageMode,
     },
     Build(bool),
     Benchmark {

--- a/crates/aiken-project/src/telemetry.rs
+++ b/crates/aiken-project/src/telemetry.rs
@@ -51,6 +51,7 @@ pub enum Event {
     RunningBenchmarks,
     FinishedTests {
         seed: u32,
+        coverage_mode: CoverageMode,
         tests: Vec<TestResult<UntypedExpr, UntypedExpr>>,
     },
     FinishedBenchmarks {
@@ -70,6 +71,39 @@ pub enum Event {
         source: DownloadSource,
     },
     ResolvingVersions,
+}
+
+#[derive(Debug, Clone, Copy, Default)]
+pub enum CoverageMode {
+    RelativeToTests,
+    #[default]
+    RelativeToLabels,
+}
+
+impl CoverageMode {
+    pub fn parse(raw_str: &str) -> Result<Self, String> {
+        if raw_str == "relative-to-tests" {
+            return Ok(CoverageMode::RelativeToTests);
+        }
+
+        if raw_str == "relative-to-labels" {
+            return Ok(CoverageMode::RelativeToLabels);
+        }
+
+        Err(
+            "unexpected coverage mode: neither 'relative-to-tests' nor 'relative-to-labels'"
+                .to_string(),
+        )
+    }
+}
+
+impl Display for CoverageMode {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            CoverageMode::RelativeToTests => write!(f, "relative-to-tests"),
+            CoverageMode::RelativeToLabels => write!(f, "relative-to-labels"),
+        }
+    }
 }
 
 pub enum EventTarget {

--- a/crates/aiken/src/cmd/check.rs
+++ b/crates/aiken/src/cmd/check.rs
@@ -6,7 +6,7 @@ use aiken_lang::{
     test_framework::PropertyTest,
 };
 use aiken_project::{
-    telemetry::json_schema,
+    telemetry::{CoverageMode, json_schema},
     watch::{self, watch_project, with_project},
 };
 use rand::prelude::*;
@@ -67,6 +67,25 @@ pub struct Args {
     #[clap(long, default_value_t = PropertyTest::DEFAULT_MAX_SUCCESS, value_name="UINT")]
     max_success: usize,
 
+    /// Display options for the property tests labels coverage.
+    ///
+    ///   - relative-to-labels:
+    ///       Ratio of each label over the total number of labels.
+    ///       Better when labels are mutually-exclusive and present in each test.
+    ///
+    ///   - relative-to-tests:
+    ///       Ratio of each label over the total number of tests/iterations.
+    ///       Better when labels are occasional and non-exclusive per test.
+    #[clap(
+        long,
+        short = 'P',
+        default_value_t = CoverageMode::default(),
+        value_parser = CoverageMode::parse,
+        value_name="COVERAGE_MODE",
+        verbatim_doc_comment
+    )]
+    property_coverage: CoverageMode,
+
     /// Only run tests if they match any of these strings.
     /// You can match a module with `-m aiken/list` or `-m list`.
     /// You can match a test with `-m "aiken/list.{map}"` or `-m "aiken/option.{flatten_1}"`
@@ -120,6 +139,7 @@ pub fn exec(
         debug,
         show_json_schema,
         match_tests,
+        property_coverage,
         exact_match,
         watch,
         trace_filter,
@@ -147,6 +167,7 @@ pub fn exec(
                 exact_match,
                 seed,
                 max_success,
+                property_coverage,
                 match trace_filter {
                     Some(trace_filter) => trace_filter(trace_level),
                     None => Tracing::All(trace_level),
@@ -168,6 +189,7 @@ pub fn exec(
                     exact_match,
                     seed,
                     max_success,
+                    property_coverage,
                     match trace_filter {
                         Some(trace_filter) => trace_filter(trace_level),
                         None => Tracing::All(trace_level),


### PR DESCRIPTION
For switching the coverage denominator between the number of iterations and the total number of labels.

```
  -P, --property-coverage <COVERAGE_MODE>
          Display options for the coverage.
            - relative-to-labels:
                Ratio of each label over the total number of labels.
                Better when labels are mutually-exclusive and present in each test.
            - relative-to-tests:
                Ratio of each label over the total number of tests/iterations.
                Better when labels are occasional and non-exclusive per test.
          [default: relative-to-labels]
```

e.g.

<details><summary>-P relative-to-labels</summary>

```
    ┍━ check_badges.test ━━━━━━━━━━━━━━━━━━━━━━━━━━
    │ PASS [after 100 tests] prop_scenario_coverage
    │ · with coverage
    │ | O.K.  57.0%
    │ | K.O.  43.0%
    │ PASS [after 100 tests] prop_check_badges_ok
    │ · with coverage
    │ | · at least one spent authorization       31.1%
    │ | · at least one reference authorization   27.3%
    │ | · mixed of reference/spent badges        18.5%
    │ | · more than one badge checked            13.9%
    │ | · more authorizations than necessary      9.2%
    │ PASS [after 100 tests] prop_check_badges_ko
    │ · with coverage
    │ | · unauthorized (key) reference      34.0%
    │ | · unauthorized (script) reference   28.0%
    │ | · unrecognized spent                24.0%
    │ | · unrecognized reference            11.0%
    │ | · out-of-range index                 3.0%
    ┕ with --seed=1168689779 → 3 tests | 3 passed | 0 failed
```
</details>

<details><summary>-P relative-to-tests</summary>

```
    ┍━ check_badges.test ━━━━━━━━━━━━━━━━━━━━━━━━━━
    │ PASS [after 100 tests] prop_scenario_coverage
    │ · with coverage
    │ | O.K.  54.0%
    │ | K.O.  46.0%
    │ PASS [after 100 tests] prop_check_badges_ok
    │ · with coverage
    │ | · at least one spent authorization       81.0%
    │ | · at least one reference authorization   65.0%
    │ | · mixed of reference/spent badges        50.0%
    │ | · more than one badge checked            37.0%
    │ | · more authorizations than necessary     23.0%
    │ PASS [after 100 tests] prop_check_badges_ko
    │ · with coverage
    │ | · unauthorized (script) reference   30.0%
    │ | · unrecognized spent                24.0%
    │ | · unauthorized (key) reference      21.0%
    │ | · unrecognized reference            18.0%
    │ | · out-of-range index                 7.0%
    ┕ with --seed=583550986 → 3 tests | 3 passed | 0 failed
```
</details>