### PR TITLE
Alias constr variant compiler crash fix

### DIFF
--- a/crates/aiken-lang/src/gen_uplc/decision_tree.rs
+++ b/crates/aiken-lang/src/gen_uplc/decision_tree.rs
@@ -8,6 +8,7 @@ use itertools::{Either, Itertools, Position};
 use crate::{
     ast::{DataTypeKey, Pattern, TypedClause, TypedDataType, TypedPattern},
     expr::{Type, TypeVar, TypedExpr, lookup_data_type_by_tipo},
+    tipo::PatternConstructor,
 };
 
 use super::{interner::AirInterner, tree::AirTree};
@@ -877,7 +878,7 @@ impl<'a, 'b> TreeGen<'a, 'b> {
                     ),
 
                     Pattern::Constructor {
-                        name,
+                        constructor: PatternConstructor::Record { name, .. },
                         arguments,
                         tipo,
                         ..

--- a/examples/acceptance_tests/125/aiken.toml
+++ b/examples/acceptance_tests/125/aiken.toml
@@ -1,0 +1,18 @@
+name = "thing/scratch"
+version = "0.0.0"
+compiler = "v1.1.17"
+plutus = "v3"
+license = "Apache-2.0"
+description = "Aiken contracts for project 'thing/scratch'"
+
+[repository]
+user = "thing"
+project = "scratch"
+platform = "github"
+
+[[dependencies]]
+name = "aiken-lang/stdlib"
+version = "v2.2.0"
+source = "github"
+
+[config]

--- a/examples/acceptance_tests/125/lib/thing.ak
+++ b/examples/acceptance_tests/125/lib/thing.ak
@@ -1,0 +1,10 @@
+use cardano/address.{Address, VerificationKey as VerificationKeyContstructor}
+
+test other() {
+  let address = Address(VerificationKeyContstructor(#"affdafafaa"), None)
+
+  when address.payment_credential is {
+    VerificationKeyContstructor(thing) -> #"affdafafaa" == thing
+    _ -> fail
+  }
+}


### PR DESCRIPTION
Fixes an issue where aliasing a constr variant like VerificationKey as VerificationKeyContstructor would cause the compiler to crash if you use VerificationKeyContstructor in a when