### PR TITLE
Fix PlutusV1/V2 script success criteria to match Haskell

### DIFF
--- a/crates/uplc/src/machine/eval_result.rs
+++ b/crates/uplc/src/machine/eval_result.rs
@@ -1,5 +1,6 @@
 use super::{Error, Trace, cost_model::ExBudget};
 use crate::ast::{Constant, NamedDeBruijn, Term};
+use pallas_primitives::conway::Language;
 
 #[derive(Debug)]
 pub struct EvalResult {
@@ -66,6 +67,40 @@ impl EvalResult {
         }
     }
 
+    /// Determine whether script execution failed, taking the Plutus language
+    /// version into account.
+    ///
+    /// This mirrors the Haskell reference implementation's `processLogsAndErrors`
+    /// in `PlutusLedgerApi.Common.Eval`:
+    ///
+    /// - **PlutusV1/V2**: A script succeeds if it terminates without error.
+    ///   Any non-error return value (not just `Bool(true)` or `Unit`) is
+    ///   considered success.
+    ///
+    /// - **PlutusV3**: A script succeeds only if it returns `Bool(true)` or
+    ///   `Unit` (the strict check, same as `failed(false)`).
+    ///
+    /// When `can_error` is `true`, the `expected_error` semantics apply
+    /// regardless of language version (same as `failed(true)`).
+    pub fn failed_with_lang(&self, can_error: bool, language: &Language) -> bool {
+        if can_error {
+            // expected-error semantics: script must return Bool(false) or error
+            return self.failed(true);
+        }
+
+        match language {
+            // PlutusV1/V2: success = execution didn't error.
+            // Any non-error result is acceptable, matching Haskell's
+            // `processLogsAndErrors` which only checks for `EvaluationFailure`.
+            Language::PlutusV1 | Language::PlutusV2 => {
+                self.result.is_err() || matches!(self.result, Ok(Term::Error))
+            }
+
+            // PlutusV3: strict check — must return Bool(true) or Unit.
+            Language::PlutusV3 => self.failed(false),
+        }
+    }
+
     pub fn debug_cost(&self) -> Option<Vec<i64>> {
         self.debug_cost.clone()
     }
@@ -80,5 +115,153 @@ impl EvalResult {
 
     pub fn result(&self) -> Result<Term<NamedDeBruijn>, Error> {
         self.result.clone()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    fn make_eval_result(result: Result<Term<NamedDeBruijn>, Error>) -> EvalResult {
+        EvalResult::new(
+            result,
+            ExBudget::default(),
+            ExBudget::default(),
+            vec![],
+            None,
+        )
+    }
+
+    fn int_term(n: i128) -> Term<NamedDeBruijn> {
+        Term::Constant(
+            Constant::Integer(n.into()).into(),
+        )
+    }
+
+    fn bool_term(b: bool) -> Term<NamedDeBruijn> {
+        Term::Constant(Constant::Bool(b).into())
+    }
+
+    fn unit_term() -> Term<NamedDeBruijn> {
+        Term::Constant(Constant::Unit.into())
+    }
+
+    fn lambda_term() -> Term<NamedDeBruijn> {
+        Term::Lambda {
+            parameter_name: NamedDeBruijn {
+                text: String::from("x"),
+                index: 0.into(),
+            }
+            .into(),
+            body: Term::Var(
+                NamedDeBruijn {
+                    text: String::from("x"),
+                    index: 0.into(),
+                }
+                .into(),
+            )
+            .into(),
+        }
+    }
+
+    // -------------------------------------------------------
+    // PlutusV1/V2: any non-error result should be success
+    // -------------------------------------------------------
+
+    #[test]
+    fn v1_integer_return_succeeds() {
+        let eval = make_eval_result(Ok(int_term(42)));
+        // Old behavior: failed(false) considers this a failure
+        assert!(eval.failed(false), "old `failed` rejects integer return");
+        // New behavior: V1 accepts any non-error result
+        assert!(
+            !eval.failed_with_lang(false, &Language::PlutusV1),
+            "V1 should accept integer return value"
+        );
+    }
+
+    #[test]
+    fn v2_integer_return_succeeds() {
+        let eval = make_eval_result(Ok(int_term(42)));
+        assert!(
+            !eval.failed_with_lang(false, &Language::PlutusV2),
+            "V2 should accept integer return value"
+        );
+    }
+
+    #[test]
+    fn v1_lambda_return_succeeds() {
+        let eval = make_eval_result(Ok(lambda_term()));
+        assert!(eval.failed(false), "old `failed` rejects lambda return");
+        assert!(
+            !eval.failed_with_lang(false, &Language::PlutusV1),
+            "V1 should accept lambda return value"
+        );
+    }
+
+    #[test]
+    fn v1_bool_true_succeeds() {
+        let eval = make_eval_result(Ok(bool_term(true)));
+        assert!(!eval.failed_with_lang(false, &Language::PlutusV1));
+    }
+
+    #[test]
+    fn v1_unit_succeeds() {
+        let eval = make_eval_result(Ok(unit_term()));
+        assert!(!eval.failed_with_lang(false, &Language::PlutusV1));
+    }
+
+    #[test]
+    fn v1_error_result_fails() {
+        let eval = make_eval_result(Ok(Term::Error));
+        assert!(eval.failed_with_lang(false, &Language::PlutusV1));
+    }
+
+    #[test]
+    fn v1_machine_error_fails() {
+        let eval = make_eval_result(Err(Error::OutOfExError(ExBudget::default())));
+        assert!(eval.failed_with_lang(false, &Language::PlutusV1));
+    }
+
+    // -------------------------------------------------------
+    // PlutusV3: strict — only Bool(true) or Unit
+    // -------------------------------------------------------
+
+    #[test]
+    fn v3_integer_return_fails() {
+        let eval = make_eval_result(Ok(int_term(42)));
+        assert!(
+            eval.failed_with_lang(false, &Language::PlutusV3),
+            "V3 should reject integer return value"
+        );
+    }
+
+    #[test]
+    fn v3_bool_true_succeeds() {
+        let eval = make_eval_result(Ok(bool_term(true)));
+        assert!(!eval.failed_with_lang(false, &Language::PlutusV3));
+    }
+
+    #[test]
+    fn v3_unit_succeeds() {
+        let eval = make_eval_result(Ok(unit_term()));
+        assert!(!eval.failed_with_lang(false, &Language::PlutusV3));
+    }
+
+    #[test]
+    fn v3_bool_false_fails() {
+        let eval = make_eval_result(Ok(bool_term(false)));
+        assert!(eval.failed_with_lang(false, &Language::PlutusV3));
+    }
+
+    #[test]
+    fn v3_lambda_return_fails() {
+        let eval = make_eval_result(Ok(lambda_term()));
+        assert!(eval.failed_with_lang(false, &Language::PlutusV3));
+    }
+
+    #[test]
+    fn v3_error_result_fails() {
+        let eval = make_eval_result(Ok(Term::Error));
+        assert!(eval.failed_with_lang(false, &Language::PlutusV3));
     }
 }


### PR DESCRIPTION
## Summary

The `EvalResult::failed()` method currently applies the same strict success check to all Plutus language versions: a script must return `Bool(true)` or `Unit` to be considered successful. This diverges from the Haskell reference implementation and causes valid PlutusV1/V2 scripts to be incorrectly rejected.

### The bug

In Haskell's `PlutusLedgerApi.Common.Eval`, the function [`processLogsAndErrors`](https://github.com/IntersectMBO/plutus/blob/master/plutus-ledger-api/src/PlutusLedgerApi/Common/Eval.hs) only checks whether the UPLC evaluator returned an `EvaluationFailure` for PlutusV1 and PlutusV2. **Any non-error return value is considered success** — the script does not need to return `Bool(true)` or `Unit`.

The strict `Bool(true)` / `Unit` requirement was introduced in PlutusV3, where the script context is passed as a single argument and the script is expected to return a "void" (Unit) value.

### Current behavior (incorrect)

```rust
// crates/uplc/src/machine/eval_result.rs
pub fn failed(&self, can_error: bool) -> bool {
    // ...
    // For can_error=false, requires Bool(true) or Unit for ALL versions
    self.result.is_err()
        || matches!(self.result, Ok(Term::Error))
        || !matches!(
            self.result,
            Ok(Term::Constant(ref con))
            if matches!(con.as_ref(), Constant::Bool(true))
                || matches!(con.as_ref(), Constant::Unit)
        )
}
```

### The fix

This PR adds a new method `failed_with_lang()` that takes a `Language` parameter:

- **PlutusV1/V2**: Success = execution completed without error (any return value accepted)
- **PlutusV3**: Success = must return `Bool(true)` or `Unit` (strict, same as existing `failed(false)`)

The existing `failed()` method is left unchanged for backward compatibility.

### Real-world impact

PlutusV2 oracle scripts (e.g., Liqwid Finance oracle contract on Cardano preview testnet) return `Data` values rather than `Bool(true)` or `Unit`. These scripts execute successfully on `cardano-node` but are incorrectly considered failed by the current `uplc` implementation.

### Haskell reference

From [`PlutusLedgerApi.Common.Eval`](https://github.com/IntersectMBO/plutus/blob/master/plutus-ledger-api/src/PlutusLedgerApi/Common/Eval.hs):

```haskell
-- V1/V2: only check for EvaluationFailure, not the return value
processLogsAndErrors :: EvaluationResult a -> [Text] -> Either EvaluationError a
processLogsAndErrors (EvaluationFailure) logs = Left (ScriptFailure logs)
processLogsAndErrors (EvaluationSuccess a) _   = Right a
```

## Test plan

- [x] 13 new unit tests covering all combinations of return values x language versions
- [x] `cargo test -p uplc` passes
- [x] `cargo clippy -p uplc -- -D warnings` passes clean
- [ ] Verify with real PlutusV2 oracle script evaluation (Liqwid Oracle on preview)