### PR TITLE
Pretty print execution units

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 _site/
 temp/
 scratch/
+.vscode/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## v1.1.18 - UNRELEASED
+
+### Added
+
+- **aiken-project**: Pretty print execution units. Added `--plain-numbers`
+  flag to `check` command, to switch between the two formats.
+
+### Changed
+
+### Removed
+
+
 ## v1.1.17 - 2025-05-08
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -156,6 +156,7 @@ dependencies = [
  "miette 7.6.0",
  "notify",
  "num-bigint",
+ "numfmt",
  "ordinal 0.4.0",
  "owo-colors 3.5.0",
  "pallas-addresses",
@@ -971,6 +972,12 @@ dependencies = [
  "colored",
  "fnv",
 ]
+
+[[package]]
+name = "dtoa"
+version = "1.0.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6add3b8cff394282be81f3fc1a0605db594ed69890078ca6e2cab1c408bcf04"
 
 [[package]]
 name = "dyn-clone"
@@ -2195,6 +2202,16 @@ checksum = "4161fcb6d602d4d2081af7c3a45852d875a03dd337a6bfdd6e06407b61342a43"
 dependencies = [
  "hermit-abi 0.3.9",
  "libc",
+]
+
+[[package]]
+name = "numfmt"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db7467e47de9fb6ea5b3f47dc34c1cf0b86359f072a46f6278119544cdbd0021"
+dependencies = [
+ "dtoa",
+ "itoa",
 ]
 
 [[package]]

--- a/crates/aiken-lsp/src/server/lsp_project.rs
+++ b/crates/aiken-lsp/src/server/lsp_project.rs
@@ -42,6 +42,7 @@ impl LspProject {
             CoverageMode::default(),
             Tracing::verbose(),
             None,
+            false,
         );
 
         self.project.restore(checkpoint);

--- a/crates/aiken-project/Cargo.toml
+++ b/crates/aiken-project/Cargo.toml
@@ -56,6 +56,7 @@ uplc = { path = '../uplc', version = "1.1.17" }
 vec1 = "1.10.1"
 walkdir.workspace = true
 zip = "0.6.4"
+numfmt = "1.1.1"
 
 [target.'cfg(not(windows))'.dependencies]
 katex = "0.4"

--- a/crates/aiken-project/src/lib.rs
+++ b/crates/aiken-project/src/lib.rs
@@ -277,6 +277,7 @@ where
         coverage_mode: CoverageMode,
         tracing: Tracing,
         env: Option<String>,
+        plain_numbers: bool,
     ) -> Result<(), Vec<Error>> {
         let options = Options {
             tracing,
@@ -291,6 +292,7 @@ where
                     seed,
                     property_max_success,
                     coverage_mode,
+                    plain_numbers,
                 }
             },
             blueprint_path: self.blueprint_path(None),
@@ -428,6 +430,7 @@ where
                 seed,
                 property_max_success,
                 coverage_mode,
+                plain_numbers,
             } => {
                 let tests =
                     self.collect_tests(verbose, match_tests, exact_match, options.tracing)?;
@@ -464,6 +467,7 @@ where
                     seed,
                     coverage_mode,
                     tests,
+                    plain_numbers,
                 });
 
                 if !errors.is_empty() {

--- a/crates/aiken-project/src/options.rs
+++ b/crates/aiken-project/src/options.rs
@@ -28,6 +28,7 @@ pub enum CodeGenMode {
         seed: u32,
         property_max_success: usize,
         coverage_mode: CoverageMode,
+        plain_numbers: bool,
     },
     Build(bool),
     Benchmark {

--- a/crates/aiken-project/src/telemetry.rs
+++ b/crates/aiken-project/src/telemetry.rs
@@ -53,6 +53,7 @@ pub enum Event {
         seed: u32,
         coverage_mode: CoverageMode,
         tests: Vec<TestResult<UntypedExpr, UntypedExpr>>,
+        plain_numbers: bool,
     },
     FinishedBenchmarks {
         seed: u32,

--- a/crates/aiken/src/cmd/check.rs
+++ b/crates/aiken/src/cmd/check.rs
@@ -124,6 +124,10 @@ pub struct Args {
     /// [optional]
     #[clap(short, long, value_parser=trace_level_parser(), default_value_t=TraceLevel::Verbose, verbatim_doc_comment)]
     trace_level: TraceLevel,
+
+    /// When enabled, print execution units as plain numbers
+    #[clap(long)]
+    plain_numbers: bool,
 }
 
 pub fn exec(
@@ -143,6 +147,7 @@ pub fn exec(
         seed,
         max_success,
         env,
+        plain_numbers,
     }: Args,
 ) -> miette::Result<()> {
     if show_json_schema {
@@ -169,6 +174,7 @@ pub fn exec(
                     None => Tracing::All(trace_level),
                 },
                 env.clone(),
+                plain_numbers,
             )
         })
     } else {
@@ -186,6 +192,7 @@ pub fn exec(
                     None => Tracing::All(trace_level),
                 },
                 env.clone(),
+                plain_numbers,
             )
         })
     };


### PR DESCRIPTION
To aid efficiency of developers in improving the efficiency of validators by making execution units displayed on terminal more readable. 
- By default units would be displayed in [Short Scale](https://kurtlawrence.github.io/rust-script-ext/numfmt/struct.Scales.html#method.short) (K = Thousands, M = Millions, B = Billions) with precision upto two decimal places.
- Should the user want to see plain numbers they can by passing in `--plain-numbers` flag to `aiken check` which would print units with underscores after three decimal places (e.g. 1_000_000)

Terminals outputs showcasing both the formats for easier review:
Default
![image](https://github.com/user-attachments/assets/79912725-1c4f-4f11-957c-ad00554f07aa)

Plain Numbers
![image](https://github.com/user-attachments/assets/705e0fd7-ab4d-4c94-b771-0f58532a0990)
