### PR TITLE
use less ambiguous separators for generic params in blueprint's JSON references

### DIFF
--- a/crates/aiken-project/src/blueprint/definitions.rs
+++ b/crates/aiken-project/src/blueprint/definitions.rs
@@ -382,13 +382,13 @@ impl Reference {
 
             Type::Tuple { elems, .. } => Self {
                 inner: format!(
-                    "Tuple{elems}",
+                    "Tuple<{elems}>",
                     elems = Self::from_types(elems, type_parameters)
                 ),
             },
             Type::Pair { fst, snd, .. } => Self {
                 inner: format!(
-                    "Pair${fst}_{snd}",
+                    "Pair<{fst},{snd}>",
                     fst = Self::from_type(fst, type_parameters),
                     snd = Self::from_type(snd, type_parameters)
                 ),
@@ -408,7 +408,7 @@ impl Reference {
 
             Type::Fn { args, ret, .. } => Self {
                 inner: format!(
-                    "Fn{args}_{ret}",
+                    "Fn({args})->{ret}",
                     args = Self::from_types(args, type_parameters),
                     ret = Self::from_type(ret, type_parameters)
                 ),
@@ -422,11 +422,11 @@ impl Reference {
         } else {
             Reference {
                 inner: format!(
-                    "${}",
+                    "<{}>",
                     args.iter()
                         .map(|s| Self::from_type(s.as_ref(), type_parameters).inner)
                         .collect::<Vec<_>>()
-                        .join("_")
+                        .join(",")
                 ),
             }
         }
@@ -447,7 +447,7 @@ impl Reference {
         if !parameters.is_empty() {
             Reference {
                 inner: format!(
-                    "{prefix}${}",
+                    "{prefix}<{}>",
                     parameters
                         .iter()
                         .map(|param| {
@@ -463,7 +463,7 @@ impl Reference {
                                 Self::from_type(param, type_parameters).inner
                             }
                         })
-                        .join("_"),
+                        .join(","),
                 ),
             }
         } else {

--- a/crates/aiken-project/src/blueprint/mod.rs
+++ b/crates/aiken-project/src/blueprint/mod.rs
@@ -391,7 +391,7 @@ mod tests {
                     "Int": {
                         "dataType": "integer"
                     },
-                    "List$ByteArray": {
+                    "List<ByteArray>": {
                         "dataType": "list",
                         "items": {
                             "$ref": "#/definitions/ByteArray"

--- a/crates/aiken-project/src/blueprint/snapshots/aiken_project__blueprint__validator__tests__generics.snap
+++ b/crates/aiken-project/src/blueprint/snapshots/aiken_project__blueprint__validator__tests__generics.snap
@@ -13,7 +13,7 @@ description: "Code:\n\npub type Either<left, right> {\n    Left(left)\n    Right
   "redeemer": {
     "title": "redeemer",
     "schema": {
-      "$ref": "#/definitions/test_module~1Either$ByteArray_test_module~1Interval$Int"
+      "$ref": "#/definitions/test_module~1Either<ByteArray,test_module~1Interval<Int>>"
     }
   },
   "compiledCode": "<redacted>",
@@ -29,7 +29,7 @@ description: "Code:\n\npub type Either<left, right> {\n    Left(left)\n    Right
     "Int": {
       "dataType": "integer"
     },
-    "test_module/Either$ByteArray_test_module/Interval$Int": {
+    "test_module/Either<ByteArray,test_module/Interval<Int>>": {
       "title": "Either",
       "anyOf": [
         {
@@ -48,13 +48,13 @@ description: "Code:\n\npub type Either<left, right> {\n    Left(left)\n    Right
           "index": 1,
           "fields": [
             {
-              "$ref": "#/definitions/test_module~1Interval$Int"
+              "$ref": "#/definitions/test_module~1Interval<Int>"
             }
           ]
         }
       ]
     },
-    "test_module/Interval$Int": {
+    "test_module/Interval<Int>": {
       "title": "Interval",
       "anyOf": [
         {

--- a/crates/aiken-project/src/blueprint/snapshots/aiken_project__blueprint__validator__tests__list_2_tuples_as_list.snap
+++ b/crates/aiken-project/src/blueprint/snapshots/aiken_project__blueprint__validator__tests__list_2_tuples_as_list.snap
@@ -7,7 +7,7 @@ description: "Code:\n\npub type Dict<key, value> {\n    inner: List<(ByteArray, 
   "redeemer": {
     "title": "redeemer",
     "schema": {
-      "$ref": "#/definitions/test_module~1Dict$test_module~1UUID_Int"
+      "$ref": "#/definitions/test_module~1Dict<test_module~1UUID,Int>"
     }
   },
   "compiledCode": "<redacted>",
@@ -19,13 +19,13 @@ description: "Code:\n\npub type Dict<key, value> {\n    inner: List<(ByteArray, 
     "Int": {
       "dataType": "integer"
     },
-    "List$Tuple$ByteArray_Int": {
+    "List<Tuple<<ByteArray,Int>>>": {
       "dataType": "list",
       "items": {
-        "$ref": "#/definitions/Tuple$ByteArray_Int"
+        "$ref": "#/definitions/Tuple<<ByteArray,Int>>"
       }
     },
-    "Tuple$ByteArray_Int": {
+    "Tuple<<ByteArray,Int>>": {
       "title": "Tuple",
       "dataType": "list",
       "items": [
@@ -37,7 +37,7 @@ description: "Code:\n\npub type Dict<key, value> {\n    inner: List<(ByteArray, 
         }
       ]
     },
-    "test_module/Dict$test_module/UUID_Int": {
+    "test_module/Dict<test_module/UUID,Int>": {
       "title": "Dict",
       "anyOf": [
         {
@@ -47,7 +47,7 @@ description: "Code:\n\npub type Dict<key, value> {\n    inner: List<(ByteArray, 
           "fields": [
             {
               "title": "inner",
-              "$ref": "#/definitions/List$Tuple$ByteArray_Int"
+              "$ref": "#/definitions/List<Tuple<<ByteArray,Int>>>"
             }
           ]
         }

--- a/crates/aiken-project/src/blueprint/snapshots/aiken_project__blueprint__validator__tests__list_pairs_as_map.snap
+++ b/crates/aiken-project/src/blueprint/snapshots/aiken_project__blueprint__validator__tests__list_pairs_as_map.snap
@@ -13,7 +13,7 @@ description: "Code:\n\npub type Dict<key, value> {\n    inner: List<Pair<ByteArr
   "redeemer": {
     "title": "redeemer",
     "schema": {
-      "$ref": "#/definitions/test_module~1Dict$test_module~1UUID_Int"
+      "$ref": "#/definitions/test_module~1Dict<test_module~1UUID,Int>"
     }
   },
   "compiledCode": "<redacted>",
@@ -29,7 +29,7 @@ description: "Code:\n\npub type Dict<key, value> {\n    inner: List<Pair<ByteArr
     "Int": {
       "dataType": "integer"
     },
-    "List$Pair$ByteArray_Int": {
+    "List<Pair<ByteArray,Int>>": {
       "dataType": "map",
       "keys": {
         "$ref": "#/definitions/ByteArray"
@@ -38,7 +38,7 @@ description: "Code:\n\npub type Dict<key, value> {\n    inner: List<Pair<ByteArr
         "$ref": "#/definitions/Int"
       }
     },
-    "test_module/Dict$test_module/UUID_Int": {
+    "test_module/Dict<test_module/UUID,Int>": {
       "title": "Dict",
       "anyOf": [
         {
@@ -48,7 +48,7 @@ description: "Code:\n\npub type Dict<key, value> {\n    inner: List<Pair<ByteArr
           "fields": [
             {
               "title": "inner",
-              "$ref": "#/definitions/List$Pair$ByteArray_Int"
+              "$ref": "#/definitions/List<Pair<ByteArray,Int>>"
             }
           ]
         }

--- a/crates/aiken-project/src/blueprint/snapshots/aiken_project__blueprint__validator__tests__pair_of_lists.snap
+++ b/crates/aiken-project/src/blueprint/snapshots/aiken_project__blueprint__validator__tests__pair_of_lists.snap
@@ -43,7 +43,7 @@ description: "Code:\n\npub type MyPair =\n  Pair<List<Int>, Bool>\n\nvalidator p
     "Int": {
       "dataType": "integer"
     },
-    "List$Int": {
+    "List<Int>": {
       "dataType": "list",
       "items": {
         "$ref": "#/definitions/Int"
@@ -54,7 +54,7 @@ description: "Code:\n\npub type MyPair =\n  Pair<List<Int>, Bool>\n\nvalidator p
       "dataType": "list",
       "items": [
         {
-          "$ref": "#/definitions/List$Int"
+          "$ref": "#/definitions/List<Int>"
         },
         {
           "$ref": "#/definitions/Bool"

--- a/crates/aiken-project/src/blueprint/snapshots/aiken_project__blueprint__validator__tests__pair_used_after_map.snap
+++ b/crates/aiken-project/src/blueprint/snapshots/aiken_project__blueprint__validator__tests__pair_used_after_map.snap
@@ -22,7 +22,7 @@ description: "Code:\n\npub type MyPair =\n  Pair<Int, Int>\n\npub type MyDatum {
     "Int": {
       "dataType": "integer"
     },
-    "List$test_module/MyPair": {
+    "List<test_module/MyPair>": {
       "dataType": "map",
       "keys": {
         "$ref": "#/definitions/Int"
@@ -51,7 +51,7 @@ description: "Code:\n\npub type MyPair =\n  Pair<Int, Int>\n\npub type MyDatum {
           "fields": [
             {
               "title": "pairs",
-              "$ref": "#/definitions/List$test_module~1MyPair"
+              "$ref": "#/definitions/List<test_module~1MyPair>"
             },
             {
               "title": "pair",

--- a/crates/aiken-project/src/blueprint/snapshots/aiken_project__blueprint__validator__tests__pair_used_before_map.snap
+++ b/crates/aiken-project/src/blueprint/snapshots/aiken_project__blueprint__validator__tests__pair_used_before_map.snap
@@ -22,7 +22,7 @@ description: "Code:\n\npub type MyPair =\n  Pair<Int, Int>\n\npub type MyDatum {
     "Int": {
       "dataType": "integer"
     },
-    "List$test_module/MyPair": {
+    "List<test_module/MyPair>": {
       "dataType": "map",
       "keys": {
         "$ref": "#/definitions/Int"
@@ -55,7 +55,7 @@ description: "Code:\n\npub type MyPair =\n  Pair<Int, Int>\n\npub type MyDatum {
             },
             {
               "title": "pairs",
-              "$ref": "#/definitions/List$test_module~1MyPair"
+              "$ref": "#/definitions/List<test_module~1MyPair>"
             }
           ]
         }

--- a/crates/aiken-project/src/blueprint/snapshots/aiken_project__blueprint__validator__tests__recursive_generic_types.snap
+++ b/crates/aiken-project/src/blueprint/snapshots/aiken_project__blueprint__validator__tests__recursive_generic_types.snap
@@ -13,7 +13,7 @@ description: "Code:\n\npub type LinkedList<a> {\n  Cons(a, LinkedList<a>)\n  Nil
   "redeemer": {
     "title": "redeemer",
     "schema": {
-      "$ref": "#/definitions/test_module~1LinkedList$Int"
+      "$ref": "#/definitions/test_module~1LinkedList<Int>"
     }
   },
   "compiledCode": "<redacted>",
@@ -42,13 +42,13 @@ description: "Code:\n\npub type LinkedList<a> {\n  Cons(a, LinkedList<a>)\n  Nil
     "Int": {
       "dataType": "integer"
     },
-    "List$test_module/LinkedList$Int": {
+    "List<test_module/LinkedList<Int>>": {
       "dataType": "list",
       "items": {
-        "$ref": "#/definitions/test_module~1LinkedList$Int"
+        "$ref": "#/definitions/test_module~1LinkedList<Int>"
       }
     },
-    "Tuple$ByteArray_List$test_module/LinkedList$Int": {
+    "Tuple<<ByteArray,List<test_module/LinkedList<Int>>>>": {
       "title": "Tuple",
       "dataType": "list",
       "items": [
@@ -56,7 +56,7 @@ description: "Code:\n\npub type LinkedList<a> {\n  Cons(a, LinkedList<a>)\n  Nil
           "$ref": "#/definitions/ByteArray"
         },
         {
-          "$ref": "#/definitions/List$test_module~1LinkedList$Int"
+          "$ref": "#/definitions/List<test_module~1LinkedList<Int>>"
         }
       ]
     },
@@ -70,7 +70,7 @@ description: "Code:\n\npub type LinkedList<a> {\n  Cons(a, LinkedList<a>)\n  Nil
           "fields": [
             {
               "title": "foo",
-              "$ref": "#/definitions/test_module~1LinkedList$Bool"
+              "$ref": "#/definitions/test_module~1LinkedList<Bool>"
             }
           ]
         },
@@ -85,13 +85,13 @@ description: "Code:\n\npub type LinkedList<a> {\n  Cons(a, LinkedList<a>)\n  Nil
             },
             {
               "title": "baz",
-              "$ref": "#/definitions/Tuple$ByteArray_List$test_module~1LinkedList$Int"
+              "$ref": "#/definitions/Tuple<<ByteArray,List<test_module~1LinkedList<Int>>>>"
             }
           ]
         }
       ]
     },
-    "test_module/LinkedList$Bool": {
+    "test_module/LinkedList<Bool>": {
       "title": "LinkedList",
       "anyOf": [
         {
@@ -103,7 +103,7 @@ description: "Code:\n\npub type LinkedList<a> {\n  Cons(a, LinkedList<a>)\n  Nil
               "$ref": "#/definitions/Bool"
             },
             {
-              "$ref": "#/definitions/test_module~1LinkedList$Bool"
+              "$ref": "#/definitions/test_module~1LinkedList<Bool>"
             }
           ]
         },
@@ -115,7 +115,7 @@ description: "Code:\n\npub type LinkedList<a> {\n  Cons(a, LinkedList<a>)\n  Nil
         }
       ]
     },
-    "test_module/LinkedList$Int": {
+    "test_module/LinkedList<Int>": {
       "title": "LinkedList",
       "anyOf": [
         {
@@ -127,7 +127,7 @@ description: "Code:\n\npub type LinkedList<a> {\n  Cons(a, LinkedList<a>)\n  Nil
               "$ref": "#/definitions/Int"
             },
             {
-              "$ref": "#/definitions/test_module~1LinkedList$Int"
+              "$ref": "#/definitions/test_module~1LinkedList<Int>"
             }
           ]
         },

--- a/crates/aiken-project/src/blueprint/snapshots/aiken_project__blueprint__validator__tests__simplified_hydra.snap
+++ b/crates/aiken-project/src/blueprint/snapshots/aiken_project__blueprint__validator__tests__simplified_hydra.snap
@@ -26,7 +26,7 @@ description: "Code:\n\n/// On-chain state\npub type State {\n    /// The contest
     "Int": {
       "dataType": "integer"
     },
-    "List$test_module/Party": {
+    "List<test_module/Party>": {
       "dataType": "list",
       "items": {
         "$ref": "#/definitions/test_module~1Party"
@@ -94,7 +94,7 @@ description: "Code:\n\n/// On-chain state\npub type State {\n    /// The contest
             {
               "title": "parties",
               "description": "List of public key hashes of all participants",
-              "$ref": "#/definitions/List$test_module~1Party"
+              "$ref": "#/definitions/List<test_module~1Party>"
             },
             {
               "title": "utxoHash",

--- a/crates/aiken-project/src/blueprint/snapshots/aiken_project__blueprint__validator__tests__tuples.snap
+++ b/crates/aiken-project/src/blueprint/snapshots/aiken_project__blueprint__validator__tests__tuples.snap
@@ -7,13 +7,13 @@ description: "Code:\n\nvalidator tuples {\n  spend(datum: Option<(Int, ByteArray
   "datum": {
     "title": "datum",
     "schema": {
-      "$ref": "#/definitions/Tuple$Int_ByteArray"
+      "$ref": "#/definitions/Tuple<<Int,ByteArray>>"
     }
   },
   "redeemer": {
     "title": "redeemer",
     "schema": {
-      "$ref": "#/definitions/Tuple$Int_Int_Int"
+      "$ref": "#/definitions/Tuple<<Int,Int,Int>>"
     }
   },
   "compiledCode": "<redacted>",
@@ -25,7 +25,7 @@ description: "Code:\n\nvalidator tuples {\n  spend(datum: Option<(Int, ByteArray
     "Int": {
       "dataType": "integer"
     },
-    "Tuple$Int_ByteArray": {
+    "Tuple<<Int,ByteArray>>": {
       "title": "Tuple",
       "dataType": "list",
       "items": [
@@ -37,7 +37,7 @@ description: "Code:\n\nvalidator tuples {\n  spend(datum: Option<(Int, ByteArray
         }
       ]
     },
-    "Tuple$Int_Int_Int": {
+    "Tuple<<Int,Int,Int>>": {
       "title": "Tuple",
       "dataType": "list",
       "items": [

--- a/crates/aiken-project/src/blueprint/snapshots/aiken_project__blueprint__validator__tests__type_aliases.snap
+++ b/crates/aiken-project/src/blueprint/snapshots/aiken_project__blueprint__validator__tests__type_aliases.snap
@@ -13,7 +13,7 @@ description: "Code:\n\npub type Asset = (ByteArray, Int)\n\npub type POSIXTime =
   "redeemer": {
     "title": "redeemer",
     "schema": {
-      "$ref": "#/definitions/test_module~1MyRedeemer$test_module~1Asset"
+      "$ref": "#/definitions/test_module~1MyRedeemer<test_module~1Asset>"
     }
   },
   "compiledCode": "<redacted>",
@@ -42,13 +42,13 @@ description: "Code:\n\npub type Asset = (ByteArray, Int)\n\npub type POSIXTime =
     "Int": {
       "dataType": "integer"
     },
-    "List$test_module/Asset": {
+    "List<test_module/Asset>": {
       "dataType": "list",
       "items": {
         "$ref": "#/definitions/test_module~1Asset"
       }
     },
-    "Pair$test_module/POSIXTime_Bool": {
+    "Pair<test_module/POSIXTime,Bool>": {
       "title": "Pair",
       "dataType": "list",
       "items": [
@@ -60,7 +60,7 @@ description: "Code:\n\npub type Asset = (ByteArray, Int)\n\npub type POSIXTime =
         }
       ]
     },
-    "Pairs$test_module/Asset_test_module/POSIXTime": {
+    "Pairs<test_module/Asset,test_module/POSIXTime>": {
       "title": "Pairs<a, POSIXTime>",
       "dataType": "map",
       "keys": {
@@ -113,13 +113,13 @@ description: "Code:\n\npub type Asset = (ByteArray, Int)\n\npub type POSIXTime =
           "index": 1,
           "fields": [
             {
-              "$ref": "#/definitions/Pair$test_module~1POSIXTime_Bool"
+              "$ref": "#/definitions/Pair<test_module~1POSIXTime,Bool>"
             }
           ]
         }
       ]
     },
-    "test_module/MyRedeemer$test_module/Asset": {
+    "test_module/MyRedeemer<test_module/Asset>": {
       "title": "MyRedeemer",
       "anyOf": [
         {
@@ -129,11 +129,11 @@ description: "Code:\n\npub type Asset = (ByteArray, Int)\n\npub type POSIXTime =
           "fields": [
             {
               "title": "fst_field",
-              "$ref": "#/definitions/List$test_module~1Asset"
+              "$ref": "#/definitions/List<test_module~1Asset>"
             },
             {
               "title": "snd_field",
-              "$ref": "#/definitions/Pairs$test_module~1Asset_test_module~1POSIXTime"
+              "$ref": "#/definitions/Pairs<test_module~1Asset,test_module~1POSIXTime>"
             }
           ]
         }

--- a/crates/aiken-project/src/snapshots/aiken_project__export__tests__recursive_types.snap
+++ b/crates/aiken-project/src/snapshots/aiken_project__export__tests__recursive_types.snap
@@ -8,13 +8,13 @@ description: "Code:\n\npub type Foo<a> {\n  Empty\n  Bar(a, Foo<a>)\n}\n\npub fn
     {
       "title": "a",
       "schema": {
-        "$ref": "#/definitions/test_module~1Foo$Int"
+        "$ref": "#/definitions/test_module~1Foo<Int>"
       }
     },
     {
       "title": "b",
       "schema": {
-        "$ref": "#/definitions/test_module~1Foo$Int"
+        "$ref": "#/definitions/test_module~1Foo<Int>"
       }
     }
   ],
@@ -30,7 +30,7 @@ description: "Code:\n\npub type Foo<a> {\n  Empty\n  Bar(a, Foo<a>)\n}\n\npub fn
     "Int": {
       "dataType": "integer"
     },
-    "test_module/Foo$Int": {
+    "test_module/Foo<Int>": {
       "title": "Foo",
       "anyOf": [
         {
@@ -48,7 +48,7 @@ description: "Code:\n\npub type Foo<a> {\n  Empty\n  Bar(a, Foo<a>)\n}\n\npub fn
               "$ref": "#/definitions/Int"
             },
             {
-              "$ref": "#/definitions/test_module~1Foo$Int"
+              "$ref": "#/definitions/test_module~1Foo<Int>"
             }
           ]
         }


### PR DESCRIPTION
Closes #1087.