### PR TITLE
Allow inline Pair in via Fuzzer's eDSL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - **aiken-lang**: Correctly infer Fuzzer & Sampler via type annotations when referring to foreign types. @KtorZ
 - **aiken-lang**: Allow type reification to pierce through Data aliases (e.g. Redeemer) holding lists, tuples or pairs, instead of crashing the compiler. @KtorZ
+- **aiken-lang**: Allow `Pair` to be used inline in Fuzzer's eDSL. @KtorZ
 
 ## v1.1.16 - 2025-04-14
 

--- a/crates/aiken-lang/src/parser/definition/snapshots/pair_in_via.snap
+++ b/crates/aiken-lang/src/parser/definition/snapshots/pair_in_via.snap
@@ -1,0 +1,78 @@
+---
+source: crates/aiken-lang/src/parser/definition/test_like.rs
+description: "Code:\n\ntest foo(x via some_generator(Pair(14, 42))) {\n  x == 56\n}\n"
+---
+Test(
+    Function {
+        arguments: [
+            ArgVia {
+                arg: UntypedArg {
+                    by: ByName(
+                        Named {
+                            name: "x",
+                            label: "x",
+                            location: 9..10,
+                        },
+                    ),
+                    location: 9..10,
+                    annotation: None,
+                    doc: None,
+                    is_validator_param: false,
+                },
+                via: Call {
+                    arguments: [
+                        CallArg {
+                            label: None,
+                            location: 30..42,
+                            value: Pair {
+                                location: 34..42,
+                                fst: UInt {
+                                    location: 35..37,
+                                    value: "14",
+                                    base: Decimal {
+                                        numeric_underscore: false,
+                                    },
+                                },
+                                snd: UInt {
+                                    location: 39..41,
+                                    value: "42",
+                                    base: Decimal {
+                                        numeric_underscore: false,
+                                    },
+                                },
+                            },
+                        },
+                    ],
+                    fun: Var {
+                        location: 15..29,
+                        name: "some_generator",
+                    },
+                    location: 15..43,
+                },
+            },
+        ],
+        body: BinOp {
+            location: 49..56,
+            name: Eq,
+            left: Var {
+                location: 49..50,
+                name: "x",
+            },
+            right: UInt {
+                location: 54..56,
+                value: "56",
+                base: Decimal {
+                    numeric_underscore: false,
+                },
+            },
+        },
+        doc: None,
+        location: 0..44,
+        name: "foo",
+        public: false,
+        return_annotation: None,
+        return_type: (),
+        end_position: 57,
+        on_test_failure: FailImmediately,
+    },
+)

--- a/crates/aiken-lang/src/parser/definition/test_like.rs
+++ b/crates/aiken-lang/src/parser/definition/test_like.rs
@@ -6,7 +6,7 @@ use crate::{
         annotation,
         chain::{Chain, call::parser as call, field_access, tuple_index::parser as tuple_index},
         error::ParseError,
-        expr::{self, bytearray, int as uint, list, string, tuple, var},
+        expr::{self, bytearray, int as uint, list, pair, string, tuple, var},
         pattern,
         token::Token,
     },
@@ -129,6 +129,7 @@ pub fn fuzzer<'a>() -> impl Parser<Token, UntypedExpr, Error = ParseError> + 'a 
             int(),
             string(),
             bytearray(),
+            pair(expression.clone()),
             tuple(expression.clone()),
             list(expression.clone()),
             var(),
@@ -140,4 +141,20 @@ pub fn fuzzer<'a>() -> impl Parser<Token, UntypedExpr, Error = ParseError> + 'a 
             Chain::TupleIndex(index, span) => expr.tuple_index(index, span),
         })
     })
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::assert_definition;
+
+    #[test]
+    fn test_pair_in_via() {
+        assert_definition!(
+            r#"
+            test foo(x via some_generator(Pair(14, 42))) {
+              x == 56
+            }
+            "#
+        );
+    }
 }


### PR DESCRIPTION
The alternative is otherwise confusing as the parser will succeed, but the type-checker fails because of an unknown type `Pair`. Given how particular are pairs, they deserve special treatment here too.