### PR TITLE
Fix LSP not finding definitions, modules or constructors not included in the dependency path.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
 - **aiken-lang**: Do not display UPLC machine logs in test reports when `-t silent` is given. @KtorZ
 - **aiken-lang**: Allow test assertions to "see through" backpassing and provide feedback on test failure even when using continuation passing style. @KtorZ
 - **aiken-lang**: Fix code generation interner to avoid FreeUnique caused by optimisations. @KtorZ
+- **aiken-lsp**: Fix import suggestions not being able to see through modules that aren't within the dependency path. @KtorZ
 
 ## v1.1.20 - 2025-12-11
 

--- a/crates/aiken-lang/src/ast.rs
+++ b/crates/aiken-lang/src/ast.rs
@@ -6,6 +6,7 @@ pub mod well_known;
 
 use crate::{
     ast::well_known::VALIDATOR_ELSE,
+    builtins,
     expr::{TypedExpr, UntypedExpr},
     line_numbers::LineNumbers,
     parser::token::{Base, Token},
@@ -113,38 +114,8 @@ impl TypedModule {
             .find_map(|definition| definition.find_node(byte_index))
     }
 
-    pub fn has_definition(&self, name: &str) -> bool {
-        self.definitions.iter().any(|def| match def {
-            Definition::Fn(f) => f.public && f.name == name,
-            Definition::TypeAlias(alias) => alias.public && alias.alias == name,
-            Definition::ModuleConstant(cst) => cst.public && cst.name == name,
-            Definition::DataType(t) => t.public && t.name == name,
-            Definition::Use(_) => false,
-            Definition::Test(_) => false,
-            Definition::Validator(_) => false,
-            Definition::Benchmark(_) => false,
-        })
-    }
-
-    pub fn has_constructor(&self, name: &str) -> bool {
-        self.definitions.iter().any(|def| match def {
-            Definition::DataType(t) if t.public && !t.opaque => t
-                .constructors
-                .iter()
-                .any(|constructor| constructor.name == name),
-            Definition::DataType(_) => false,
-            Definition::Fn(_) => false,
-            Definition::TypeAlias(_) => false,
-            Definition::ModuleConstant(_) => false,
-            Definition::Use(_) => false,
-            Definition::Test(_) => false,
-            Definition::Validator(_) => false,
-            Definition::Benchmark(_) => false,
-        })
-    }
-
     pub fn validate_module_name(&self) -> Result<(), Error> {
-        if self.name == "aiken" || self.name == "aiken/builtin" {
+        if self.name == builtins::PRELUDE || self.name == builtins::BUILTIN {
             return Err(Error::ReservedModuleName {
                 name: self.name.to_string(),
             });

--- a/crates/aiken-lang/src/builtins.rs
+++ b/crates/aiken-lang/src/builtins.rs
@@ -590,7 +590,7 @@ pub fn plutus(id_gen: &IdGenerator) -> TypeInfo {
             ValueConstructorVariant::ModuleFn {
                 name: "unconstr_index".to_string(),
                 field_map: None,
-                module: "aiken/builtin".to_string(),
+                module: BUILTIN.to_string(),
                 arity: 1,
                 location: Span::empty(),
                 builtin: None,
@@ -606,7 +606,7 @@ pub fn plutus(id_gen: &IdGenerator) -> TypeInfo {
             ValueConstructorVariant::ModuleFn {
                 name: "unconstr_fields".to_string(),
                 field_map: None,
-                module: "aiken/builtin".to_string(),
+                module: BUILTIN.to_string(),
                 arity: 1,
                 location: Span::empty(),
                 builtin: None,
@@ -1166,7 +1166,7 @@ pub fn prelude_functions(
 
     functions.insert(
         FunctionAccessKey {
-            module_name: "aiken/builtin".to_string(),
+            module_name: BUILTIN.to_string(),
             function_name: "unconstr_index".to_string(),
         },
         unconstr_index_func,
@@ -1230,7 +1230,7 @@ pub fn prelude_functions(
 
     functions.insert(
         FunctionAccessKey {
-            module_name: "aiken/builtin".to_string(),
+            module_name: BUILTIN.to_string(),
             function_name: "unconstr_fields".to_string(),
         },
         unconstr_fields_func,

--- a/crates/aiken-lang/src/gen_uplc/decision_tree.rs
+++ b/crates/aiken-lang/src/gen_uplc/decision_tree.rs
@@ -1415,8 +1415,8 @@ mod tester {
         let mut warnings = vec![];
 
         let mut module_types = HashMap::new();
-        module_types.insert("aiken".to_string(), builtins::prelude(&id_gen));
-        module_types.insert("aiken/builtin".to_string(), builtins::plutus(&id_gen));
+        module_types.insert(builtins::PRELUDE.to_string(), builtins::prelude(&id_gen));
+        module_types.insert(builtins::BUILTIN.to_string(), builtins::plutus(&id_gen));
 
         for (package, module) in extra {
             let mut warnings = vec![];

--- a/crates/aiken-lang/src/tests/check.rs
+++ b/crates/aiken-lang/src/tests/check.rs
@@ -37,8 +37,8 @@ fn check_module(
     let mut warnings = vec![];
 
     let mut module_types = HashMap::new();
-    module_types.insert("aiken".to_string(), builtins::prelude(&id_gen));
-    module_types.insert("aiken/builtin".to_string(), builtins::plutus(&id_gen));
+    module_types.insert(builtins::PRELUDE.to_string(), builtins::prelude(&id_gen));
+    module_types.insert(builtins::BUILTIN.to_string(), builtins::plutus(&id_gen));
 
     for module in extra {
         let mut warnings = vec![];

--- a/crates/aiken-lsp/src/edits.rs
+++ b/crates/aiken-lsp/src/edits.rs
@@ -3,7 +3,6 @@ use aiken_lang::{
     ast::{Definition, ModuleKind, Span, UntypedDefinition, Use},
     line_numbers::LineNumbers,
 };
-use aiken_project::module::CheckedModule;
 use itertools::Itertools;
 use std::fs;
 
@@ -64,12 +63,8 @@ impl ParsedDocument {
         }
     }
 
-    pub fn import(
-        &self,
-        import: &CheckedModule,
-        unqualified: Option<&str>,
-    ) -> Option<AnnotatedEdit> {
-        let import_path = import.name.split('/').collect_vec();
+    pub fn import(&self, import: &str, unqualified: Option<&str>) -> Option<AnnotatedEdit> {
+        let import_path = import.split('/').collect_vec();
 
         let mut last_import = None;
 
@@ -197,7 +192,7 @@ impl ParsedDocument {
 
     pub fn use_qualified(
         &self,
-        module: &CheckedModule,
+        module: &str,
         unqualified: &str,
         range: &lsp_types::Range,
     ) -> Option<AnnotatedEdit> {
@@ -209,17 +204,14 @@ impl ParsedDocument {
                 as_name: imported_as,
                 ..
             }) = def
-                && path.join("/") == module.name
+                && path.join("/") == module
             {
                 as_name = imported_as.as_deref();
             }
         }
 
-        let title = format!(
-            "Use qualified from {}",
-            as_name.unwrap_or(module.name.as_str())
-        );
-        let suffix = as_name.or_else(|| module.name.split("/").last())?;
+        let title = format!("Use qualified from {}", as_name.unwrap_or(module));
+        let suffix = as_name.or_else(|| module.split("/").last())?;
         Some(AnnotatedEdit::SimpleEdit(
             title,
             lsp_types::TextEdit {
@@ -240,7 +232,7 @@ impl ParsedDocument {
 
     fn insert_qualified_before(
         &self,
-        import: &CheckedModule,
+        import: &str,
         as_name: Option<&str>,
         unqualified: &str,
         location: Span,
@@ -248,7 +240,7 @@ impl ParsedDocument {
         let title = format!(
             "Import '{}' from {}",
             unqualified,
-            as_name.unwrap_or(import.name.as_str())
+            as_name.unwrap_or(import)
         );
         AnnotatedEdit::SimpleEdit(
             title,
@@ -262,7 +254,7 @@ impl ParsedDocument {
 
     fn insert_qualified_after(
         &self,
-        import: &CheckedModule,
+        import: &str,
         as_name: Option<&str>,
         unqualified: &str,
         location: Span,
@@ -270,7 +262,7 @@ impl ParsedDocument {
         let title = format!(
             "Import '{}' from {}",
             unqualified,
-            as_name.unwrap_or(import.name.as_str())
+            as_name.unwrap_or(import)
         );
         AnnotatedEdit::SimpleEdit(
             title,
@@ -280,7 +272,7 @@ impl ParsedDocument {
 
     fn add_new_qualified(
         &self,
-        import: &CheckedModule,
+        import: &str,
         as_name: Option<&str>,
         unqualified: &str,
         position: usize,
@@ -288,7 +280,7 @@ impl ParsedDocument {
         let title = format!(
             "Import '{}' from {}",
             unqualified,
-            as_name.unwrap_or(import.name.as_str())
+            as_name.unwrap_or(import)
         );
         AnnotatedEdit::SimpleEdit(
             title,
@@ -298,13 +290,13 @@ impl ParsedDocument {
 
     fn add_new_import_line(
         &self,
-        import: &CheckedModule,
+        import: &str,
         unqualified: Option<&str>,
         location: Option<Span>,
     ) -> AnnotatedEdit {
         let import_line = format!(
             "use {}{}",
-            import.name,
+            import,
             match unqualified {
                 Some(unqualified) => format!(".{{{unqualified}}}"),
                 None => String::new(),

--- a/crates/aiken-lsp/src/quickfix.rs
+++ b/crates/aiken-lsp/src/quickfix.rs
@@ -2,7 +2,6 @@ use crate::{
     edits::{self, AnnotatedEdit, ParsedDocument},
     server::lsp_project::LspProject,
 };
-use aiken_project::module::CheckedModule;
 use std::{collections::HashMap, str::FromStr};
 
 const UNKNOWN_VARIABLE: &str = "aiken::check::unknown::variable";
@@ -280,15 +279,13 @@ fn unknown_identifier(
     let mut edits = Vec::new();
 
     if let Some(serde_json::Value::String(var_name)) = data {
-        for module in compiler.project.modules() {
-            if module.ast.has_definition(var_name) {
-                if let Some(edit) = parsed_document.import(&module, Some(var_name)) {
-                    edits.push(edit)
-                }
+        for module in compiler.project.glossary().find_definition(var_name) {
+            if let Some(edit) = parsed_document.import(module, Some(var_name)) {
+                edits.push(edit)
+            }
 
-                if let Some(edit) = suggest_qualified(parsed_document, &module, var_name, range) {
-                    edits.push(edit)
-                }
+            if let Some(edit) = suggest_qualified(parsed_document, module, var_name, range) {
+                edits.push(edit)
             }
         }
     }
@@ -305,17 +302,18 @@ fn unknown_constructor(
     let mut edits = Vec::new();
 
     if let Some(serde_json::Value::String(constructor_name)) = data {
-        for module in compiler.project.modules() {
-            if module.ast.has_constructor(constructor_name) {
-                if let Some(edit) = parsed_document.import(&module, Some(constructor_name)) {
-                    edits.push(edit)
-                }
+        for module in compiler
+            .project
+            .glossary()
+            .find_constructor(constructor_name)
+        {
+            if let Some(edit) = parsed_document.import(module, Some(constructor_name)) {
+                edits.push(edit)
+            }
 
-                if let Some(edit) =
-                    suggest_qualified(parsed_document, &module, constructor_name, range)
-                {
-                    edits.push(edit)
-                }
+            if let Some(edit) = suggest_qualified(parsed_document, module, constructor_name, range)
+            {
+                edits.push(edit)
             }
         }
     }
@@ -325,7 +323,7 @@ fn unknown_constructor(
 
 fn suggest_qualified(
     parsed_document: &ParsedDocument,
-    module: &CheckedModule,
+    module: &str,
     identifier: &str,
     range: &lsp_types::Range,
 ) -> Option<AnnotatedEdit> {
@@ -357,14 +355,11 @@ fn unknown_module(
 ) -> Vec<AnnotatedEdit> {
     let mut edits = Vec::new();
 
-    if let Some(serde_json::Value::String(module_name)) = data {
-        for module in compiler.project.modules() {
-            if module.name.ends_with(module_name)
-                && let Some(edit) = parsed_document.import(&module, None)
-            {
-                edits.push(edit);
-            }
-        }
+    if let Some(serde_json::Value::String(module_name)) = data
+        && let Some(module) = compiler.project.glossary().find_module(module_name)
+        && let Some(edit) = parsed_document.import(module, None)
+    {
+        edits.push(edit);
     }
 
     edits

--- a/crates/aiken-project/src/lib.rs
+++ b/crates/aiken-project/src/lib.rs
@@ -26,7 +26,7 @@ use crate::{
     },
     config::ProjectConfig,
     error::{Error, Warning},
-    module::{CheckedModule, CheckedModules, ParsedModule, ParsedModules},
+    module::{CheckedModule, CheckedModules, Glossary, ParsedModule, ParsedModules},
     options::BlueprintExport,
     telemetry::{CoverageMode, Event},
 };
@@ -102,6 +102,7 @@ where
     constants: IndexMap<FunctionAccessKey, TypedExpr>,
     data_types: IndexMap<DataTypeKey, TypedDataType>,
     module_sources: HashMap<String, (String, LineNumbers)>,
+    glossary: Glossary,
 }
 
 impl<T> Project<T>
@@ -133,8 +134,8 @@ where
 
         let mut module_types = HashMap::new();
 
-        module_types.insert("aiken".to_string(), builtins::prelude(&id_gen));
-        module_types.insert("aiken/builtin".to_string(), builtins::plutus(&id_gen));
+        module_types.insert(builtins::PRELUDE.to_string(), builtins::prelude(&id_gen));
+        module_types.insert(builtins::BUILTIN.to_string(), builtins::plutus(&id_gen));
 
         let functions = builtins::prelude_functions(&id_gen, &module_types);
 
@@ -155,6 +156,7 @@ where
             constants: IndexMap::new(),
             data_types,
             module_sources: HashMap::new(),
+            glossary: Glossary::default(),
         }
     }
 
@@ -168,6 +170,10 @@ where
             utils::indexmap::as_str_ref_values(&self.module_sources),
             tracing,
         )
+    }
+
+    pub fn glossary(&self) -> &Glossary {
+        &self.glossary
     }
 
     pub fn warnings(&mut self) -> Vec<Warning> {
@@ -913,6 +919,8 @@ where
         let our_modules: BTreeSet<String> = modules.keys().cloned().collect();
 
         self.with_dependencies(modules)?;
+
+        modules.extends_glossary(&mut self.glossary);
 
         for name in modules.sequence(&our_modules)? {
             if let Some(module) = modules.remove(&name) {

--- a/crates/aiken-project/src/module.rs
+++ b/crates/aiken-project/src/module.rs
@@ -2,10 +2,11 @@ use crate::{Error, Warning};
 use aiken_lang::{
     IdGenerator,
     ast::{
-        DataType, DataTypeKey, Definition, Function, FunctionAccessKey, Located, ModuleKind,
-        Tracing, TypedDataType, TypedFunction, TypedModule, TypedValidator, UntypedModule,
-        Validator,
+        DataType, DataTypeKey, Definition, Function, FunctionAccessKey, Located, ModuleConstant,
+        ModuleKind, Tracing, TypeAlias, TypedDataType, TypedFunction, TypedModule, TypedValidator,
+        UntypedModule, Validator,
     },
+    builtins,
     expr::TypedExpr,
     line_numbers::LineNumbers,
     parser::extra::{Comment, ModuleExtra, comments_before},
@@ -15,7 +16,7 @@ use indexmap::IndexMap;
 use miette::NamedSource;
 use petgraph::{Direction, Graph, algo, graph::NodeIndex};
 use std::{
-    collections::{BTreeSet, HashMap},
+    collections::{BTreeMap, BTreeSet, HashMap},
     io,
     ops::{Deref, DerefMut},
     path::PathBuf,
@@ -115,11 +116,129 @@ impl ParsedModule {
     }
 }
 
+/// Used by the LSP to lookup missing definitions in modules.
+#[derive(Debug)]
+pub struct Glossary(BTreeMap<String, ModuleGlossary>);
+
+impl Default for Glossary {
+    fn default() -> Self {
+        let id_gen = IdGenerator::new();
+        Self(BTreeMap::from([(
+            builtins::BUILTIN.to_string(),
+            ModuleGlossary {
+                public_definitions: builtins::plutus(&id_gen).values.keys().cloned().collect(),
+                public_constructors: BTreeSet::new(),
+            },
+        )]))
+    }
+}
+
+impl Glossary {
+    pub fn add(&mut self, module: &ParsedModule) {
+        let glossary =
+            module
+                .ast
+                .definitions
+                .iter()
+                .fold(ModuleGlossary::default(), |mut glossary, def| {
+                    match def {
+                        Definition::Fn(Function { public, name, .. })
+                        | Definition::ModuleConstant(ModuleConstant { public, name, .. })
+                        | Definition::TypeAlias(TypeAlias {
+                            public,
+                            alias: name,
+                            ..
+                        }) if *public => {
+                            glossary.public_definitions.insert(name.clone());
+                        }
+                        Definition::DataType(t) if t.public => {
+                            glossary.public_definitions.insert(t.name.clone());
+                            if !t.opaque {
+                                for constructor in t.constructors.iter() {
+                                    glossary
+                                        .public_constructors
+                                        .insert(constructor.name.clone());
+                                }
+                            }
+                        }
+                        Definition::Fn(_)
+                        | Definition::TypeAlias(_)
+                        | Definition::ModuleConstant(_)
+                        | Definition::DataType(_)
+                        | Definition::Use(_)
+                        | Definition::Test(_)
+                        | Definition::Validator(_)
+                        | Definition::Benchmark(_) => (),
+                    };
+
+                    glossary
+                });
+
+        if !glossary.is_empty() {
+            self.0.insert(module.name.clone(), glossary);
+        }
+    }
+
+    /// Check whether a module is in the glossary
+    pub fn find_module(&self, needle: &str) -> Option<&str> {
+        self.0
+            .keys()
+            .find(|module_name| module_name.ends_with(needle))
+            .map(|k| k.as_str())
+    }
+
+    /// Find a module with a matching definition
+    pub fn find_definition(&self, needle: &str) -> Vec<&str> {
+        self.0
+            .iter()
+            .filter(|(_, definitions)| {
+                definitions
+                    .public_definitions
+                    .iter()
+                    .any(|def| def == needle)
+            })
+            .map(|(k, _)| k.as_str())
+            .collect()
+    }
+
+    /// Find a module with a matching constructor
+    pub fn find_constructor(&self, needle: &str) -> Vec<&str> {
+        self.0
+            .iter()
+            .filter(|(_, definitions)| {
+                definitions
+                    .public_constructors
+                    .iter()
+                    .any(|def| def == needle)
+            })
+            .map(|(k, _)| k.as_str())
+            .collect()
+    }
+}
+
+#[derive(Debug, Default)]
+pub struct ModuleGlossary {
+    public_definitions: BTreeSet<String>,
+    public_constructors: BTreeSet<String>,
+}
+
+impl ModuleGlossary {
+    pub fn is_empty(&self) -> bool {
+        self.public_definitions.is_empty() && self.public_constructors.is_empty()
+    }
+}
+
 pub struct ParsedModules(HashMap<String, ParsedModule>);
 
 impl ParsedModules {
     pub fn new() -> Self {
         Self(HashMap::new())
+    }
+
+    pub fn extends_glossary(&self, glossary: &mut Glossary) {
+        for module in self.0.values() {
+            glossary.add(module);
+        }
     }
 
     #[allow(clippy::result_large_err)]

--- a/crates/aiken-project/src/test_framework.rs
+++ b/crates/aiken-project/src/test_framework.rs
@@ -34,8 +34,8 @@ mod test {
         let module_name = "";
 
         let mut module_types = HashMap::new();
-        module_types.insert("aiken".to_string(), builtins::prelude(&id_gen));
-        module_types.insert("aiken/builtin".to_string(), builtins::plutus(&id_gen));
+        module_types.insert(builtins::PRELUDE.to_string(), builtins::prelude(&id_gen));
+        module_types.insert(builtins::BUILTIN.to_string(), builtins::plutus(&id_gen));
 
         let mut warnings = vec![];
         let (ast, _) = parser::module(src, TEST_KIND).expect("Failed to parse module");


### PR DESCRIPTION
In particular, allow the LSP to suggest imports from builtins when relevant.

This whole thing has been broken ever since we introduced the module pruning to avoid compiling modules not strictly required by the program. As a result, we wouldn't have access to definitions from fully new modules, and the LSP quickfix would simply look as if they worked half of the time. Since we already parse all modules anyway, we can simply stash the definitions and constructor names into some kind of indexes to lookup from later.

<img width="981" height="181" alt="Screenshot 2026-04-24 at 10 58 10" src="https://github.com/user-attachments/assets/f7ac9372-1f5d-485e-a33a-231ff1ff8dec" />
<img width="1172" height="111" alt="Screenshot 2026-04-24 at 10 58 30" src="https://github.com/user-attachments/assets/3cec5be1-5953-4256-b17e-f8136590025c" />
<img width="907" height="137" alt="Screenshot 2026-04-24 at 10 59 08" src="https://github.com/user-attachments/assets/71e0e3dc-3410-479c-bf85-b43584c4daa8" />
<img width="516" height="144" alt="Screenshot 2026-04-24 at 11 00 05" src="https://github.com/user-attachments/assets/3f7fcda6-3015-4f57-b024-a4dd87673647" />
