### PR TITLE
reject malformed list spread patterns with a leading comma

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
 - **aiken-lang**: Allow test assertions to "see through" backpassing and provide feedback on test failure even when using continuation passing style. @KtorZ
 - **aiken-lang**: Fix code generation interner to avoid FreeUnique caused by optimisations. @KtorZ
 - **aiken-lang**: Fix compiler removing empty list checks with `-t silent` for list patterns containing only discards. @KtorZ
+- **aiken-lang**: Reject malformed list spread patterns with a leading comma (e.g. `[, ..rest]`) at parse time instead of crashing during code generation. Fixes [#1313](https://github.com/aiken-lang/aiken/issues/1313). @SAY-5
 - **aiken-lsp**: Fix import suggestions not being able to see through modules that aren't within the dependency path. @KtorZ
 
 ## v1.1.20 - 2025-12-11

--- a/crates/aiken-lang/src/parser/pattern/list.rs
+++ b/crates/aiken-lang/src/parser/pattern/list.rs
@@ -23,6 +23,15 @@ pub fn parser(
         )))
         .then_ignore(just(Token::RightSquare))
         .validate(|(elements, tail), span: ast::Span, emit| {
+            // A leading comma without a preceding element (e.g. `[, ..rest]`) is malformed.
+            if elements.is_empty() && tail.is_some() {
+                emit(ParseError::expected_input_found(
+                    span,
+                    None,
+                    Some(error::Pattern::Match),
+                ));
+            }
+
             let tail = match tail {
                 // There is a tail and it has a Pattern::Var or Pattern::Discard
                 Some(Some(pat @ (UntypedPattern::Var { .. } | UntypedPattern::Discard { .. }))) => {

--- a/crates/aiken-lang/src/parser/pattern/mod.rs
+++ b/crates/aiken-lang/src/parser/pattern/mod.rs
@@ -114,4 +114,19 @@ mod tests {
     fn pattern_list_spread() {
         assert_pattern!("[head, ..]");
     }
+
+    #[test]
+    fn pattern_list_spread_without_head_is_rejected() {
+        use chumsky::Parser;
+
+        let crate::parser::lexer::LexInfo { tokens, .. } =
+            crate::parser::lexer::run("[, ..rest]").unwrap();
+
+        let stream = chumsky::Stream::from_iter(
+            crate::ast::Span::create(tokens.len(), 1),
+            tokens.into_iter(),
+        );
+
+        assert!(super::parser().parse(stream).is_err());
+    }
 }


### PR DESCRIPTION
The pattern parser accepted `[, ..rest]` as a list pattern with no head elements, which passed exhaustiveness checking and then hit `assert!(props.kind.is_expect())` in `gen_uplc.rs`, crashing the compiler with a fatal error. This rejects the leading-comma form at parse time with the existing malformed-list-spread diagnostic, matching the fact that `[..rest]` is already a parse error. Closes #1313.