### PR TITLE
Lsp quickfixes renamed imports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@
 - **aiken-lang**: Correctly infer Fuzzer & Sampler via type annotations when referring to foreign types. @KtorZ
 - **aiken-lang**: Allow type reification to pierce through Data aliases (e.g. Redeemer) holding lists, tuples or pairs, instead of crashing the compiler. @KtorZ
 - **aiken-lang**: Allow `Pair` to be used inline in Fuzzer's eDSL. @KtorZ
+- **aiken-lsp**: Fix module's inhabitant import quickfix for renamed modules. @KtorZ
 
 ## v1.1.16 - 2025-04-14
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@
 - **aiken-lang**: Allow type reification to pierce through Data aliases (e.g. Redeemer) holding lists, tuples or pairs, instead of crashing the compiler. @KtorZ
 - **aiken-lang**: Allow `Pair` to be used inline in Fuzzer's eDSL. @KtorZ
 - **aiken-lsp**: Fix module's inhabitant import quickfix for renamed modules. @KtorZ
+- **aiken-lsp**: Fix quickfix suggestion to use qualified for renamed modules. @KtorZ
 
 ## v1.1.16 - 2025-04-14
 

--- a/crates/aiken-lang/src/ast.rs
+++ b/crates/aiken-lang/src/ast.rs
@@ -484,7 +484,7 @@ pub struct Use<PackageName> {
     pub location: Span,
     pub module: Vec<String>,
     pub package: PackageName,
-    pub unqualified: Vec<UnqualifiedImport>,
+    pub unqualified: (usize, Vec<UnqualifiedImport>),
 }
 
 pub type TypedModuleConstant = ModuleConstant<TypedExpr>;

--- a/crates/aiken-lang/src/format.rs
+++ b/crates/aiken-lang/src/format.rs
@@ -317,7 +317,7 @@ impl<'comments> Formatter<'comments> {
         Use {
             module,
             as_name,
-            unqualified,
+            unqualified: (_, unqualified),
             ..
         }: &'a Use<()>,
     ) -> Document<'a> {

--- a/crates/aiken-lang/src/parser.rs
+++ b/crates/aiken-lang/src/parser.rs
@@ -41,9 +41,9 @@ pub fn module(
                     }
                     Some((location, unqualified)) => {
                         let mut merged_unqualified = Vec::new();
-                        merged_unqualified.extend(unqualified);
-                        merged_unqualified.extend(import.unqualified);
-                        store.insert(key, (location, merged_unqualified));
+                        merged_unqualified.extend(unqualified.1);
+                        merged_unqualified.extend(import.unqualified.1);
+                        store.insert(key, (location, (unqualified.0, merged_unqualified)));
                     }
                 }
             }

--- a/crates/aiken-lang/src/parser/definition/snapshots/import_alias.snap
+++ b/crates/aiken-lang/src/parser/definition/snapshots/import_alias.snap
@@ -12,5 +12,8 @@ Use {
         "list",
     ],
     package: (),
-    unqualified: [],
+    unqualified: (
+        14,
+        [],
+    ),
 }

--- a/crates/aiken-lang/src/parser/definition/snapshots/import_basic.snap
+++ b/crates/aiken-lang/src/parser/definition/snapshots/import_basic.snap
@@ -10,5 +10,8 @@ Use {
         "list",
     ],
     package: (),
-    unqualified: [],
+    unqualified: (
+        14,
+        [],
+    ),
 }

--- a/crates/aiken-lang/src/parser/definition/snapshots/import_unqualified.snap
+++ b/crates/aiken-lang/src/parser/definition/snapshots/import_unqualified.snap
@@ -10,20 +10,23 @@ Use {
         "address",
     ],
     package: (),
-    unqualified: [
-        UnqualifiedImport {
-            location: 17..29,
-            name: "Address",
-            as_name: Some(
-                "A",
-            ),
-        },
-        UnqualifiedImport {
-            location: 31..41,
-            name: "thing",
-            as_name: Some(
-                "w",
-            ),
-        },
-    ],
+    unqualified: (
+        42,
+        [
+            UnqualifiedImport {
+                location: 17..29,
+                name: "Address",
+                as_name: Some(
+                    "A",
+                ),
+            },
+            UnqualifiedImport {
+                location: 31..41,
+                name: "thing",
+                as_name: Some(
+                    "w",
+                ),
+            },
+        ],
+    ),
 }

--- a/crates/aiken-lang/src/snapshots/can_handle_comments_at_end_of_file.snap
+++ b/crates/aiken-lang/src/snapshots/can_handle_comments_at_end_of_file.snap
@@ -15,7 +15,10 @@ Module {
                     "aiken",
                 ],
                 package: (),
-                unqualified: [],
+                unqualified: (
+                    9,
+                    [],
+                ),
             },
         ),
     ],

--- a/crates/aiken-lang/src/snapshots/merge_imports.snap
+++ b/crates/aiken-lang/src/snapshots/merge_imports.snap
@@ -16,23 +16,26 @@ Module {
                     "list",
                 ],
                 package: (),
-                unqualified: [
-                    UnqualifiedImport {
-                        location: 16..19,
-                        name: "bar",
-                        as_name: None,
-                    },
-                    UnqualifiedImport {
-                        location: 21..24,
-                        name: "foo",
-                        as_name: None,
-                    },
-                    UnqualifiedImport {
-                        location: 42..45,
-                        name: "baz",
-                        as_name: None,
-                    },
-                ],
+                unqualified: (
+                    25,
+                    [
+                        UnqualifiedImport {
+                            location: 16..19,
+                            name: "bar",
+                            as_name: None,
+                        },
+                        UnqualifiedImport {
+                            location: 21..24,
+                            name: "foo",
+                            as_name: None,
+                        },
+                        UnqualifiedImport {
+                            location: 42..45,
+                            name: "baz",
+                            as_name: None,
+                        },
+                    ],
+                ),
             },
         ),
     ],

--- a/crates/aiken-lang/src/snapshots/windows_newline.snap
+++ b/crates/aiken-lang/src/snapshots/windows_newline.snap
@@ -16,7 +16,10 @@ Module {
                     "list",
                 ],
                 package: (),
-                unqualified: [],
+                unqualified: (
+                    14,
+                    [],
+                ),
             },
         ),
     ],

--- a/crates/aiken-lang/src/tipo/environment.rs
+++ b/crates/aiken-lang/src/tipo/environment.rs
@@ -953,7 +953,7 @@ impl<'a> Environment<'a> {
             Definition::Use(Use {
                 module,
                 as_name,
-                unqualified,
+                unqualified: (_, unqualified),
                 location,
                 package: _,
             }) => {

--- a/crates/aiken-lsp/src/quickfix.rs
+++ b/crates/aiken-lsp/src/quickfix.rs
@@ -289,7 +289,7 @@ fn suggest_qualified(
     range: &lsp_types::Range,
 ) -> Option<AnnotatedEdit> {
     if let Some(AnnotatedEdit::SimpleEdit(use_qualified_title, use_qualified)) =
-        ParsedDocument::use_qualified(&module.name, identifier, range)
+        parsed_document.use_qualified(module, identifier, range)
     {
         if let Some(AnnotatedEdit::SimpleEdit(_, add_new_line)) =
             parsed_document.import(module, None)


### PR DESCRIPTION
- :round_pushpin: **Fix module's inhabitant import quickfix for renamed modules.**
    For example, trying to use quickfix _import Foo from foo_ in a module
  that looks like:

  ```aiken
  use foo.{Bar} as renamed
  ```

  would result in:

  ```aiken
  use foo.{Bar} as renamed.{Foo}
  ```

  instead of:

  ```aiken
  use foo.{Bar, Foo} as renamed
  ```

  This is now fixed, although only tested manually since we don't have
  any good ways of automatically testing the LSP quickfixes...

- :round_pushpin: **Fix quickfix suggestion to use qualified for renamed modules.**
    When a module is declared as:

  ```
  use foo as renamed
  ```

  We would otherwise wrongly suggest to _import Foo from foo_, instead
  of correctly suggesting to _import Foo from renamed_.

  This commit fixes it.
