### PR TITLE
Lsp pub and pluck quickfixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,8 +26,9 @@
   pub fn as_data(data: Data) -> Data
   ```
 
-- **aiken-lsp**: New quickfix to automatically plucking inferred types in holes within annotations. @KtorZ
-- **aiken-lsp**: New quickfix to automatically make functions and constants public when detected unused. @KtorZ
+- **aiken-lsp**: New quickfix to pluck inferred types in holes within annotations. @KtorZ
+- **aiken-lsp**: New quickfix to make functions and constants public when detected unused. @KtorZ
+- **aiken-lsp**: New quickfix to make types public when 'leaking' from a public function (e.g. validator handlers). @KtorZ
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,7 +27,7 @@
   ```
 
 - **aiken-lsp**: New quickfix to pluck inferred types in holes within annotations. @KtorZ
-- **aiken-lsp**: New quickfix to make functions and constants public when detected unused. @KtorZ
+- **aiken-lsp**: New quickfix to make private functions, types or constants public when detected unused. @KtorZ
 - **aiken-lsp**: New quickfix to make types public when 'leaking' from a public function (e.g. validator handlers). @KtorZ
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,12 +4,6 @@
 
 ### Added
 
-- **aiken-lang**: New prelude function to conveniently upcast any serialisable type into `Data` in places where the compiler cannot do it implicitly.
-
-  ```aiken
-  pub fn as_data(data: Data) -> Data
-  ```
-
 - **aiken**: New `--property-coverage` flag to the `check` command, to switch the coverage denominator between the number of iterations and the total number of labels. @KtorZ
 
   ```
@@ -25,6 +19,14 @@
 
           [default: relative-to-labels]
   ```
+
+- **aiken-lang**: New prelude function to conveniently upcast any serialisable type into `Data` in places where the compiler cannot do it implicitly.
+
+  ```aiken
+  pub fn as_data(data: Data) -> Data
+  ```
+
+- **aiken-lsp**: New quickfix for automatically plucking inferred types in holes within annotations. @KtorZ
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,8 @@
   pub fn as_data(data: Data) -> Data
   ```
 
-- **aiken-lsp**: New quickfix for automatically plucking inferred types in holes within annotations. @KtorZ
+- **aiken-lsp**: New quickfix to automatically plucking inferred types in holes within annotations. @KtorZ
+- **aiken-lsp**: New quickfix to automatically make functions and constants public when detected unused. @KtorZ
 
 ### Fixed
 

--- a/crates/aiken-lang/src/tipo/error.rs
+++ b/crates/aiken-lang/src/tipo/error.rs
@@ -1895,13 +1895,13 @@ impl ExtraData for Warning {
             | Warning::SingleWhenClause { .. }
             | Warning::Todo { .. }
             | Warning::UnusedConstructor { .. }
-            | Warning::UnusedType { .. }
             | Warning::UnusedVariable { .. }
             | Warning::DiscardedLetAssignment { .. }
             | Warning::ValidatorInLibraryModule { .. }
             | Warning::CompactTraceLabelIsNotstring { .. }
             | Warning::UseWhenInstead { .. } => None,
             Warning::UnusedPrivateFunction { name, .. }
+            | Warning::UnusedType { name, .. }
             | Warning::UnusedPrivateModuleConstant { name, .. } => Some(name.clone()),
             Warning::Utf8ByteArrayIsValidHexString { value, .. } => Some(value.clone()),
             Warning::UnexpectedTypeHole { tipo, .. } => Some(tipo.to_pretty(0)),

--- a/crates/aiken-lang/src/tipo/error.rs
+++ b/crates/aiken-lang/src/tipo/error.rs
@@ -1873,7 +1873,6 @@ impl ExtraData for Warning {
             | Warning::SingleConstructorExpect { .. }
             | Warning::SingleWhenClause { .. }
             | Warning::Todo { .. }
-            | Warning::UnexpectedTypeHole { .. }
             | Warning::UnusedConstructor { .. }
             | Warning::UnusedPrivateFunction { .. }
             | Warning::UnusedPrivateModuleConstant { .. }
@@ -1884,13 +1883,13 @@ impl ExtraData for Warning {
             | Warning::CompactTraceLabelIsNotstring { .. }
             | Warning::UseWhenInstead { .. } => None,
             Warning::Utf8ByteArrayIsValidHexString { value, .. } => Some(value.clone()),
+            Warning::UnexpectedTypeHole { tipo, .. } => Some(tipo.to_pretty(0)),
             Warning::UnusedImportedModule { location, .. } => {
                 Some(format!("{},{}", false, location.start))
             }
             Warning::UnusedImportedValueOrType { location, .. } => {
                 Some(format!("{},{}", true, location.start))
             }
-
             Warning::UnusedRecordFields { suggestion, .. } => {
                 Some(Formatter::new().pattern(suggestion).to_pretty_string(80))
             }

--- a/crates/aiken-lang/src/tipo/error.rs
+++ b/crates/aiken-lang/src/tipo/error.rs
@@ -1874,14 +1874,14 @@ impl ExtraData for Warning {
             | Warning::SingleWhenClause { .. }
             | Warning::Todo { .. }
             | Warning::UnusedConstructor { .. }
-            | Warning::UnusedPrivateFunction { .. }
-            | Warning::UnusedPrivateModuleConstant { .. }
             | Warning::UnusedType { .. }
             | Warning::UnusedVariable { .. }
             | Warning::DiscardedLetAssignment { .. }
             | Warning::ValidatorInLibraryModule { .. }
             | Warning::CompactTraceLabelIsNotstring { .. }
             | Warning::UseWhenInstead { .. } => None,
+            Warning::UnusedPrivateFunction { name, .. }
+            | Warning::UnusedPrivateModuleConstant { name, .. } => Some(name.clone()),
             Warning::Utf8ByteArrayIsValidHexString { value, .. } => Some(value.clone()),
             Warning::UnexpectedTypeHole { tipo, .. } => Some(tipo.to_pretty(0)),
             Warning::UnusedImportedModule { location, .. } => {

--- a/crates/aiken-lang/src/tipo/error.rs
+++ b/crates/aiken-lang/src/tipo/error.rs
@@ -586,13 +586,23 @@ The culprit is:
 {type_info}
 
 Maybe you meant to turn it public using the '{keyword_pub}' keyword?"#
-        , type_info = leaked.to_pretty(4).if_supports_color(Stdout, |s| s.red())
+        , type_info = if leaked.alias().is_some() {
+            let alias = leaked.to_pretty(0).if_supports_color(Stdout, |s| s.magenta()).to_string();
+            format!(
+                "{} aliased as {alias}",
+                leaked.clone().set_alias(None).to_pretty(4).if_supports_color(Stdout, |s| s.red()),
+            )
+        } else {
+            leaked.to_pretty(4).if_supports_color(Stdout, |s| s.red()).to_string()
+        }
         , keyword_pub = "pub".if_supports_color(Stdout, |s| s.bright_blue())
     ))]
     PrivateTypeLeak {
         #[label("private type leak")]
         location: Span,
         leaked: Type,
+        #[label("defined here")]
+        leaked_location: Option<Span>,
     },
 
     #[error(
@@ -1148,7 +1158,6 @@ impl ExtraData for Error {
             | Error::NotExhaustivePatternMatch { .. }
             | Error::NotFn { .. }
             | Error::PositionalArgumentAfterLabeled { .. }
-            | Error::PrivateTypeLeak { .. }
             | Error::RecordAccessUnknownType { .. }
             | Error::RecordUpdateInvalidConstructor { .. }
             | Error::RecursiveType { .. }
@@ -1178,6 +1187,18 @@ impl ExtraData for Error {
             | Error::IncorrectBenchmarkArity { .. }
             | Error::MustInferFirst { .. }
             | Error::InvalidFieldAccess { .. } => None,
+
+            Error::PrivateTypeLeak {
+                leaked,
+                leaked_location,
+                ..
+            } => leaked_location.map(|span| {
+                format!(
+                    "{},{}",
+                    leaked.clone().set_alias(None).to_pretty(0),
+                    span.start
+                )
+            }),
 
             Error::UnknownType { name, .. }
             | Error::UnknownTypeConstructor { name, .. }

--- a/crates/aiken-lang/src/tipo/hydrator.rs
+++ b/crates/aiken-lang/src/tipo/hydrator.rs
@@ -101,7 +101,7 @@ impl Hydrator {
         let mut unbounds = vec![];
         let tipo = self.do_type_from_annotation(annotation, environment, &mut unbounds)?;
 
-        if let Some(location) = unbounds.last() {
+        if let Some((tipo, location)) = unbounds.last() {
             environment.warnings.push(Warning::UnexpectedTypeHole {
                 location: **location,
                 tipo: tipo.clone(),
@@ -117,7 +117,7 @@ impl Hydrator {
         &mut self,
         annotation: &'a Annotation,
         environment: &mut Environment,
-        unbounds: &mut Vec<&'a Span>,
+        unbounds: &mut Vec<(Rc<Type>, &'a Span)>,
     ) -> Result<Rc<Type>, Error> {
         let return_type = match annotation {
             Annotation::Constructor {
@@ -229,8 +229,9 @@ impl Hydrator {
             },
 
             Annotation::Hole { location, .. } => {
-                unbounds.push(location);
-                Ok(environment.new_unbound_var())
+                let unbound = environment.new_unbound_var();
+                unbounds.push((unbound.clone(), location));
+                Ok(unbound)
             }
 
             Annotation::Tuple { elems, .. } => {

--- a/crates/aiken-lsp/README.md
+++ b/crates/aiken-lsp/README.md
@@ -33,7 +33,20 @@ instructions](https://github.com/neovim/nvim-lspconfig/blob/master/doc/server_co
 - [x] Go-to definition
 - [x] Type annotation on hover
 - [x] Code actions providing quickfixes for a variety of errors:
-    - [x] `aiken::check::unknown::variable`
-    - [x] `aiken::check::unknown::type`
-    - [x] `aiken::check::unknown::type_constructor`
-    - [x] `aiken::check::unknown::module`
+
+  | error                                            | quickfix                                           |
+  | ---                                              | ---                                                |
+  | `check::unknown::variable`                       | Add relevant import or use qualified import inline |
+  | `check::unknown::type`                           | Add relevant import or use qualified import inline |
+  | `check::unknown::type_constructor`               | Add relevant import or use qualified import inline |
+  | `check::unknown::module`                         | Add relevant import                                |
+  | `check::unused:import::value`                    | Remove redundant imports                           |
+  | `check::unused::import::module`                  | Remove redundant imports                           |
+  | `check::single_constructor_expect`               | Replace `expect` with `let`                        |
+  | `check::syntax::unused_record_fields`            | Remove redundant fields                            |
+  | `check::syntax::bytearray_literal_is_hex_string` | Prefix string with `#`                             |
+  | `check::unexpected::type_hole`                   | Replace type hole with inferred type               |
+  | `check::unused::function`                        | Make private function public                       |
+  | `check::unused::constant`                        | Make private constant public                       |
+  | `check::unused::type`                            | Make private type public                           |
+  | `check::private_leak`                            | Make leaked type public                            |

--- a/crates/aiken-lsp/src/edits.rs
+++ b/crates/aiken-lsp/src/edits.rs
@@ -52,6 +52,18 @@ fn insert_text(at: usize, line_numbers: &LineNumbers, new_text: String) -> lsp_t
 /// whether the import is a newline or not. It is set to 'false' when adding a qualified import
 /// to an existing list.
 impl ParsedDocument {
+    pub fn position(&self, index: usize) -> lsp_types::Position {
+        let cursor = self
+            .line_numbers
+            .line_and_column_number(index)
+            .expect("Spans are within bounds");
+
+        lsp_types::Position {
+            line: cursor.line as u32 - 1,
+            character: cursor.column as u32 - 1,
+        }
+    }
+
     pub fn import(
         &self,
         import: &CheckedModule,

--- a/crates/aiken-lsp/src/quickfix.rs
+++ b/crates/aiken-lsp/src/quickfix.rs
@@ -190,7 +190,7 @@ pub fn quickfix(
                 &mut actions,
                 text_document,
                 diagnostic,
-                make_type_public(&parsed_document, diagnostic),
+                make_type_public(parsed_document, diagnostic),
             ),
         };
     }

--- a/crates/aiken-lsp/src/quickfix.rs
+++ b/crates/aiken-lsp/src/quickfix.rs
@@ -18,6 +18,7 @@ const UTF8_BYTE_ARRAY_IS_VALID_HEX_STRING: &str =
 const UNEXPECTED_TYPE_HOLE: &str = "aiken::check::unexpected::type_hole";
 const UNUSED_PRIVATE_FUNCTION: &str = "aiken::check::unused::function";
 const UNUSED_PRIVATE_CONSTANT: &str = "aiken::check::unused::constant";
+const UNUSED_PRIVATE_TYPE: &str = "aiken::check::unused::type";
 const PRIVATE_TYPE_LEAK: &str = "aiken::check::private_leak";
 
 /// Errors for which we can provide quickfixes
@@ -91,6 +92,7 @@ pub fn assert(diagnostic: lsp_types::Diagnostic) -> Option<Quickfix> {
 
     if match_code(&diagnostic, Severity::WARNING, UNUSED_PRIVATE_FUNCTION)
         || match_code(&diagnostic, Severity::WARNING, UNUSED_PRIVATE_CONSTANT)
+        || match_code(&diagnostic, Severity::WARNING, UNUSED_PRIVATE_TYPE)
     {
         return Some(Quickfix::UnusedPrivate(diagnostic));
     }

--- a/crates/aiken-lsp/src/quickfix.rs
+++ b/crates/aiken-lsp/src/quickfix.rs
@@ -16,6 +16,8 @@ const UNUSED_RECORD_FIELDS: &str = "aiken::check::syntax::unused_record_fields";
 const UTF8_BYTE_ARRAY_IS_VALID_HEX_STRING: &str =
     "aiken::check::syntax::bytearray_literal_is_hex_string";
 const UNEXPECTED_TYPE_HOLE: &str = "aiken::check::unexpected::type_hole";
+const UNUSED_PRIVATE_FUNCTION: &str = "aiken::check::unused::function";
+const UNUSED_PRIVATE_CONSTANT: &str = "aiken::check::unused::constant";
 
 /// Errors for which we can provide quickfixes
 #[allow(clippy::enum_variant_names)]
@@ -28,6 +30,7 @@ pub enum Quickfix {
     UseLet(lsp_types::Diagnostic),
     UnusedRecordFields(lsp_types::Diagnostic),
     UnexpectedTypeHole(lsp_types::Diagnostic),
+    UnusedPrivate(lsp_types::Diagnostic),
 }
 
 fn match_code(
@@ -82,6 +85,12 @@ pub fn assert(diagnostic: lsp_types::Diagnostic) -> Option<Quickfix> {
 
     if match_code(&diagnostic, Severity::WARNING, UNEXPECTED_TYPE_HOLE) {
         return Some(Quickfix::UnexpectedTypeHole(diagnostic));
+    }
+
+    if match_code(&diagnostic, Severity::WARNING, UNUSED_PRIVATE_FUNCTION)
+        || match_code(&diagnostic, Severity::WARNING, UNUSED_PRIVATE_CONSTANT)
+    {
+        return Some(Quickfix::UnusedPrivate(diagnostic));
     }
 
     None
@@ -162,6 +171,12 @@ pub fn quickfix(
                 text_document,
                 diagnostic,
                 fill_type_hole(diagnostic),
+            ),
+            Quickfix::UnusedPrivate(diagnostic) => each_as_distinct_action(
+                &mut actions,
+                text_document,
+                diagnostic,
+                make_value_public(diagnostic),
             ),
         };
     }
@@ -422,6 +437,25 @@ fn fill_type_hole(diagnostic: &lsp_types::Diagnostic) -> Vec<AnnotatedEdit> {
             lsp_types::TextEdit {
                 range: diagnostic.range,
                 new_text: inferred_type.to_string(),
+            },
+        ));
+    }
+
+    edits
+}
+
+fn make_value_public(diagnostic: &lsp_types::Diagnostic) -> Vec<AnnotatedEdit> {
+    let mut edits = Vec::new();
+
+    if let Some(serde_json::Value::String(name)) = diagnostic.data.as_ref() {
+        edits.push(AnnotatedEdit::SimpleEdit(
+            format!("Make '{}' public", name),
+            lsp_types::TextEdit {
+                range: lsp_types::Range {
+                    start: diagnostic.range.start,
+                    end: diagnostic.range.start,
+                },
+                new_text: "pub ".to_string(),
             },
         ));
     }


### PR DESCRIPTION
- :round_pushpin: **New quickfix for automatically plucking inferred types in holes within annotations.**
  

- :round_pushpin: **New quickfix to automatically make functions and constants public when detected unused.**
  

- :round_pushpin: **New quickfix to make types public when 'leaking' from a public function (e.g. validator handlers)**
    Also improved the error message when detecting a leaking type through
  an aliased type. Now display both the alias and the source type, for
  clarity.

- :round_pushpin: **Also enable unused quickfix for types.**
  
