### PR TITLE
Handle invalid params in apply_params_to_script without panicking

### DIFF
--- a/crates/uplc/src/tx.rs
+++ b/crates/uplc/src/tx.rs
@@ -191,9 +191,9 @@ pub fn apply_params_to_script(
     params_bytes: &[u8], // PlutusData array
     plutus_script_bytes: &[u8],
 ) -> Result<Vec<u8>, Error> {
-    let params = match PlutusData::decode_fragment(params_bytes).unwrap() {
-        PlutusData::Array(res) => res,
-        _ => unreachable!(),
+    let params = match PlutusData::decode_fragment(params_bytes) {
+        Ok(PlutusData::Array(res)) => res,
+        Ok(_) | Err(_) => return Err(Error::ApplyParamsError),
     };
 
     let mut buffer = Vec::new();

--- a/crates/uplc/src/tx/tests.rs
+++ b/crates/uplc/src/tx/tests.rs
@@ -1775,3 +1775,37 @@ fn eval_extraneous_redeemer() {
         _ => unreachable!(),
     };
 }
+
+#[test]
+fn apply_params_to_script_rejects_malformed_params_cbor() {
+    let result = super::apply_params_to_script(&[0xd6, 0xec], &[]);
+
+    assert!(matches!(result, Err(super::error::Error::ApplyParamsError)));
+}
+
+#[test]
+fn apply_params_to_script_rejects_non_array_params() {
+    let result = super::apply_params_to_script(&[0x00], &[]);
+
+    assert!(matches!(result, Err(super::error::Error::ApplyParamsError)));
+}
+
+#[test]
+fn apply_params_to_script_rejects_invalid_params_without_panicking() {
+    // Malformed params CBOR used to panic at `decode_fragment(...).unwrap()`.
+    const MALFORMED_PARAMS_CBOR: &[u8] = &[0xd6, 0xec];
+
+    // Well-formed PlutusData that is not an array used to panic at `_ => unreachable!()`.
+    // This is PlutusData::BigInt(0) encoded as CBOR.
+    const NON_ARRAY_PARAMS_CBOR: &[u8] = &[0x00];
+
+    assert!(matches!(
+        super::apply_params_to_script(MALFORMED_PARAMS_CBOR, &[]),
+        Err(super::error::Error::ApplyParamsError)
+    ));
+
+    assert!(matches!(
+        super::apply_params_to_script(NON_ARRAY_PARAMS_CBOR, &[]),
+        Err(super::error::Error::ApplyParamsError)
+    ));
+}


### PR DESCRIPTION
Fixes #1322.

`apply_params_to_script` returns `Result<Vec<u8>, Error>`, but it could still panic for invalid `params_bytes`:
- malformed CBOR would panic at `decode_fragment(...).unwrap()`
- valid `PlutusData` that was not an array would panic at `_ => unreachable!()`

This changes both cases to return `Error::ApplyParamsError`.