### PR TITLE
Properly support field names in lists when encoding into blueprint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [next] - 2025-08-06
+
+### Fixed
+
+- `aiken-project`: Properly support field names in lists when encoding into blueprint. @emiflake
+
 ## v1.1.19 - 2025-07-28
 
 ### Added

--- a/crates/aiken-project/src/blueprint/definitions.rs
+++ b/crates/aiken-project/src/blueprint/definitions.rs
@@ -124,7 +124,7 @@ impl Definitions<Annotated<Schema>> {
                 }
                 Schema::List(Items::Many(items)) => {
                     items.iter().for_each(|item| {
-                        mark(src.clone(), item, usage, traverse_schema);
+                        mark(src.clone(), &item.annotated, usage, traverse_schema);
                     });
                 }
                 Schema::Data(data) => traverse_data(src, data, usage),
@@ -143,7 +143,7 @@ impl Definitions<Annotated<Schema>> {
                 }
                 Data::List(Items::Many(items)) => {
                     items.iter().for_each(|item| {
-                        mark(src.clone(), item, usage, traverse_data);
+                        mark(src.clone(), &item.annotated, usage, traverse_data);
                     });
                 }
                 Data::Map(keys, values) => {
@@ -263,14 +263,17 @@ impl Definitions<Annotated<Schema>> {
                 Schema::Pair(left, right) => {
                     let left = swap_declaration(left);
                     let right = swap_declaration(right);
-                    Some(Items::Many(vec![left, right]))
+                    Some(Items::Many(vec![left.into(), right.into()]))
                 }
                 Schema::List(Items::One(item)) => {
                     let item = swap_declaration(item);
                     Some(Items::One(item))
                 }
                 Schema::List(Items::Many(items)) => Some(Items::Many(
-                    items.iter_mut().map(swap_declaration).collect(),
+                    items
+                        .iter_mut()
+                        .map(|annot| swap_declaration(&mut annot.annotated).into())
+                        .collect(),
                 )),
                 Schema::Integer => {
                     *schema = Schema::Data(Data::Integer);

--- a/crates/aiken-project/src/blueprint/parameter.rs
+++ b/crates/aiken-project/src/blueprint/parameter.rs
@@ -119,10 +119,11 @@ fn validate_schema(
             let items = items
                 .iter()
                 .map(|item| {
-                    item.schema(definitions)
-                        .ok_or_else(|| Error::UnresolvedSchemaReference {
-                            reference: item.reference().unwrap().clone(),
-                        })
+                    item.annotated.schema(definitions).ok_or_else(|| {
+                        Error::UnresolvedSchemaReference {
+                            reference: item.annotated.reference().unwrap().clone(),
+                        }
+                    })
                 })
                 .collect::<Result<Vec<_>, _>>()?;
 
@@ -176,10 +177,11 @@ fn validate_data(
             let items = items
                 .iter()
                 .map(|item| {
-                    item.schema(definitions)
-                        .ok_or_else(|| Error::UnresolvedSchemaReference {
-                            reference: item.reference().unwrap().clone(),
-                        })
+                    item.annotated.schema(definitions).ok_or_else(|| {
+                        Error::UnresolvedSchemaReference {
+                            reference: item.annotated.reference().unwrap().clone(),
+                        }
+                    })
                 })
                 .collect::<Result<Vec<_>, _>>()?;
 

--- a/crates/aiken-project/src/blueprint/snapshots/aiken_project__blueprint__validator__tests__list_decorator_field_names.snap
+++ b/crates/aiken-project/src/blueprint/snapshots/aiken_project__blueprint__validator__tests__list_decorator_field_names.snap
@@ -1,0 +1,40 @@
+---
+source: crates/aiken-project/src/blueprint/validator.rs
+description: "Code:\n\n@list\npub type Product {\n    x: Int,\n    y: Int,\n}\n\nvalidator list_decorator_field_names {\n  spend(_datum: Option<Product>, _redeemer: Int, _utxo: Data, _self: Data,) {\n    True\n  }\n}\n"
+---
+{
+  "title": "test_module.list_decorator_field_names.spend",
+  "datum": {
+    "title": "_datum",
+    "schema": {
+      "$ref": "#/definitions/test_module~1Product"
+    }
+  },
+  "redeemer": {
+    "title": "_redeemer",
+    "schema": {
+      "$ref": "#/definitions/Int"
+    }
+  },
+  "compiledCode": "<redacted>",
+  "hash": "<redacted>",
+  "definitions": {
+    "Int": {
+      "dataType": "integer"
+    },
+    "test_module/Product": {
+      "title": "Product",
+      "dataType": "list",
+      "items": [
+        {
+          "title": "x",
+          "$ref": "#/definitions/Int"
+        },
+        {
+          "title": "y",
+          "$ref": "#/definitions/Int"
+        }
+      ]
+    }
+  }
+}

--- a/crates/aiken-project/src/blueprint/validator.rs
+++ b/crates/aiken-project/src/blueprint/validator.rs
@@ -851,6 +851,25 @@ mod tests {
     }
 
     #[test]
+    fn list_decorator_field_names() {
+        assert_validator!(
+            r#"
+            @list
+            pub type Product {
+                x: Int,
+                y: Int,
+            }
+
+            validator list_decorator_field_names {
+              spend(_datum: Option<Product>, _redeemer: Int, _utxo: Data, _self: Data,) {
+                True
+              }
+            }
+            "#
+        );
+    }
+
+    #[test]
     fn validate_arguments_integer() {
         let definitions = fixture_definitions();
 
@@ -952,8 +971,8 @@ mod tests {
         definitions.insert(
             &schema,
             Schema::Data(Data::List(Items::Many(vec![
-                Declaration::Referenced(Reference::new("Int")),
-                Declaration::Referenced(Reference::new("ByteArray")),
+                Annotated::from(Declaration::Referenced(Reference::new("Int"))),
+                Annotated::from(Declaration::Referenced(Reference::new("ByteArray"))),
             ])))
             .into(),
         );

--- a/crates/aiken/src/cmd/blueprint/apply.rs
+++ b/crates/aiken/src/cmd/blueprint/apply.rs
@@ -207,7 +207,7 @@ fn ask_schema(
                     ix + 1,
                     Ordinal::<usize>(ix + 1).suffix()
                 );
-                let inner_schema = lookup_declaration(&decl.clone().into(), definitions);
+                let inner_schema = lookup_declaration(&decl.clone(), definitions);
                 elems.push(ask_schema(&inner_schema, definitions)?);
             }
 


### PR DESCRIPTION
The blueprint spec allows field names for polymorphic lists. With the new decorator syntax (`@list`, hurray!), we now support creating polymorphic lists with field names (using `type Name { ... }`). This commit adds the necessary logic to not forget the field name when encoding into blueprint. It also adds a snapshot test to ensure this happens correctly.

The changes are a little heavy-handed and add a bit more structure to lists in the schema data type in general, but I believe it is justified, as it is useful metadata that can be used by other tools. That being said, the JSON schema spec technically says that anything beside a `$ref` field should be ignored, and as such this *can not* break any existing user of the generated plutus.json, provided they are following the spec correctly.

If however, we would like to follow the JSON schema more closely (and transitively CIP-57, too). Then, perhaps, the structure of the elements ought to be like so instead:
```json
{
  "allOf": [{ "$ref": "... some reference ..." }],
  "title": "... some title ... "
}
```

This is a little more work but technically slightly more correct, as I understand it. Personally, I think this would cause more breakage with some tools that don't follow the spec right now, however. Let me know what you think!