### PR TITLE
fix(aiken-lang): diagnose oversized @tag values instead of panicking

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [next] - YYYY-MM-DD
+
+### Fixed
+
+- **aiken-lang**: Emit a `DecoratorValidation` diagnostic instead of panicking when an `@tag(...)` decorator value exceeds `usize::MAX`. Fixes [#1319](https://github.com/aiken-lang/aiken/issues/1319). @SAY-5
+
 ## v1.1.22 - 2026-05-15
 
 ### Added

--- a/crates/aiken-lang/src/tests/check.rs
+++ b/crates/aiken-lang/src/tests/check.rs
@@ -4542,6 +4542,24 @@ fn decorator_validation_overlaping_tags() {
 }
 
 #[test]
+fn decorator_validation_tag_overflow() {
+    // A tag value beyond `usize::MAX` must surface as a normal diagnostic,
+    // not a `usize::from_str(...).unwrap()` panic during decorator checking.
+    let source_code = r#"
+        pub type Datum {
+          @tag(18446744073709551616)
+          TooLarge
+          Other
+        }
+    "#;
+
+    assert!(matches!(
+        check(parse(source_code)),
+        Err((_, Error::DecoratorValidation { .. }))
+    ))
+}
+
+#[test]
 fn validator_parameter_scope_escape() {
     let source_code = r#"
         validator placeholder(foo: Option<Int>) {

--- a/crates/aiken-lang/src/tipo/infer.rs
+++ b/crates/aiken-lang/src/tipo/infer.rs
@@ -1076,17 +1076,23 @@ impl TypedDataType {
                 None,
             )?;
 
-            let (tag, location) = constructor
-                .decorators
-                .iter()
-                .find_map(|decorator| {
-                    if let DecoratorKind::Tag { value, .. } = &decorator.kind {
-                        Some((value.parse().unwrap(), &decorator.location))
-                    } else {
-                        None
-                    }
-                })
-                .unwrap_or((index, &constructor.location));
+            let mut tagged: Option<(usize, &Span)> = None;
+            for decorator in &constructor.decorators {
+                if let DecoratorKind::Tag { value, .. } = &decorator.kind {
+                    let parsed =
+                        value
+                            .parse::<usize>()
+                            .map_err(|_| Error::DecoratorValidation {
+                                location: decorator.location,
+                                message: format!(
+                                    "tag value `{value}` does not fit in a usize on this platform"
+                                ),
+                            })?;
+                    tagged = Some((parsed, &decorator.location));
+                    break;
+                }
+            }
+            let (tag, location) = tagged.unwrap_or((index, &constructor.location));
 
             if let Some(first) = seen.insert(tag, location) {
                 return Err(Error::DecoratorTagOverlap {


### PR DESCRIPTION
An oversized `@tag(...)` integer value (above `usize::MAX`) reached `value.parse().unwrap()` in `TypedDataType::check_decorators` and panicked the compiler instead of producing a normal diagnostic. The parse error is now surfaced as a `DecoratorValidation` diagnostic, matching the issue's expected behavior.

Fixes #1319