### PR TITLE
implement `export_all_types` flag in config

### DIFF
--- a/crates/aiken-project/src/blueprint/mod.rs
+++ b/crates/aiken-project/src/blueprint/mod.rs
@@ -9,7 +9,7 @@ use crate::{
     config::{self, PlutusVersion, ProjectConfig},
     module::CheckedModules,
 };
-use aiken_lang::gen_uplc::CodeGenerator;
+use aiken_lang::{ast::Definition, gen_uplc::CodeGenerator, tipo::Type};
 use definitions::Definitions;
 pub use error::Error;
 use pallas_addresses::ScriptHash;
@@ -17,6 +17,7 @@ use schema::{Annotated, Schema};
 use std::{
     collections::{BTreeSet, HashMap},
     fmt::Debug,
+    rc::Rc,
 };
 use uplc::{PlutusData, ast::SerializableProgram, tx::script_context::PlutusScript};
 use validator::Validator;
@@ -91,9 +92,41 @@ impl Blueprint {
             })
             .collect();
 
+        let validators: Vec<_> = validators?.into_iter().flatten().collect();
+
+        if config.export_all_types {
+            let project_package = config.name.to_string();
+            let modules_map: &HashMap<String, _> = modules.into();
+
+            for module in modules.values() {
+                if module.package != project_package {
+                    continue;
+                }
+
+                for def in module.ast.definitions() {
+                    if let Definition::DataType(data_type) = def {
+                        if !data_type.public || data_type.opaque {
+                            continue;
+                        }
+
+                        let tipo = Rc::new(Type::App {
+                            public: data_type.public,
+                            contains_opaque: data_type.opaque,
+                            module: module.name.clone(),
+                            name: data_type.name.clone(),
+                            args: data_type.typed_parameters.clone(),
+                            alias: None,
+                        });
+
+                        let _ = Annotated::from_type(modules_map, &tipo, &mut definitions);
+                    }
+                }
+            }
+        }
+
         Ok(Blueprint {
             preamble,
-            validators: validators?.into_iter().flatten().collect(),
+            validators,
             definitions,
         })
     }

--- a/crates/aiken-project/src/config.rs
+++ b/crates/aiken-project/src/config.rs
@@ -47,6 +47,9 @@ pub struct ProjectConfig {
     #[serde(default)]
     pub dependencies: Vec<Dependency>,
 
+    #[serde(default, skip_serializing_if = "std::ops::Not::not")]
+    pub export_all_types: bool,
+
     #[serde(default)]
     pub config: BTreeMap<String, BTreeMap<String, SimpleExpr>>,
 }
@@ -393,6 +396,7 @@ impl ProjectConfig {
                 },
                 source: Platform::Github,
             }],
+            export_all_types: false,
             config: BTreeMap::new(),
         }
     }

--- a/crates/aiken-project/src/lib.rs
+++ b/crates/aiken-project/src/lib.rs
@@ -407,7 +407,7 @@ where
                 let blueprint = Blueprint::new(&self.config, &self.checked_modules, &mut generator)
                     .map_err(|err| Error::Blueprint(err.into()))?;
 
-                if blueprint.validators.is_empty() {
+                if blueprint.validators.is_empty() && !self.config.export_all_types {
                     self.warnings.push(Warning::NoValidators);
                 }
 

--- a/examples/acceptance_tests/128/aiken.toml
+++ b/examples/acceptance_tests/128/aiken.toml
@@ -1,0 +1,10 @@
+name = "aiken-lang/acceptance_test_128"
+version = "0.0.0"
+compiler = "v1.1.21"
+plutus = "v3"
+export_all_types = true
+
+[repository]
+user = "aiken-lang"
+project = "acceptance_test_128"
+platform = "github"

--- a/examples/acceptance_tests/128/validators/placeholder.ak
+++ b/examples/acceptance_tests/128/validators/placeholder.ak
@@ -1,0 +1,4 @@
+pub type ExampleDatum {
+  example: String,
+  number: Int
+}


### PR DESCRIPTION
When developing a new aiken project, often we don't have all of the validators in place already. But we want to start building with some types that we will eventually use. Currently, we have to manually stub out validators so that aiken generates the blueprint with such types in place. This commit adds a new flag to the config that will cause aiken to generate the blueprint with all public types, even if they are not used in the project elsewhere.

The warning message that is printed when no validators are found during compilation is muted when this flag is set.

There could be a better place for this flag, so if there are preferences about that, let me know. There shouldn't be any breaking changes with this PR, since the new flag is optional and previous behavior is maintained when it is not present.