### PR TITLE
Format and display in docs simple unary-op expressions

### DIFF
--- a/crates/aiken-lang/src/expr.rs
+++ b/crates/aiken-lang/src/expr.rs
@@ -214,6 +214,7 @@ impl TypedExpr {
             Self::List { elements, .. } if elements.len() <= 3 => {
                 elements.iter().all(|e| e.is_simple_expr_to_format())
             }
+            Self::UnOp { value, .. } => value.is_simple_expr_to_format(),
             _ => false,
         }
     }

--- a/crates/aiken-lang/src/format.rs
+++ b/crates/aiken-lang/src/format.rs
@@ -427,6 +427,10 @@ impl<'comments> Formatter<'comments> {
                 )
             }
             TypedExpr::Var { name, .. } => name.to_doc(),
+            TypedExpr::UnOp { value, op, .. } => match op {
+                UnOp::Not => docvec!["!", self.const_expr(value)],
+                UnOp::Negate => docvec!["-", self.const_expr(value)],
+            },
             _ => Document::Str(""),
         }
     }


### PR DESCRIPTION
<img width="214" height="156" alt="image" src="https://github.com/user-attachments/assets/327398c0-8b43-4cab-ae8d-51f91ad47608" />


Fixes #1137.