### PR TITLE
Add protocol-aware PV11 UPLC evaluation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [next] - 2026-06-12
+
+### Fixed
+
+- **uplc**: Evaluate phase-two scripts with protocol-aware builtin semantics and parse PlutusV3 PV11 cost models. @colll78
+
 ## v1.1.22 - 2026-05-15
 
 ### Added

--- a/crates/uplc/src/ast.rs
+++ b/crates/uplc/src/ast.rs
@@ -4,7 +4,9 @@ use crate::{
     flat::Binder,
     machine::{
         Machine,
-        cost_model::{CostModel, ExBudget, initialize_cost_model},
+        cost_model::{
+            CostModel, ExBudget, initialize_cost_model, initialize_cost_model_with_protocol,
+        },
         eval_result::EvalResult,
         value::to_pallas_bigint,
     },
@@ -896,6 +898,33 @@ impl Program<NamedDeBruijn> {
         )
     }
 
+    /// Evaluate a Program as a specific PlutusVersion and protocol version,
+    /// using the default cost model for the chosen PlutusVersion.
+    pub fn eval_version_with_protocol(
+        self,
+        initial_budget: ExBudget,
+        version: &Language,
+        protocol_major_version: u16,
+    ) -> EvalResult {
+        let mut machine = Machine::new_with_protocol(
+            version.clone(),
+            protocol_major_version,
+            CostModel::default(),
+            initial_budget,
+            200,
+        );
+
+        let term = machine.run(self.term);
+
+        EvalResult::new(
+            term,
+            machine.ex_budget,
+            initial_budget,
+            machine.traces,
+            machine.spend_counter.map(|i| i.into()),
+        )
+    }
+
     pub fn eval_as(
         self,
         version: &Language,
@@ -907,6 +936,36 @@ impl Program<NamedDeBruijn> {
         let mut machine = Machine::new(
             version.clone(),
             initialize_cost_model(version, costs),
+            budget,
+            200, //slippage
+        );
+
+        let term = machine.run(self.term);
+
+        EvalResult::new(
+            term,
+            machine.ex_budget,
+            budget,
+            machine.traces,
+            machine.spend_counter.map(|i| i.into()),
+        )
+    }
+
+    /// Evaluate a Program with an explicit ledger cost model and protocol
+    /// version.
+    pub fn eval_as_with_protocol(
+        self,
+        version: &Language,
+        protocol_major_version: u16,
+        costs: &[i64],
+        initial_budget: Option<&ExBudget>,
+    ) -> EvalResult {
+        let budget = initial_budget.copied().unwrap_or_default();
+
+        let mut machine = Machine::new_with_protocol(
+            version.clone(),
+            protocol_major_version,
+            initialize_cost_model_with_protocol(version, protocol_major_version, costs),
             budget,
             200, //slippage
         );
@@ -951,6 +1010,16 @@ impl Program<DeBruijn> {
     pub fn eval_version(self, initial_budget: ExBudget, version: &Language) -> EvalResult {
         let program: Program<NamedDeBruijn> = self.clone().into();
         program.eval_version(initial_budget, version)
+    }
+
+    pub fn eval_version_with_protocol(
+        self,
+        initial_budget: ExBudget,
+        version: &Language,
+        protocol_major_version: u16,
+    ) -> EvalResult {
+        let program: Program<NamedDeBruijn> = self.clone().into();
+        program.eval_version_with_protocol(initial_budget, version, protocol_major_version)
     }
 }
 

--- a/crates/uplc/src/machine.rs
+++ b/crates/uplc/src/machine.rs
@@ -15,7 +15,7 @@ use pallas_primitives::conway::Language;
 
 use self::{
     cost_model::CostModel,
-    runtime::BuiltinRuntime,
+    runtime::{BuiltinRuntime, BuiltinSemantics},
     value::{Env, Value},
 };
 
@@ -83,7 +83,7 @@ pub struct Machine {
     unbudgeted_steps: [u32; 10],
     pub traces: Vec<Trace>,
     pub spend_counter: Option<[i64; (TERM_COUNT + BUILTIN_COUNT) * 2]>,
-    version: Language,
+    semantics: BuiltinSemantics,
 }
 
 impl Machine {
@@ -93,6 +93,8 @@ impl Machine {
         initial_budget: ExBudget,
         slippage: u32,
     ) -> Machine {
+        let semantics = BuiltinSemantics::for_language(&version);
+
         Machine {
             costs,
             ex_budget: initial_budget,
@@ -100,7 +102,28 @@ impl Machine {
             unbudgeted_steps: [0; 10],
             traces: vec![],
             spend_counter: None,
-            version,
+            semantics,
+        }
+    }
+
+    pub fn new_with_protocol(
+        version: Language,
+        protocol_major_version: u16,
+        costs: CostModel,
+        initial_budget: ExBudget,
+        slippage: u32,
+    ) -> Machine {
+        let semantics =
+            BuiltinSemantics::for_language_and_protocol(&version, protocol_major_version);
+
+        Machine {
+            costs,
+            ex_budget: initial_budget,
+            slippage,
+            unbudgeted_steps: [0; 10],
+            traces: vec![],
+            spend_counter: None,
+            semantics,
         }
     }
 
@@ -110,6 +133,8 @@ impl Machine {
         initial_budget: ExBudget,
         slippage: u32,
     ) -> Machine {
+        let semantics = BuiltinSemantics::for_language(&version);
+
         Machine {
             costs,
             ex_budget: initial_budget,
@@ -117,7 +142,28 @@ impl Machine {
             unbudgeted_steps: [0; 10],
             traces: vec![],
             spend_counter: Some([0; (TERM_COUNT + BUILTIN_COUNT) * 2]),
-            version,
+            semantics,
+        }
+    }
+
+    pub fn new_debug_with_protocol(
+        version: Language,
+        protocol_major_version: u16,
+        costs: CostModel,
+        initial_budget: ExBudget,
+        slippage: u32,
+    ) -> Machine {
+        let semantics =
+            BuiltinSemantics::for_language_and_protocol(&version, protocol_major_version);
+
+        Machine {
+            costs,
+            ex_budget: initial_budget,
+            slippage,
+            unbudgeted_steps: [0; 10],
+            traces: vec![],
+            spend_counter: Some([0; (TERM_COUNT + BUILTIN_COUNT) * 2]),
+            semantics,
         }
     }
 
@@ -373,7 +419,7 @@ impl Machine {
     }
 
     fn eval_builtin_app(&mut self, runtime: BuiltinRuntime) -> Result<Value, Error> {
-        let cost = runtime.to_ex_budget(&self.costs.builtin_costs)?;
+        let cost = runtime.to_ex_budget(&self.costs.builtin_costs, self.semantics)?;
 
         self.spend_budget(cost)?;
 
@@ -384,7 +430,7 @@ impl Machine {
             counter[i + 1] += cost.cpu;
         }
 
-        runtime.call(&self.version, &mut self.traces)
+        runtime.call(self.semantics, &mut self.traces)
     }
 
     fn lookup_var(&mut self, name: &NamedDeBruijn, env: &[Value]) -> Result<Value, Error> {

--- a/crates/uplc/src/machine/cost_model.rs
+++ b/crates/uplc/src/machine/cost_model.rs
@@ -1,4 +1,4 @@
-use super::{Error, Value};
+use super::{Error, Value, runtime::BuiltinSemantics};
 use crate::builtins::DefaultFunction;
 use num_traits::Signed;
 use pallas_primitives::conway::Language;
@@ -23,6 +23,10 @@ pub struct ExBudget {
     pub mem: i64,
     pub cpu: i64,
 }
+
+// Existing default cost models use a large sentinel for builtins that are not
+// available in a language version.
+const UNAVAILABLE_BUILTIN_COST: i64 = 30000000000;
 
 impl ExBudget {
     pub fn occurrences(&mut self, n: i64) {
@@ -358,6 +362,216 @@ pub struct BuiltinCosts {
     find_first_set_bit: CostingFun<OneArgument>,
     ripemd_160: CostingFun<OneArgument>,
     exp_mod_int: CostingFun<ThreeArguments>,
+    pub pv11_builtin_costs: Pv11BuiltinCosts,
+}
+
+#[derive(Debug, PartialEq)]
+pub struct Pv11BuiltinCosts {
+    pub drop_list: CostingFun<TwoArguments>,
+    pub length_of_array: CostingFun<OneArgument>,
+    pub list_to_array: CostingFun<OneArgument>,
+    pub index_array: CostingFun<TwoArguments>,
+    pub bls12_381_g1_multi_scalar_mul: CostingFun<TwoArguments>,
+    pub bls12_381_g2_multi_scalar_mul: CostingFun<TwoArguments>,
+    pub insert_coin: CostingFun<FourArguments>,
+    pub lookup_coin: CostingFun<ThreeArguments>,
+    pub union_value: CostingFun<TwoArguments>,
+    pub value_contains: CostingFun<TwoArguments>,
+    pub value_data: CostingFun<OneArgument>,
+    pub un_value_data: CostingFun<OneArgument>,
+    pub scale_value: CostingFun<TwoArguments>,
+}
+
+impl Pv11BuiltinCosts {
+    fn unavailable() -> Self {
+        Self {
+            drop_list: CostingFun {
+                cpu: TwoArguments::ConstantCost(UNAVAILABLE_BUILTIN_COST),
+                mem: TwoArguments::ConstantCost(UNAVAILABLE_BUILTIN_COST),
+            },
+            length_of_array: CostingFun {
+                cpu: OneArgument::ConstantCost(UNAVAILABLE_BUILTIN_COST),
+                mem: OneArgument::ConstantCost(UNAVAILABLE_BUILTIN_COST),
+            },
+            list_to_array: CostingFun {
+                cpu: OneArgument::ConstantCost(UNAVAILABLE_BUILTIN_COST),
+                mem: OneArgument::ConstantCost(UNAVAILABLE_BUILTIN_COST),
+            },
+            index_array: CostingFun {
+                cpu: TwoArguments::ConstantCost(UNAVAILABLE_BUILTIN_COST),
+                mem: TwoArguments::ConstantCost(UNAVAILABLE_BUILTIN_COST),
+            },
+            bls12_381_g1_multi_scalar_mul: CostingFun {
+                cpu: TwoArguments::ConstantCost(UNAVAILABLE_BUILTIN_COST),
+                mem: TwoArguments::ConstantCost(UNAVAILABLE_BUILTIN_COST),
+            },
+            bls12_381_g2_multi_scalar_mul: CostingFun {
+                cpu: TwoArguments::ConstantCost(UNAVAILABLE_BUILTIN_COST),
+                mem: TwoArguments::ConstantCost(UNAVAILABLE_BUILTIN_COST),
+            },
+            insert_coin: CostingFun {
+                cpu: FourArguments::ConstantCost(UNAVAILABLE_BUILTIN_COST),
+                mem: FourArguments::ConstantCost(UNAVAILABLE_BUILTIN_COST),
+            },
+            lookup_coin: CostingFun {
+                cpu: ThreeArguments::ConstantCost(UNAVAILABLE_BUILTIN_COST),
+                mem: ThreeArguments::ConstantCost(UNAVAILABLE_BUILTIN_COST),
+            },
+            union_value: CostingFun {
+                cpu: TwoArguments::ConstantCost(UNAVAILABLE_BUILTIN_COST),
+                mem: TwoArguments::ConstantCost(UNAVAILABLE_BUILTIN_COST),
+            },
+            value_contains: CostingFun {
+                cpu: TwoArguments::ConstantCost(UNAVAILABLE_BUILTIN_COST),
+                mem: TwoArguments::ConstantCost(UNAVAILABLE_BUILTIN_COST),
+            },
+            value_data: CostingFun {
+                cpu: OneArgument::ConstantCost(UNAVAILABLE_BUILTIN_COST),
+                mem: OneArgument::ConstantCost(UNAVAILABLE_BUILTIN_COST),
+            },
+            un_value_data: CostingFun {
+                cpu: OneArgument::ConstantCost(UNAVAILABLE_BUILTIN_COST),
+                mem: OneArgument::ConstantCost(UNAVAILABLE_BUILTIN_COST),
+            },
+            scale_value: CostingFun {
+                cpu: TwoArguments::ConstantCost(UNAVAILABLE_BUILTIN_COST),
+                mem: TwoArguments::ConstantCost(UNAVAILABLE_BUILTIN_COST),
+            },
+        }
+    }
+
+    fn from_van_rossem_costs(costs: &[i64]) -> Self {
+        debug_assert!(costs.len() >= 350);
+
+        Self {
+            drop_list: CostingFun {
+                cpu: TwoArguments::LinearInX(LinearSize {
+                    intercept: costs[302],
+                    slope: costs[303],
+                }),
+                mem: TwoArguments::ConstantCost(costs[304]),
+            },
+            length_of_array: CostingFun {
+                cpu: OneArgument::ConstantCost(costs[305]),
+                mem: OneArgument::ConstantCost(costs[306]),
+            },
+            list_to_array: CostingFun {
+                cpu: OneArgument::LinearCost(LinearSize {
+                    intercept: costs[307],
+                    slope: costs[308],
+                }),
+                mem: OneArgument::LinearCost(LinearSize {
+                    intercept: costs[309],
+                    slope: costs[310],
+                }),
+            },
+            index_array: CostingFun {
+                cpu: TwoArguments::ConstantCost(costs[311]),
+                mem: TwoArguments::ConstantCost(costs[312]),
+            },
+            bls12_381_g1_multi_scalar_mul: CostingFun {
+                cpu: TwoArguments::LinearInX(LinearSize {
+                    intercept: costs[313],
+                    slope: costs[314],
+                }),
+                mem: TwoArguments::ConstantCost(costs[315]),
+            },
+            bls12_381_g2_multi_scalar_mul: CostingFun {
+                cpu: TwoArguments::LinearInX(LinearSize {
+                    intercept: costs[316],
+                    slope: costs[317],
+                }),
+                mem: TwoArguments::ConstantCost(costs[318]),
+            },
+            insert_coin: CostingFun {
+                cpu: FourArguments::LinearInU(LinearSize {
+                    intercept: costs[319],
+                    slope: costs[320],
+                }),
+                mem: FourArguments::LinearInU(LinearSize {
+                    intercept: costs[321],
+                    slope: costs[322],
+                }),
+            },
+            lookup_coin: CostingFun {
+                cpu: ThreeArguments::LinearInZ(LinearSize {
+                    intercept: costs[323],
+                    slope: costs[324],
+                }),
+                mem: ThreeArguments::ConstantCost(costs[325]),
+            },
+            union_value: CostingFun {
+                cpu: TwoArguments::WithInteractionInXAndY(TwoVariableWithInteractionSize {
+                    coeff_00: costs[326],
+                    coeff_10: costs[327],
+                    coeff_01: costs[328],
+                    coeff_11: costs[329],
+                }),
+                mem: TwoArguments::AddedSizes(AddedSizes {
+                    intercept: costs[330],
+                    slope: costs[331],
+                }),
+            },
+            value_contains: CostingFun {
+                cpu: TwoArguments::ConstAboveDiagonal(ConstantOrTwoArguments {
+                    constant: costs[332],
+                    model: Box::new(TwoArguments::LinearInXAndY(TwoVariableLinearSize {
+                        intercept: costs[333],
+                        slope1: costs[334],
+                        slope2: costs[335],
+                    })),
+                }),
+                mem: TwoArguments::ConstantCost(costs[336]),
+            },
+            value_data: CostingFun {
+                cpu: OneArgument::LinearCost(LinearSize {
+                    intercept: costs[337],
+                    slope: costs[338],
+                }),
+                mem: OneArgument::LinearCost(LinearSize {
+                    intercept: costs[339],
+                    slope: costs[340],
+                }),
+            },
+            un_value_data: CostingFun {
+                cpu: OneArgument::QuadraticCost(QuadraticFunction {
+                    coeff_0: costs[341],
+                    coeff_1: costs[342],
+                    coeff_2: costs[343],
+                }),
+                mem: OneArgument::LinearCost(LinearSize {
+                    intercept: costs[344],
+                    slope: costs[345],
+                }),
+            },
+            scale_value: CostingFun {
+                cpu: TwoArguments::LinearInY(LinearSize {
+                    intercept: costs[346],
+                    slope: costs[347],
+                }),
+                mem: TwoArguments::LinearInY(LinearSize {
+                    intercept: costs[348],
+                    slope: costs[349],
+                }),
+            },
+        }
+    }
+}
+
+fn pv11_exp_mod_integer_costs(costs: &[i64]) -> CostingFun<ThreeArguments> {
+    debug_assert!(costs.len() >= 350);
+
+    CostingFun {
+        cpu: ThreeArguments::ExpModCost(ExpModCostingFunction {
+            coefficient_00: costs[297],
+            coefficient_11: costs[298],
+            coefficient_12: costs[299],
+        }),
+        mem: ThreeArguments::LinearInZ(LinearSize {
+            intercept: costs[300],
+            slope: costs[301],
+        }),
+    }
 }
 
 impl BuiltinCosts {
@@ -856,6 +1070,7 @@ impl BuiltinCosts {
                 cpu: ThreeArguments::ConstantCost(30000000000),
                 mem: ThreeArguments::ConstantCost(30000000000),
             },
+            pv11_builtin_costs: Pv11BuiltinCosts::unavailable(),
         }
     }
 
@@ -1354,6 +1569,7 @@ impl BuiltinCosts {
                 cpu: ThreeArguments::ConstantCost(30000000000),
                 mem: ThreeArguments::ConstantCost(30000000000),
             },
+            pv11_builtin_costs: Pv11BuiltinCosts::unavailable(),
         }
     }
 
@@ -1963,6 +2179,7 @@ impl BuiltinCosts {
                 cpu: ThreeArguments::ConstantCost(30000000000),
                 mem: ThreeArguments::ConstantCost(30000000000),
             },
+            pv11_builtin_costs: Pv11BuiltinCosts::unavailable(),
         }
     }
 }
@@ -1974,7 +2191,12 @@ impl Default for BuiltinCosts {
 }
 
 impl BuiltinCosts {
-    pub fn to_ex_budget(&self, fun: DefaultFunction, args: &[Value]) -> Result<ExBudget, Error> {
+    pub fn to_ex_budget(
+        &self,
+        fun: DefaultFunction,
+        args: &[Value],
+        semantics: BuiltinSemantics,
+    ) -> Result<ExBudget, Error> {
         Ok(match fun {
             DefaultFunction::AddInteger => ExBudget {
                 mem: self
@@ -2201,28 +2423,34 @@ impl BuiltinCosts {
                 ),
             },
             DefaultFunction::AppendString => ExBudget {
-                mem: self
-                    .append_string
-                    .mem
-                    .cost(args[0].to_ex_mem(), args[1].to_ex_mem()),
-                cpu: self
-                    .append_string
-                    .cpu
-                    .cost(args[0].to_ex_mem(), args[1].to_ex_mem()),
+                mem: self.append_string.mem.cost(
+                    args[0].to_ex_mem_with_semantics(semantics),
+                    args[1].to_ex_mem_with_semantics(semantics),
+                ),
+                cpu: self.append_string.cpu.cost(
+                    args[0].to_ex_mem_with_semantics(semantics),
+                    args[1].to_ex_mem_with_semantics(semantics),
+                ),
             },
             DefaultFunction::EqualsString => ExBudget {
-                mem: self
-                    .equals_string
-                    .mem
-                    .cost(args[0].to_ex_mem(), args[1].to_ex_mem()),
-                cpu: self
-                    .equals_string
-                    .cpu
-                    .cost(args[0].to_ex_mem(), args[1].to_ex_mem()),
+                mem: self.equals_string.mem.cost(
+                    args[0].to_ex_mem_with_semantics(semantics),
+                    args[1].to_ex_mem_with_semantics(semantics),
+                ),
+                cpu: self.equals_string.cpu.cost(
+                    args[0].to_ex_mem_with_semantics(semantics),
+                    args[1].to_ex_mem_with_semantics(semantics),
+                ),
             },
             DefaultFunction::EncodeUtf8 => ExBudget {
-                mem: self.encode_utf8.mem.cost(args[0].to_ex_mem()),
-                cpu: self.encode_utf8.cpu.cost(args[0].to_ex_mem()),
+                mem: self
+                    .encode_utf8
+                    .mem
+                    .cost(args[0].to_ex_mem_with_semantics(semantics)),
+                cpu: self
+                    .encode_utf8
+                    .cpu
+                    .cost(args[0].to_ex_mem_with_semantics(semantics)),
             },
             DefaultFunction::DecodeUtf8 => ExBudget {
                 mem: self.decode_utf8.mem.cost(args[0].to_ex_mem()),
@@ -2708,6 +2936,28 @@ impl BuiltinCosts {
 }
 
 pub fn initialize_cost_model(version: &Language, costs: &[i64]) -> CostModel {
+    initialize_cost_model_with_semantics(version, BuiltinSemantics::for_language(version), costs)
+}
+
+pub fn initialize_cost_model_with_protocol(
+    version: &Language,
+    protocol_major_version: u16,
+    costs: &[i64],
+) -> CostModel {
+    initialize_cost_model_with_semantics(
+        version,
+        BuiltinSemantics::for_language_and_protocol(version, protocol_major_version),
+        costs,
+    )
+}
+
+fn initialize_cost_model_with_semantics(
+    version: &Language,
+    semantics: BuiltinSemantics,
+    costs: &[i64],
+) -> CostModel {
+    let has_pv11_tail = matches!(version, Language::PlutusV3) && costs.len() >= 350;
+
     let cost_map: HashMap<&str, i64> = match version {
         Language::PlutusV1 => {
             hashmap! {
@@ -3314,7 +3564,7 @@ pub fn initialize_cost_model(version: &Language, costs: &[i64]) -> CostModel {
                 "byteStringToInteger-mem-arguments-slope" => costs[250],
             };
 
-            if costs.len() == 297 {
+            if costs.len() >= 297 {
                 let test = hashmap! {
                     "andByteString-cpu-arguments-intercept"=> costs[251],
                     "andByteString-cpu-arguments-slope1"=> costs[252],
@@ -3500,14 +3750,27 @@ pub fn initialize_cost_model(version: &Language, costs: &[i64]) -> CostModel {
                         .get("multiply_integer-mem-arguments-slope")
                         .unwrap_or(&30000000000),
                 }),
-                cpu: TwoArguments::MultipliedSizes(MultipliedSizes {
-                    intercept: *cost_map
-                        .get("multiply_integer-cpu-arguments-intercept")
-                        .unwrap_or(&30000000000),
-                    slope: *cost_map
-                        .get("multiply_integer-cpu-arguments-slope")
-                        .unwrap_or(&30000000000),
-                }),
+                cpu: match semantics {
+                    BuiltinSemantics::A => TwoArguments::AddedSizes(AddedSizes {
+                        intercept: *cost_map
+                            .get("multiply_integer-cpu-arguments-intercept")
+                            .unwrap_or(&30000000000),
+                        slope: *cost_map
+                            .get("multiply_integer-cpu-arguments-slope")
+                            .unwrap_or(&30000000000),
+                    }),
+                    BuiltinSemantics::B
+                    | BuiltinSemantics::C
+                    | BuiltinSemantics::D
+                    | BuiltinSemantics::E => TwoArguments::MultipliedSizes(MultipliedSizes {
+                        intercept: *cost_map
+                            .get("multiply_integer-cpu-arguments-intercept")
+                            .unwrap_or(&30000000000),
+                        slope: *cost_map
+                            .get("multiply_integer-cpu-arguments-slope")
+                            .unwrap_or(&30000000000),
+                    }),
+                },
             },
             divide_integer: CostingFun {
                 mem: TwoArguments::SubtractedSizes(SubtractedSizes {
@@ -3521,8 +3784,8 @@ pub fn initialize_cost_model(version: &Language, costs: &[i64]) -> CostModel {
                         .get("divide_integer-mem-arguments-minimum")
                         .unwrap_or(&30000000000),
                 }),
-                cpu: match version {
-                    Language::PlutusV1 | Language::PlutusV2 => {
+                cpu: match semantics {
+                    BuiltinSemantics::A | BuiltinSemantics::B => {
                         TwoArguments::ConstAboveDiagonal(ConstantOrTwoArguments {
                             constant: *cost_map
                                 .get("divide_integer-cpu-arguments-constant")
@@ -3537,7 +3800,7 @@ pub fn initialize_cost_model(version: &Language, costs: &[i64]) -> CostModel {
                             })),
                         })
                     }
-                    Language::PlutusV3 => TwoArguments::ConstAboveDiagonalIntoQuadraticXAndY(
+                    BuiltinSemantics::C => TwoArguments::ConstAboveDiagonalIntoQuadraticXAndY(
                         *cost_map
                             .get("divide_integer-cpu-arguments-constant")
                             .unwrap_or(&30000000000),
@@ -3565,6 +3828,53 @@ pub fn initialize_cost_model(version: &Language, costs: &[i64]) -> CostModel {
                                 .unwrap_or(&30000000000),
                         },
                     ),
+                    BuiltinSemantics::D => {
+                        TwoArguments::AboveAndBelowDiagonal(ConstantOrTwoArguments {
+                            constant: *cost_map
+                                .get("divide_integer-cpu-arguments-constant")
+                                .unwrap_or(&30000000000),
+                            model: Box::new(TwoArguments::MultipliedSizes(MultipliedSizes {
+                                intercept: *cost_map
+                                    .get("divide_integer-cpu-arguments-model-arguments-intercept")
+                                    .unwrap_or(&30000000000),
+                                slope: *cost_map
+                                    .get("divide_integer-cpu-arguments-model-arguments-slope")
+                                    .unwrap_or(&30000000000),
+                            })),
+                        })
+                    }
+                    BuiltinSemantics::E => {
+                        TwoArguments::AboveAndBelowDiagonal(ConstantOrTwoArguments {
+                            constant: *cost_map
+                                .get("divide_integer-cpu-arguments-constant")
+                                .unwrap_or(&30000000000),
+                            model: Box::new(TwoArguments::QuadraticInXAndY(
+                                TwoArgumentsQuadraticFunction {
+                                    minimum: *cost_map
+                                        .get("divide_integer-cpu-arguments-minimum")
+                                        .unwrap_or(&30000000000),
+                                    coeff_00: *cost_map
+                                        .get("divide_integer-cpu-arguments-c00")
+                                        .unwrap_or(&30000000000),
+                                    coeff_10: *cost_map
+                                        .get("divide_integer-cpu-arguments-c10")
+                                        .unwrap_or(&30000000000),
+                                    coeff_01: *cost_map
+                                        .get("divide_integer-cpu-arguments-c01")
+                                        .unwrap_or(&30000000000),
+                                    coeff_20: *cost_map
+                                        .get("divide_integer-cpu-arguments-c20")
+                                        .unwrap_or(&30000000000),
+                                    coeff_11: *cost_map
+                                        .get("divide_integer-cpu-arguments-c11")
+                                        .unwrap_or(&30000000000),
+                                    coeff_02: *cost_map
+                                        .get("divide_integer-cpu-arguments-c02")
+                                        .unwrap_or(&30000000000),
+                                },
+                            )),
+                        })
+                    }
                 },
             },
             quotient_integer: CostingFun {
@@ -3626,8 +3936,8 @@ pub fn initialize_cost_model(version: &Language, costs: &[i64]) -> CostModel {
                 },
             },
             remainder_integer: CostingFun {
-                mem: match version {
-                    Language::PlutusV1 | Language::PlutusV2 => {
+                mem: match semantics {
+                    BuiltinSemantics::A | BuiltinSemantics::B => {
                         TwoArguments::SubtractedSizes(SubtractedSizes {
                             intercept: *cost_map
                                 .get("remainder_integer-mem-arguments-intercept")
@@ -3640,17 +3950,30 @@ pub fn initialize_cost_model(version: &Language, costs: &[i64]) -> CostModel {
                                 .unwrap_or(&30000000000),
                         })
                     }
-                    Language::PlutusV3 => TwoArguments::LinearInY(LinearSize {
+                    BuiltinSemantics::C | BuiltinSemantics::E => {
+                        TwoArguments::LinearInY(LinearSize {
+                            intercept: *cost_map
+                                .get("remainder_integer-mem-arguments-intercept")
+                                .unwrap_or(&30000000000),
+                            slope: *cost_map
+                                .get("remainder_integer-mem-arguments-slope")
+                                .unwrap_or(&30000000000),
+                        })
+                    }
+                    BuiltinSemantics::D => TwoArguments::LinearInY2(SubtractedSizes {
                         intercept: *cost_map
                             .get("remainder_integer-mem-arguments-intercept")
                             .unwrap_or(&30000000000),
                         slope: *cost_map
                             .get("remainder_integer-mem-arguments-slope")
                             .unwrap_or(&30000000000),
+                        minimum: *cost_map
+                            .get("remainder_integer-mem-arguments-minimum")
+                            .unwrap_or(&30000000000),
                     }),
                 },
-                cpu: match version {
-                    Language::PlutusV1 | Language::PlutusV2 => {
+                cpu: match semantics {
+                    BuiltinSemantics::A | BuiltinSemantics::B | BuiltinSemantics::D => {
                         TwoArguments::ConstAboveDiagonal(ConstantOrTwoArguments {
                             constant: *cost_map
                                 .get("remainder_integer-cpu-arguments-constant")
@@ -3667,39 +3990,41 @@ pub fn initialize_cost_model(version: &Language, costs: &[i64]) -> CostModel {
                             })),
                         })
                     }
-                    Language::PlutusV3 => TwoArguments::ConstAboveDiagonalIntoQuadraticXAndY(
-                        *cost_map
-                            .get("remainder_integer-cpu-arguments-constant")
-                            .unwrap_or(&30000000000),
-                        TwoArgumentsQuadraticFunction {
-                            minimum: *cost_map
-                                .get("remainder_integer-cpu-arguments-minimum")
+                    BuiltinSemantics::C | BuiltinSemantics::E => {
+                        TwoArguments::ConstAboveDiagonalIntoQuadraticXAndY(
+                            *cost_map
+                                .get("remainder_integer-cpu-arguments-constant")
                                 .unwrap_or(&30000000000),
-                            coeff_00: *cost_map
-                                .get("remainder_integer-cpu-arguments-c00")
-                                .unwrap_or(&30000000000),
-                            coeff_10: *cost_map
-                                .get("remainder_integer-cpu-arguments-c10")
-                                .unwrap_or(&30000000000),
-                            coeff_01: *cost_map
-                                .get("remainder_integer-cpu-arguments-c01")
-                                .unwrap_or(&30000000000),
-                            coeff_20: *cost_map
-                                .get("remainder_integer-cpu-arguments-c20")
-                                .unwrap_or(&30000000000),
-                            coeff_11: *cost_map
-                                .get("remainder_integer-cpu-arguments-c11")
-                                .unwrap_or(&30000000000),
-                            coeff_02: *cost_map
-                                .get("remainder_integer-cpu-arguments-c02")
-                                .unwrap_or(&30000000000),
-                        },
-                    ),
+                            TwoArgumentsQuadraticFunction {
+                                minimum: *cost_map
+                                    .get("remainder_integer-cpu-arguments-minimum")
+                                    .unwrap_or(&30000000000),
+                                coeff_00: *cost_map
+                                    .get("remainder_integer-cpu-arguments-c00")
+                                    .unwrap_or(&30000000000),
+                                coeff_10: *cost_map
+                                    .get("remainder_integer-cpu-arguments-c10")
+                                    .unwrap_or(&30000000000),
+                                coeff_01: *cost_map
+                                    .get("remainder_integer-cpu-arguments-c01")
+                                    .unwrap_or(&30000000000),
+                                coeff_20: *cost_map
+                                    .get("remainder_integer-cpu-arguments-c20")
+                                    .unwrap_or(&30000000000),
+                                coeff_11: *cost_map
+                                    .get("remainder_integer-cpu-arguments-c11")
+                                    .unwrap_or(&30000000000),
+                                coeff_02: *cost_map
+                                    .get("remainder_integer-cpu-arguments-c02")
+                                    .unwrap_or(&30000000000),
+                            },
+                        )
+                    }
                 },
             },
             mod_integer: CostingFun {
-                mem: match version {
-                    Language::PlutusV1 | Language::PlutusV2 => {
+                mem: match semantics {
+                    BuiltinSemantics::A | BuiltinSemantics::B => {
                         TwoArguments::SubtractedSizes(SubtractedSizes {
                             intercept: *cost_map
                                 .get("mod_integer-mem-arguments-intercept")
@@ -3712,17 +4037,30 @@ pub fn initialize_cost_model(version: &Language, costs: &[i64]) -> CostModel {
                                 .unwrap_or(&30000000000),
                         })
                     }
-                    Language::PlutusV3 => TwoArguments::LinearInY(LinearSize {
+                    BuiltinSemantics::C | BuiltinSemantics::E => {
+                        TwoArguments::LinearInY(LinearSize {
+                            intercept: *cost_map
+                                .get("mod_integer-mem-arguments-intercept")
+                                .unwrap_or(&30000000000),
+                            slope: *cost_map
+                                .get("mod_integer-mem-arguments-slope")
+                                .unwrap_or(&30000000000),
+                        })
+                    }
+                    BuiltinSemantics::D => TwoArguments::LinearInY2(SubtractedSizes {
                         intercept: *cost_map
                             .get("mod_integer-mem-arguments-intercept")
                             .unwrap_or(&30000000000),
                         slope: *cost_map
                             .get("mod_integer-mem-arguments-slope")
                             .unwrap_or(&30000000000),
+                        minimum: *cost_map
+                            .get("mod_integer-mem-arguments-minimum")
+                            .unwrap_or(&30000000000),
                     }),
                 },
-                cpu: match version {
-                    Language::PlutusV1 | Language::PlutusV2 => {
+                cpu: match semantics {
+                    BuiltinSemantics::A | BuiltinSemantics::B => {
                         TwoArguments::ConstAboveDiagonal(ConstantOrTwoArguments {
                             constant: *cost_map
                                 .get("mod_integer-cpu-arguments-constant")
@@ -3737,7 +4075,7 @@ pub fn initialize_cost_model(version: &Language, costs: &[i64]) -> CostModel {
                             })),
                         })
                     }
-                    Language::PlutusV3 => TwoArguments::ConstAboveDiagonalIntoQuadraticXAndY(
+                    BuiltinSemantics::C => TwoArguments::ConstAboveDiagonalIntoQuadraticXAndY(
                         *cost_map
                             .get("mod_integer-cpu-arguments-constant")
                             .unwrap_or(&30000000000),
@@ -3765,6 +4103,53 @@ pub fn initialize_cost_model(version: &Language, costs: &[i64]) -> CostModel {
                                 .unwrap_or(&30000000000),
                         },
                     ),
+                    BuiltinSemantics::D => {
+                        TwoArguments::AboveAndBelowDiagonal(ConstantOrTwoArguments {
+                            constant: *cost_map
+                                .get("mod_integer-cpu-arguments-constant")
+                                .unwrap_or(&30000000000),
+                            model: Box::new(TwoArguments::MultipliedSizes(MultipliedSizes {
+                                intercept: *cost_map
+                                    .get("mod_integer-cpu-arguments-model-arguments-intercept")
+                                    .unwrap_or(&30000000000),
+                                slope: *cost_map
+                                    .get("mod_integer-cpu-arguments-model-arguments-slope")
+                                    .unwrap_or(&30000000000),
+                            })),
+                        })
+                    }
+                    BuiltinSemantics::E => {
+                        TwoArguments::AboveAndBelowDiagonal(ConstantOrTwoArguments {
+                            constant: *cost_map
+                                .get("mod_integer-cpu-arguments-constant")
+                                .unwrap_or(&30000000000),
+                            model: Box::new(TwoArguments::QuadraticInXAndY(
+                                TwoArgumentsQuadraticFunction {
+                                    minimum: *cost_map
+                                        .get("mod_integer-cpu-arguments-minimum")
+                                        .unwrap_or(&30000000000),
+                                    coeff_00: *cost_map
+                                        .get("mod_integer-cpu-arguments-c00")
+                                        .unwrap_or(&30000000000),
+                                    coeff_10: *cost_map
+                                        .get("mod_integer-cpu-arguments-c10")
+                                        .unwrap_or(&30000000000),
+                                    coeff_01: *cost_map
+                                        .get("mod_integer-cpu-arguments-c01")
+                                        .unwrap_or(&30000000000),
+                                    coeff_20: *cost_map
+                                        .get("mod_integer-cpu-arguments-c20")
+                                        .unwrap_or(&30000000000),
+                                    coeff_11: *cost_map
+                                        .get("mod_integer-cpu-arguments-c11")
+                                        .unwrap_or(&30000000000),
+                                    coeff_02: *cost_map
+                                        .get("mod_integer-cpu-arguments-c02")
+                                        .unwrap_or(&30000000000),
+                                },
+                            )),
+                        })
+                    }
                 },
             },
             equals_integer: CostingFun {
@@ -5112,18 +5497,16 @@ pub fn initialize_cost_model(version: &Language, costs: &[i64]) -> CostModel {
                     cpu: ThreeArguments::ConstantCost(30000000000),
                     mem: ThreeArguments::ConstantCost(30000000000),
                 },
+                Language::PlutusV3 if has_pv11_tail => pv11_exp_mod_integer_costs(costs),
                 Language::PlutusV3 => CostingFun {
-                    cpu: ThreeArguments::ConstantCost(
-                        *cost_map
-                            .get("expModInteger-cpu-arguments")
-                            .unwrap_or(&30000000000),
-                    ),
-                    mem: ThreeArguments::ConstantCost(
-                        *cost_map
-                            .get("expModInteger-memory-arguments")
-                            .unwrap_or(&30000000000),
-                    ),
+                    cpu: ThreeArguments::ConstantCost(30000000000),
+                    mem: ThreeArguments::ConstantCost(30000000000),
                 },
+            },
+            pv11_builtin_costs: if has_pv11_tail {
+                Pv11BuiltinCosts::from_van_rossem_costs(costs)
+            } else {
+                Pv11BuiltinCosts::unavailable()
             },
         },
     }
@@ -5139,6 +5522,7 @@ pub struct CostingFun<T> {
 pub enum OneArgument {
     ConstantCost(i64),
     LinearCost(LinearSize),
+    QuadraticCost(QuadraticFunction),
 }
 
 impl OneArgument {
@@ -5146,6 +5530,7 @@ impl OneArgument {
         match self {
             OneArgument::ConstantCost(c) => *c,
             OneArgument::LinearCost(m) => m.slope * x + m.intercept,
+            OneArgument::QuadraticCost(q) => q.coeff_0 + (q.coeff_1 * x) + (q.coeff_2 * x * x),
         }
     }
 }
@@ -5155,7 +5540,9 @@ pub enum TwoArguments {
     ConstantCost(i64),
     LinearInX(LinearSize),
     LinearInY(LinearSize),
+    LinearInY2(SubtractedSizes),
     LinearInXAndY(TwoVariableLinearSize),
+    WithInteractionInXAndY(TwoVariableWithInteractionSize),
     AddedSizes(AddedSizes),
     SubtractedSizes(SubtractedSizes),
     MultipliedSizes(MultipliedSizes),
@@ -5163,8 +5550,10 @@ pub enum TwoArguments {
     MaxSize(MaxSize),
     LinearOnDiagonal(ConstantOrLinear),
     ConstAboveDiagonal(ConstantOrTwoArguments),
+    AboveAndBelowDiagonal(ConstantOrTwoArguments),
     ConstBelowDiagonal(ConstantOrTwoArguments),
     QuadraticInY(QuadraticFunction),
+    QuadraticInXAndY(TwoArgumentsQuadraticFunction),
     ConstAboveDiagonalIntoQuadraticXAndY(i64, TwoArgumentsQuadraticFunction),
 }
 
@@ -5174,7 +5563,11 @@ impl TwoArguments {
             TwoArguments::ConstantCost(c) => *c,
             TwoArguments::LinearInX(l) => l.slope * x + l.intercept,
             TwoArguments::LinearInY(l) => l.slope * y + l.intercept,
+            TwoArguments::LinearInY2(l) => l.slope * y + l.intercept,
             TwoArguments::LinearInXAndY(l) => l.slope1 * x + l.slope2 * y + l.intercept,
+            TwoArguments::WithInteractionInXAndY(l) => {
+                l.coeff_00 + l.coeff_10 * x + l.coeff_01 * y + l.coeff_11 * x * y
+            }
             TwoArguments::AddedSizes(s) => s.slope * (x + y) + s.intercept,
             TwoArguments::SubtractedSizes(s) => s.slope * s.minimum.max(x - y) + s.intercept,
             TwoArguments::MultipliedSizes(s) => s.slope * (x * y) + s.intercept,
@@ -5195,6 +5588,10 @@ impl TwoArguments {
                     p.cost(x, y)
                 }
             }
+            TwoArguments::AboveAndBelowDiagonal(l) => {
+                let p = *l.model.clone();
+                p.cost(x.max(y), x.min(y))
+            }
             TwoArguments::ConstBelowDiagonal(l) => {
                 if x > y {
                     l.constant
@@ -5204,6 +5601,15 @@ impl TwoArguments {
                 }
             }
             TwoArguments::QuadraticInY(q) => q.coeff_0 + (q.coeff_1 * y) + (q.coeff_2 * y * y),
+            TwoArguments::QuadraticInXAndY(q) => std::cmp::max(
+                q.minimum,
+                q.coeff_00
+                    + q.coeff_10 * x
+                    + q.coeff_01 * y
+                    + q.coeff_20 * x * x
+                    + q.coeff_11 * x * y
+                    + q.coeff_02 * y * y,
+            ),
             TwoArguments::ConstAboveDiagonalIntoQuadraticXAndY(constant, q) => {
                 if x < y {
                     *constant
@@ -5231,6 +5637,7 @@ pub enum ThreeArguments {
     LinearInY(LinearSize),
     LinearInZ(LinearSize),
     QuadraticInZ(QuadraticFunction),
+    ExpModCost(ExpModCostingFunction),
     LiteralInYorLinearInZ(LinearSize),
     LinearInMaxYZ(LinearSize),
     LinearInYandZ(TwoVariableLinearSize),
@@ -5245,6 +5652,12 @@ impl ThreeArguments {
             ThreeArguments::LinearInY(l) => y * l.slope + l.intercept,
             ThreeArguments::LinearInZ(l) => z * l.slope + l.intercept,
             ThreeArguments::QuadraticInZ(q) => q.coeff_0 + (q.coeff_1 * z) + (q.coeff_2 * z * z),
+            ThreeArguments::ExpModCost(e) => {
+                let cost =
+                    e.coefficient_00 + e.coefficient_11 * y * z + e.coefficient_12 * y * z * z;
+
+                if x <= z { cost } else { cost + cost / 2 }
+            }
             ThreeArguments::LiteralInYorLinearInZ(l) => {
                 if y == 0 {
                     l.slope * z + l.intercept
@@ -5254,6 +5667,21 @@ impl ThreeArguments {
             }
             ThreeArguments::LinearInMaxYZ(l) => y.max(z) * l.slope + l.intercept,
             ThreeArguments::LinearInYandZ(l) => y * l.slope1 + z * l.slope2 + l.intercept,
+        }
+    }
+}
+
+#[derive(Debug, PartialEq)]
+pub enum FourArguments {
+    ConstantCost(i64),
+    LinearInU(LinearSize),
+}
+
+impl FourArguments {
+    pub fn cost(&self, _: i64, _: i64, _: i64, u: i64) -> i64 {
+        match self {
+            FourArguments::ConstantCost(c) => *c,
+            FourArguments::LinearInU(l) => l.slope * u + l.intercept,
         }
     }
 }
@@ -5282,6 +5710,14 @@ pub struct TwoVariableLinearSize {
     pub intercept: i64,
     pub slope1: i64,
     pub slope2: i64,
+}
+
+#[derive(Debug, PartialEq, Clone)]
+pub struct TwoVariableWithInteractionSize {
+    pub coeff_00: i64,
+    pub coeff_10: i64,
+    pub coeff_01: i64,
+    pub coeff_11: i64,
 }
 
 #[derive(Debug, PartialEq, Clone)]
@@ -5346,6 +5782,13 @@ pub struct TwoArgumentsQuadraticFunction {
     coeff_02: i64,
 }
 
+#[derive(Debug, PartialEq, Clone)]
+pub struct ExpModCostingFunction {
+    coefficient_00: i64,
+    coefficient_11: i64,
+    coefficient_12: i64,
+}
+
 #[repr(u8)]
 #[derive(Debug, EnumIter, Display, Clone, Copy)]
 pub enum StepKind {
@@ -5384,6 +5827,10 @@ impl TryFrom<u8> for StepKind {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::{
+        builtins::DefaultFunction,
+        machine::{runtime::BuiltinSemantics, value::Value},
+    };
     use pretty_assertions::assert_eq;
 
     #[test]
@@ -5483,5 +5930,225 @@ mod tests {
         let cost_model = initialize_cost_model(&Language::PlutusV3, &costs);
 
         assert_eq!(CostModel::v3(), cost_model);
+    }
+
+    #[test]
+    fn plutus_v3_pv11_divide_integer_uses_above_and_below_diagonal() {
+        let mut costs: Vec<i64> = (0..350).collect();
+        costs[49] = 85848;
+        costs[50] = 123203;
+        costs[51] = 7305;
+        costs[52] = -900;
+        costs[53] = 1716;
+        costs[54] = 960;
+        costs[55] = 57;
+        costs[56] = 85848;
+
+        let language_only = initialize_cost_model(&Language::PlutusV3, &costs);
+        let pv11 = initialize_cost_model_with_protocol(&Language::PlutusV3, 11, &costs);
+
+        let old_cpu = language_only.builtin_costs.divide_integer.cpu.cost(1, 2);
+        let pv11_cpu = pv11.builtin_costs.divide_integer.cpu.cost(1, 2);
+
+        assert_eq!(85848, old_cpu);
+        assert_eq!(49340, pv11_cpu - old_cpu);
+    }
+
+    #[test]
+    fn plutus_v2_protocol_selects_multiply_integer_a_or_b_costing() {
+        let mut costs: Vec<i64> = (0..350).collect();
+        costs[115] = 10;
+        costs[116] = 3;
+
+        let before_chang = initialize_cost_model_with_protocol(&Language::PlutusV2, 8, &costs);
+        let after_chang = initialize_cost_model_with_protocol(&Language::PlutusV2, 9, &costs);
+        let language_only = initialize_cost_model(&Language::PlutusV2, &costs);
+
+        assert_eq!(
+            TwoArguments::AddedSizes(AddedSizes {
+                intercept: 10,
+                slope: 3
+            }),
+            before_chang.builtin_costs.multiply_integer.cpu
+        );
+        assert_eq!(
+            TwoArguments::MultipliedSizes(MultipliedSizes {
+                intercept: 10,
+                slope: 3,
+            }),
+            after_chang.builtin_costs.multiply_integer.cpu
+        );
+        assert_eq!(
+            10 + 3 * (2 + 4),
+            before_chang.builtin_costs.multiply_integer.cpu.cost(2, 4)
+        );
+        assert_eq!(
+            10 + 3 * (2 * 4),
+            after_chang.builtin_costs.multiply_integer.cpu.cost(2, 4)
+        );
+        assert_eq!(
+            after_chang.builtin_costs.multiply_integer.cpu,
+            language_only.builtin_costs.multiply_integer.cpu
+        );
+    }
+
+    #[test]
+    fn plutus_v2_pv11_linear_in_y2_keeps_ledger_payload() {
+        let costs: Vec<i64> = (0..350).collect();
+
+        let cost_model = initialize_cost_model_with_protocol(&Language::PlutusV2, 11, &costs);
+        let builtin_costs = &cost_model.builtin_costs;
+
+        assert_eq!(
+            TwoArguments::LinearInY2(SubtractedSizes {
+                intercept: 130,
+                slope: 132,
+                minimum: 131,
+            }),
+            builtin_costs.remainder_integer.mem
+        );
+        assert_eq!(
+            TwoArguments::LinearInY2(SubtractedSizes {
+                intercept: 112,
+                slope: 114,
+                minimum: 113,
+            }),
+            builtin_costs.mod_integer.mem
+        );
+        assert_eq!(
+            130 + 132 * 7,
+            builtin_costs.remainder_integer.mem.cost(3, 7)
+        );
+    }
+
+    #[test]
+    fn plutus_v3_350_entry_cost_model_parses_pv11_tail() {
+        let costs: Vec<i64> = (0..350).collect();
+
+        let cost_model = initialize_cost_model_with_protocol(&Language::PlutusV3, 11, &costs);
+        let builtin_costs = &cost_model.builtin_costs;
+        let pv11 = &builtin_costs.pv11_builtin_costs;
+
+        assert_eq!(
+            ThreeArguments::ExpModCost(ExpModCostingFunction {
+                coefficient_00: 297,
+                coefficient_11: 298,
+                coefficient_12: 299,
+            }),
+            builtin_costs.exp_mod_int.cpu
+        );
+        assert_eq!(
+            ThreeArguments::LinearInZ(LinearSize {
+                intercept: 300,
+                slope: 301,
+            }),
+            builtin_costs.exp_mod_int.mem
+        );
+        assert_eq!(
+            TwoArguments::LinearInX(LinearSize {
+                intercept: 302,
+                slope: 303,
+            }),
+            pv11.drop_list.cpu
+        );
+        assert_eq!(TwoArguments::ConstantCost(304), pv11.drop_list.mem);
+        assert_eq!(
+            OneArgument::LinearCost(LinearSize {
+                intercept: 307,
+                slope: 308,
+            }),
+            pv11.list_to_array.cpu
+        );
+        assert_eq!(
+            TwoArguments::WithInteractionInXAndY(TwoVariableWithInteractionSize {
+                coeff_00: 326,
+                coeff_10: 327,
+                coeff_01: 328,
+                coeff_11: 329,
+            }),
+            pv11.union_value.cpu
+        );
+        assert_eq!(
+            TwoArguments::AddedSizes(AddedSizes {
+                intercept: 330,
+                slope: 331,
+            }),
+            pv11.union_value.mem
+        );
+        assert_eq!(330 + 331 * (2 + 4), pv11.union_value.mem.cost(2, 4));
+        assert_eq!(
+            OneArgument::QuadraticCost(QuadraticFunction {
+                coeff_0: 341,
+                coeff_1: 342,
+                coeff_2: 343,
+            }),
+            pv11.un_value_data.cpu
+        );
+        assert_eq!(
+            TwoArguments::LinearInY(LinearSize {
+                intercept: 348,
+                slope: 349,
+            }),
+            pv11.scale_value.mem
+        );
+    }
+
+    #[test]
+    fn string_costing_uses_utf8_byte_length_under_d_and_e() {
+        let costs = BuiltinCosts::v3();
+        let one_multibyte = [Value::string("é".to_string()), Value::string(String::new())];
+        let two_multibyte = [
+            Value::string("é".to_string()),
+            Value::string("é".to_string()),
+        ];
+
+        let append_c = costs
+            .to_ex_budget(
+                DefaultFunction::AppendString,
+                &one_multibyte,
+                BuiltinSemantics::C,
+            )
+            .unwrap();
+        let append_e = costs
+            .to_ex_budget(
+                DefaultFunction::AppendString,
+                &one_multibyte,
+                BuiltinSemantics::E,
+            )
+            .unwrap();
+        let equals_c = costs
+            .to_ex_budget(
+                DefaultFunction::EqualsString,
+                &two_multibyte,
+                BuiltinSemantics::C,
+            )
+            .unwrap();
+        let equals_d = costs
+            .to_ex_budget(
+                DefaultFunction::EqualsString,
+                &two_multibyte,
+                BuiltinSemantics::D,
+            )
+            .unwrap();
+        let encode_c = costs
+            .to_ex_budget(
+                DefaultFunction::EncodeUtf8,
+                &one_multibyte[..1],
+                BuiltinSemantics::C,
+            )
+            .unwrap();
+        let encode_e = costs
+            .to_ex_budget(
+                DefaultFunction::EncodeUtf8,
+                &one_multibyte[..1],
+                BuiltinSemantics::E,
+            )
+            .unwrap();
+
+        assert_eq!(59957, append_e.cpu - append_c.cpu);
+        assert_eq!(1, append_e.mem - append_c.mem);
+        assert_eq!(60594, equals_d.cpu - equals_c.cpu);
+        assert_eq!(42921, encode_e.cpu - encode_c.cpu);
+        assert_eq!(2, encode_e.mem - encode_c.mem);
     }
 }

--- a/crates/uplc/src/machine/cost_model.rs
+++ b/crates/uplc/src/machine/cost_model.rs
@@ -6094,61 +6094,66 @@ mod tests {
     }
 
     #[test]
-    fn string_costing_uses_utf8_byte_length_under_d_and_e() {
+    fn string_costing_uses_utf8_text_units_under_d_and_e() {
         let costs = BuiltinCosts::v3();
-        let one_multibyte = [Value::string("é".to_string()), Value::string(String::new())];
-        let two_multibyte = [
-            Value::string("é".to_string()),
-            Value::string("é".to_string()),
+        let ascii_and_empty = [
+            Value::string("abcd".to_string()),
+            Value::string(String::new()),
         ];
+        let mixed = [
+            Value::string("abcd".to_string()),
+            Value::string("éé".to_string()),
+        ];
+
+        assert_eq!(
+            4,
+            ascii_and_empty[0].to_ex_mem_with_semantics(BuiltinSemantics::C)
+        );
+        assert_eq!(
+            1,
+            ascii_and_empty[0].to_ex_mem_with_semantics(BuiltinSemantics::E)
+        );
+        assert_eq!(
+            0,
+            ascii_and_empty[1].to_ex_mem_with_semantics(BuiltinSemantics::E)
+        );
+        assert_eq!(
+            1,
+            Value::string("é".to_string()).to_ex_mem_with_semantics(BuiltinSemantics::D)
+        );
 
         let append_c = costs
             .to_ex_budget(
                 DefaultFunction::AppendString,
-                &one_multibyte,
+                &ascii_and_empty,
                 BuiltinSemantics::C,
             )
             .unwrap();
         let append_e = costs
             .to_ex_budget(
                 DefaultFunction::AppendString,
-                &one_multibyte,
+                &ascii_and_empty,
                 BuiltinSemantics::E,
             )
             .unwrap();
-        let equals_c = costs
-            .to_ex_budget(
-                DefaultFunction::EqualsString,
-                &two_multibyte,
-                BuiltinSemantics::C,
-            )
-            .unwrap();
         let equals_d = costs
-            .to_ex_budget(
-                DefaultFunction::EqualsString,
-                &two_multibyte,
-                BuiltinSemantics::D,
-            )
-            .unwrap();
-        let encode_c = costs
-            .to_ex_budget(
-                DefaultFunction::EncodeUtf8,
-                &one_multibyte[..1],
-                BuiltinSemantics::C,
-            )
+            .to_ex_budget(DefaultFunction::EqualsString, &mixed, BuiltinSemantics::D)
             .unwrap();
         let encode_e = costs
             .to_ex_budget(
                 DefaultFunction::EncodeUtf8,
-                &one_multibyte[..1],
+                &ascii_and_empty[..1],
                 BuiltinSemantics::E,
             )
             .unwrap();
 
-        assert_eq!(59957, append_e.cpu - append_c.cpu);
-        assert_eq!(1, append_e.mem - append_c.mem);
-        assert_eq!(60594, equals_d.cpu - equals_c.cpu);
-        assert_eq!(42921, encode_e.cpu - encode_c.cpu);
-        assert_eq!(2, encode_e.mem - encode_c.mem);
+        assert_eq!(costs.append_string.cpu.cost(4, 0), append_c.cpu);
+        assert_eq!(costs.append_string.mem.cost(4, 0), append_c.mem);
+        assert_eq!(costs.append_string.cpu.cost(1, 0), append_e.cpu);
+        assert_eq!(costs.append_string.mem.cost(1, 0), append_e.mem);
+        assert_eq!(costs.equals_string.cpu.cost(1, 1), equals_d.cpu);
+        assert_eq!(costs.equals_string.mem.cost(1, 1), equals_d.mem);
+        assert_eq!(costs.encode_utf8.cpu.cost(1), encode_e.cpu);
+        assert_eq!(costs.encode_utf8.mem.cost(1), encode_e.mem);
     }
 }

--- a/crates/uplc/src/machine/runtime.rs
+++ b/crates/uplc/src/machine/runtime.rs
@@ -35,18 +35,61 @@ const BLST_P2_COMPRESSED_SIZE: usize = 96;
 
 pub const INTEGER_TO_BYTE_STRING_MAXIMUM_OUTPUT_LENGTH: i64 = 8192;
 
+pub const CHANG_PROTOCOL_VERSION: u16 = 9;
+pub const VAN_ROSSEM_PROTOCOL_VERSION: u16 = 11;
+
+/// Ledger builtin semantics variants.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum BuiltinSemantics {
-    V1,
-    V2,
+    A,
+    B,
+    C,
+    D,
+    E,
+}
+
+impl BuiltinSemantics {
+    pub fn for_language(language: &Language) -> Self {
+        match language {
+            // Preserve the old language-only evaluator behavior. Protocol-aware
+            // entry points can still select pre-Chang A explicitly.
+            Language::PlutusV1 | Language::PlutusV2 => BuiltinSemantics::B,
+            Language::PlutusV3 => BuiltinSemantics::C,
+        }
+    }
+
+    pub fn for_language_and_protocol(language: &Language, protocol_major_version: u16) -> Self {
+        match language {
+            Language::PlutusV1 | Language::PlutusV2
+                if protocol_major_version >= VAN_ROSSEM_PROTOCOL_VERSION =>
+            {
+                BuiltinSemantics::D
+            }
+            Language::PlutusV1 | Language::PlutusV2
+                if protocol_major_version >= CHANG_PROTOCOL_VERSION =>
+            {
+                BuiltinSemantics::B
+            }
+            Language::PlutusV1 | Language::PlutusV2 => BuiltinSemantics::A,
+            Language::PlutusV3 if protocol_major_version >= VAN_ROSSEM_PROTOCOL_VERSION => {
+                BuiltinSemantics::E
+            }
+            Language::PlutusV3 => BuiltinSemantics::C,
+        }
+    }
+
+    pub fn costs_strings_by_utf8_bytes(self) -> bool {
+        matches!(self, BuiltinSemantics::D | BuiltinSemantics::E)
+    }
+
+    fn cons_byte_string_range_checks(self) -> bool {
+        matches!(self, BuiltinSemantics::C | BuiltinSemantics::E)
+    }
 }
 
 impl From<&Language> for BuiltinSemantics {
     fn from(language: &Language) -> Self {
-        match language {
-            Language::PlutusV1 => BuiltinSemantics::V1,
-            Language::PlutusV2 => BuiltinSemantics::V1,
-            Language::PlutusV3 => BuiltinSemantics::V2,
-        }
+        Self::for_language(language)
     }
 }
 
@@ -82,8 +125,12 @@ impl BuiltinRuntime {
         self.forces += 1;
     }
 
-    pub fn call(&self, language: &Language, traces: &mut Vec<Trace>) -> Result<Value, Error> {
-        self.fun.call(language.into(), &self.args, traces)
+    pub fn call(
+        &self,
+        semantics: BuiltinSemantics,
+        traces: &mut Vec<Trace>,
+    ) -> Result<Value, Error> {
+        self.fun.call(semantics, &self.args, traces)
     }
 
     pub fn push(&mut self, arg: Value) -> Result<(), Error> {
@@ -92,8 +139,12 @@ impl BuiltinRuntime {
         Ok(())
     }
 
-    pub fn to_ex_budget(&self, costs: &BuiltinCosts) -> Result<ExBudget, Error> {
-        costs.to_ex_budget(self.fun, &self.args)
+    pub fn to_ex_budget(
+        &self,
+        costs: &BuiltinCosts,
+        semantics: BuiltinSemantics,
+    ) -> Result<ExBudget, Error> {
+        costs.to_ex_budget(self.fun, &self.args, semantics)
     }
 }
 
@@ -515,19 +566,16 @@ impl DefaultFunction {
                 let arg1 = args[0].unwrap_integer()?;
                 let arg2 = args[1].unwrap_byte_string()?;
 
-                let byte: u8 = match semantics {
-                    BuiltinSemantics::V1 => {
-                        let wrap = arg1.mod_floor(&256.into());
-
-                        wrap.try_into().unwrap()
+                let byte: u8 = if semantics.cons_byte_string_range_checks() {
+                    if *arg1 > 255.into() || *arg1 < 0.into() {
+                        return Err(Error::ByteStringConsNotAByte(arg1.clone()));
                     }
-                    BuiltinSemantics::V2 => {
-                        if *arg1 > 255.into() || *arg1 < 0.into() {
-                            return Err(Error::ByteStringConsNotAByte(arg1.clone()));
-                        }
 
-                        arg1.try_into().unwrap()
-                    }
+                    arg1.try_into().unwrap()
+                } else {
+                    let wrap = arg1.mod_floor(&256.into());
+
+                    wrap.try_into().unwrap()
                 };
 
                 let mut ret = vec![byte];
@@ -1944,7 +1992,49 @@ fn verify_schnorr(public_key: &[u8], message: &[u8], signature: &[u8]) -> Result
 
 #[cfg(test)]
 mod tests {
-    use super::{convert_constr_to_tag, convert_tag_to_constr};
+    use super::{BuiltinSemantics, convert_constr_to_tag, convert_tag_to_constr};
+    use crate::{builtins::DefaultFunction, machine::value::Value};
+    use pallas_primitives::conway::Language;
+
+    #[test]
+    fn protocol_versions_select_ledger_semantics() {
+        assert_eq!(
+            BuiltinSemantics::for_language_and_protocol(&Language::PlutusV2, 8),
+            BuiltinSemantics::A
+        );
+        assert_eq!(
+            BuiltinSemantics::for_language_and_protocol(&Language::PlutusV2, 9),
+            BuiltinSemantics::B
+        );
+        assert_eq!(
+            BuiltinSemantics::for_language_and_protocol(&Language::PlutusV3, 10),
+            BuiltinSemantics::C
+        );
+        assert_eq!(
+            BuiltinSemantics::for_language_and_protocol(&Language::PlutusV3, 11),
+            BuiltinSemantics::E
+        );
+        assert_eq!(
+            BuiltinSemantics::for_language_and_protocol(&Language::PlutusV2, 11),
+            BuiltinSemantics::D
+        );
+    }
+
+    #[test]
+    fn cons_byte_string_keeps_d_wrapping_and_e_range_checking() {
+        let args = [Value::integer(256.into()), Value::byte_string(vec![])];
+
+        let wrapped = DefaultFunction::ConsByteString
+            .call(BuiltinSemantics::D, &args, &mut vec![])
+            .unwrap();
+
+        assert_eq!(wrapped, Value::byte_string(vec![0]));
+        assert!(
+            DefaultFunction::ConsByteString
+                .call(BuiltinSemantics::E, &args, &mut vec![])
+                .is_err()
+        );
+    }
 
     #[test]
     fn compact_tag_range() {

--- a/crates/uplc/src/machine/value.rs
+++ b/crates/uplc/src/machine/value.rs
@@ -284,7 +284,7 @@ impl Value {
                 Constant::ByteString(b) => total += Self::byte_string_to_ex_mem(b),
                 Constant::String(s) => {
                     total += if semantics.costs_strings_by_utf8_bytes() {
-                        s.len() as i64
+                        Self::utf8_text_to_ex_mem(s)
                     } else {
                         s.chars().count() as i64
                     };
@@ -303,6 +303,12 @@ impl Value {
         }
 
         total
+    }
+
+    fn utf8_text_to_ex_mem(s: &str) -> i64 {
+        let bytes = s.len() as i64;
+
+        if bytes == 0 { 0 } else { ((bytes - 1) / 4) + 1 }
     }
 
     fn integer_to_ex_mem(i: &BigInt) -> i64 {
@@ -670,7 +676,7 @@ mod tests {
             Rc::new(Constant::ProtoList(
                 Type::String,
                 vec![
-                    Constant::String("a".to_string()),
+                    Constant::String("abcd".to_string()),
                     Constant::String("é".to_string()),
                     Constant::ByteString(vec![1, 2, 3, 4, 5, 6, 7, 8, 9]),
                 ],
@@ -679,7 +685,7 @@ mod tests {
 
         let value = Value::Con(nested.into());
 
-        assert_eq!(value.to_ex_mem_with_semantics(BuiltinSemantics::C), 6);
-        assert_eq!(value.to_ex_mem_with_semantics(BuiltinSemantics::D), 7);
+        assert_eq!(value.to_ex_mem_with_semantics(BuiltinSemantics::C), 9);
+        assert_eq!(value.to_ex_mem_with_semantics(BuiltinSemantics::D), 6);
     }
 }

--- a/crates/uplc/src/machine/value.rs
+++ b/crates/uplc/src/machine/value.rs
@@ -1,6 +1,6 @@
 use super::{
     Error,
-    runtime::{self, BuiltinRuntime},
+    runtime::{self, BuiltinRuntime, BuiltinSemantics},
 };
 use crate::{
     ast::{Constant, NamedDeBruijn, Term, Type},
@@ -260,38 +260,13 @@ impl Value {
         Ok(arg1_exmem)
     }
 
-    // TODO: Make this to_ex_mem not recursive.
     pub fn to_ex_mem(&self) -> i64 {
+        self.to_ex_mem_with_semantics(BuiltinSemantics::C)
+    }
+
+    pub fn to_ex_mem_with_semantics(&self, semantics: BuiltinSemantics) -> i64 {
         match self {
-            Value::Con(c) => match c.as_ref() {
-                Constant::Integer(i) => {
-                    if *i == 0.into() {
-                        1
-                    } else {
-                        (integer_log2(i.abs()) / 64) + 1
-                    }
-                }
-                Constant::ByteString(b) => {
-                    if b.is_empty() {
-                        1
-                    } else {
-                        ((b.len() as i64 - 1) / 8) + 1
-                    }
-                }
-                Constant::String(s) => s.chars().count() as i64,
-                Constant::Unit => 1,
-                Constant::Bool(_) => 1,
-                Constant::ProtoList(_, items) => items.iter().fold(0, |acc, constant| {
-                    acc + Value::Con(constant.clone().into()).to_ex_mem()
-                }),
-                Constant::ProtoPair(_, _, l, r) => {
-                    Value::Con(l.clone()).to_ex_mem() + Value::Con(r.clone()).to_ex_mem()
-                }
-                Constant::Data(item) => self.data_to_ex_mem(item),
-                Constant::Bls12_381G1Element(_) => size_of::<blst::blst_p1>() as i64 / 8,
-                Constant::Bls12_381G2Element(_) => size_of::<blst::blst_p2>() as i64 / 8,
-                Constant::Bls12_381MlResult(_) => size_of::<blst::blst_fp12>() as i64 / 8,
-            },
+            Value::Con(c) => Self::constant_to_ex_mem(c, semantics),
             Value::Delay(_, _) => 1,
             Value::Lambda { .. } => 1,
             Value::Builtin { .. } => 1,
@@ -299,12 +274,62 @@ impl Value {
         }
     }
 
-    // I made data not recursive since data tends to be deeply nested
-    // thus causing a significant hit on performance
+    fn constant_to_ex_mem(constant: &Constant, semantics: BuiltinSemantics) -> i64 {
+        let mut stack = vec![constant];
+        let mut total = 0;
+
+        while let Some(constant) = stack.pop() {
+            match constant {
+                Constant::Integer(i) => total += Self::integer_to_ex_mem(i),
+                Constant::ByteString(b) => total += Self::byte_string_to_ex_mem(b),
+                Constant::String(s) => {
+                    total += if semantics.costs_strings_by_utf8_bytes() {
+                        s.len() as i64
+                    } else {
+                        s.chars().count() as i64
+                    };
+                }
+                Constant::Unit | Constant::Bool(_) => total += 1,
+                Constant::ProtoList(_, items) => stack.extend(items.iter()),
+                Constant::ProtoPair(_, _, l, r) => {
+                    stack.push(l.as_ref());
+                    stack.push(r.as_ref());
+                }
+                Constant::Data(item) => total += Self::data_to_ex_mem_inner(item),
+                Constant::Bls12_381G1Element(_) => total += size_of::<blst::blst_p1>() as i64 / 8,
+                Constant::Bls12_381G2Element(_) => total += size_of::<blst::blst_p2>() as i64 / 8,
+                Constant::Bls12_381MlResult(_) => total += size_of::<blst::blst_fp12>() as i64 / 8,
+            }
+        }
+
+        total
+    }
+
+    fn integer_to_ex_mem(i: &BigInt) -> i64 {
+        if i.is_zero() {
+            1
+        } else {
+            (integer_log2(i.abs()) / 64) + 1
+        }
+    }
+
+    fn byte_string_to_ex_mem(b: &[u8]) -> i64 {
+        if b.is_empty() {
+            1
+        } else {
+            ((b.len() as i64 - 1) / 8) + 1
+        }
+    }
+
     pub fn data_to_ex_mem(&self, data: &PlutusData) -> i64 {
+        Self::data_to_ex_mem_inner(data)
+    }
+
+    fn data_to_ex_mem_inner(data: &PlutusData) -> i64 {
         let mut stack: VecDeque<&PlutusData> = VecDeque::new();
         let mut total = 0;
         stack.push_front(data);
+
         while let Some(item) = stack.pop_front() {
             // each time we deconstruct a data we add 4 memory units
             total += 4;
@@ -333,11 +358,10 @@ impl Value {
                 PlutusData::BigInt(i) => {
                     let i = from_pallas_bigint(i);
 
-                    total += Value::Con(Constant::Integer(i).into()).to_ex_mem();
+                    total += Self::integer_to_ex_mem(&i);
                 }
                 PlutusData::BoundedBytes(b) => {
-                    let byte_string: Vec<u8> = b.deref().clone();
-                    total += Value::Con(Constant::ByteString(byte_string).into()).to_ex_mem();
+                    total += Self::byte_string_to_ex_mem(b.deref());
                 }
                 PlutusData::Array(a) => {
                     // create new stack with of items from the list of data
@@ -479,10 +503,14 @@ pub fn to_pallas_bigint(n: &BigInt) -> conway::BigInt {
 #[cfg(test)]
 mod tests {
     use crate::{
-        ast::Constant,
-        machine::value::{Value, integer_log2},
+        ast::{Constant, Type},
+        machine::{
+            runtime::BuiltinSemantics,
+            value::{Value, integer_log2},
+        },
     };
     use num_bigint::BigInt;
+    use std::rc::Rc;
 
     #[test]
     fn to_ex_mem_bigint() {
@@ -631,5 +659,27 @@ mod tests {
             integer_log2(BigInt::parse_bytes("999999999999999999999999999999999999999999999999999999999999999999999999999999999999".as_bytes(), 10).unwrap()),
             279
         );
+    }
+
+    #[test]
+    fn to_ex_mem_counts_nested_constants_iteratively() {
+        let nested = Constant::ProtoPair(
+            Type::Integer,
+            Type::List(Type::String.into()),
+            Rc::new(Constant::Integer((1_i128 << 64).into())),
+            Rc::new(Constant::ProtoList(
+                Type::String,
+                vec![
+                    Constant::String("a".to_string()),
+                    Constant::String("é".to_string()),
+                    Constant::ByteString(vec![1, 2, 3, 4, 5, 6, 7, 8, 9]),
+                ],
+            )),
+        );
+
+        let value = Value::Con(nested.into());
+
+        assert_eq!(value.to_ex_mem_with_semantics(BuiltinSemantics::C), 6);
+        assert_eq!(value.to_ex_mem_with_semantics(BuiltinSemantics::D), 7);
     }
 }

--- a/crates/uplc/src/tx.rs
+++ b/crates/uplc/src/tx.rs
@@ -53,6 +53,32 @@ pub fn eval_phase_two(
     )
 }
 
+/// Like eval_phase_two, but selects builtin semantics and costing from an
+/// explicit protocol major version.
+#[allow(clippy::too_many_arguments)]
+pub fn eval_phase_two_with_protocol(
+    tx: &MintedTx,
+    utxos: &[ResolvedInput],
+    cost_mdls: Option<&CostModels>,
+    initial_budget: Option<&ExBudget>,
+    slot_config: &SlotConfig,
+    protocol_major_version: u16,
+    run_phase_one: bool,
+    with_redeemer: fn(&Redeemer) -> (),
+) -> Result<Vec<(Redeemer, EvalResult)>, Error> {
+    eval_phase_two_with_override_and_protocol(
+        tx,
+        utxos,
+        cost_mdls,
+        initial_budget,
+        slot_config,
+        protocol_major_version,
+        HashMap::new(),
+        run_phase_one,
+        with_redeemer,
+    )
+}
+
 /// Like eval_phase_two, but allows replacing scripts dynamically for simulations
 #[allow(clippy::too_many_arguments)]
 pub fn eval_phase_two_with_override(
@@ -61,6 +87,58 @@ pub fn eval_phase_two_with_override(
     cost_mdls: Option<&CostModels>,
     initial_budget: Option<&ExBudget>,
     slot_config: &SlotConfig,
+    override_scripts: HashMap<ScriptHash, PlutusScript>,
+    run_phase_one: bool,
+    with_redeemer: fn(&Redeemer) -> (),
+) -> Result<Vec<(Redeemer, EvalResult)>, Error> {
+    eval_phase_two_with_override_and_optional_protocol(
+        tx,
+        utxos,
+        cost_mdls,
+        initial_budget,
+        slot_config,
+        None,
+        override_scripts,
+        run_phase_one,
+        with_redeemer,
+    )
+}
+
+/// Like eval_phase_two_with_override, but selects builtin semantics and costing
+/// from an explicit protocol major version.
+#[allow(clippy::too_many_arguments)]
+pub fn eval_phase_two_with_override_and_protocol(
+    tx: &MintedTx,
+    utxos: &[ResolvedInput],
+    cost_mdls: Option<&CostModels>,
+    initial_budget: Option<&ExBudget>,
+    slot_config: &SlotConfig,
+    protocol_major_version: u16,
+    override_scripts: HashMap<ScriptHash, PlutusScript>,
+    run_phase_one: bool,
+    with_redeemer: fn(&Redeemer) -> (),
+) -> Result<Vec<(Redeemer, EvalResult)>, Error> {
+    eval_phase_two_with_override_and_optional_protocol(
+        tx,
+        utxos,
+        cost_mdls,
+        initial_budget,
+        slot_config,
+        Some(protocol_major_version),
+        override_scripts,
+        run_phase_one,
+        with_redeemer,
+    )
+}
+
+#[allow(clippy::too_many_arguments)]
+fn eval_phase_two_with_override_and_optional_protocol(
+    tx: &MintedTx,
+    utxos: &[ResolvedInput],
+    cost_mdls: Option<&CostModels>,
+    initial_budget: Option<&ExBudget>,
+    slot_config: &SlotConfig,
+    protocol_major_version: Option<u16>,
     override_scripts: HashMap<ScriptHash, PlutusScript>,
     run_phase_one: bool,
     with_redeemer: fn(&Redeemer) -> (),
@@ -95,15 +173,29 @@ pub fn eval_phase_two_with_override(
 
                 with_redeemer(&redeemer);
 
-                let (redeemer, eval_result) = eval::eval_redeemer(
-                    tx,
-                    utxos,
-                    slot_config,
-                    &redeemer,
-                    &lookup_table,
-                    cost_mdls,
-                    &remaining_budget,
-                )?;
+                let (redeemer, eval_result) =
+                    if let Some(protocol_major_version) = protocol_major_version {
+                        eval::eval_redeemer_with_protocol(
+                            tx,
+                            utxos,
+                            slot_config,
+                            &redeemer,
+                            &lookup_table,
+                            cost_mdls,
+                            &remaining_budget,
+                            protocol_major_version,
+                        )?
+                    } else {
+                        eval::eval_redeemer(
+                            tx,
+                            utxos,
+                            slot_config,
+                            &redeemer,
+                            &lookup_table,
+                            cost_mdls,
+                            &remaining_budget,
+                        )?
+                    };
 
                 // The subtraction is safe here as ex units counting is done during evaluation.
                 // Redeemer would fail already if budget was negative.
@@ -129,6 +221,54 @@ pub fn eval_phase_two_raw(
     cost_mdls_bytes: Option<&[u8]>,
     initial_budget: (u64, u64),
     slot_config: (u64, u64, u32),
+    run_phase_one: bool,
+    with_redeemer: fn(&Redeemer) -> (),
+) -> Result<Vec<(Vec<u8>, EvalResult)>, Error> {
+    eval_phase_two_raw_with_optional_protocol(
+        tx_bytes,
+        utxos_bytes,
+        cost_mdls_bytes,
+        initial_budget,
+        slot_config,
+        None,
+        run_phase_one,
+        with_redeemer,
+    )
+}
+
+/// Like eval_phase_two_raw, but selects builtin semantics and costing from an
+/// explicit protocol major version.
+#[allow(clippy::too_many_arguments)]
+pub fn eval_phase_two_raw_with_protocol(
+    tx_bytes: &[u8],
+    utxos_bytes: &[(Vec<u8>, Vec<u8>)],
+    cost_mdls_bytes: Option<&[u8]>,
+    initial_budget: (u64, u64),
+    slot_config: (u64, u64, u32),
+    protocol_major_version: u16,
+    run_phase_one: bool,
+    with_redeemer: fn(&Redeemer) -> (),
+) -> Result<Vec<(Vec<u8>, EvalResult)>, Error> {
+    eval_phase_two_raw_with_optional_protocol(
+        tx_bytes,
+        utxos_bytes,
+        cost_mdls_bytes,
+        initial_budget,
+        slot_config,
+        Some(protocol_major_version),
+        run_phase_one,
+        with_redeemer,
+    )
+}
+
+#[allow(clippy::too_many_arguments)]
+fn eval_phase_two_raw_with_optional_protocol(
+    tx_bytes: &[u8],
+    utxos_bytes: &[(Vec<u8>, Vec<u8>)],
+    cost_mdls_bytes: Option<&[u8]>,
+    initial_budget: (u64, u64),
+    slot_config: (u64, u64, u32),
+    protocol_major_version: Option<u16>,
     run_phase_one: bool,
     with_redeemer: fn(&Redeemer) -> (),
 ) -> Result<Vec<(Vec<u8>, EvalResult)>, Error> {
@@ -162,15 +302,30 @@ pub fn eval_phase_two_raw(
 
     match multi_era_tx {
         MultiEraTx::Conway(tx) => {
-            match eval_phase_two(
-                &tx,
-                &utxos,
-                cost_mdls.as_ref(),
-                Some(&budget),
-                &sc,
-                run_phase_one,
-                with_redeemer,
-            ) {
+            let result = if let Some(protocol_major_version) = protocol_major_version {
+                eval_phase_two_with_protocol(
+                    &tx,
+                    &utxos,
+                    cost_mdls.as_ref(),
+                    Some(&budget),
+                    &sc,
+                    protocol_major_version,
+                    run_phase_one,
+                    with_redeemer,
+                )
+            } else {
+                eval_phase_two(
+                    &tx,
+                    &utxos,
+                    cost_mdls.as_ref(),
+                    Some(&budget),
+                    &sc,
+                    run_phase_one,
+                    with_redeemer,
+                )
+            };
+
+            match result {
                 Ok(redeemers) => Ok(redeemers
                     .into_iter()
                     .map(|(r, e)| (r.encode_fragment().unwrap(), e))

--- a/crates/uplc/src/tx/eval.rs
+++ b/crates/uplc/src/tx/eval.rs
@@ -24,10 +24,57 @@ pub fn eval_redeemer(
     cost_mdls_opt: Option<&CostModels>,
     initial_budget: &ExBudget,
 ) -> Result<(Redeemer, EvalResult), Error> {
+    eval_redeemer_with_optional_protocol(
+        tx,
+        utxos,
+        slot_config,
+        redeemer,
+        lookup_table,
+        cost_mdls_opt,
+        initial_budget,
+        None,
+    )
+}
+
+#[allow(clippy::too_many_arguments)]
+pub fn eval_redeemer_with_protocol(
+    tx: &MintedTx,
+    utxos: &[ResolvedInput],
+    slot_config: &SlotConfig,
+    redeemer: &Redeemer,
+    lookup_table: &DataLookupTable,
+    cost_mdls_opt: Option<&CostModels>,
+    initial_budget: &ExBudget,
+    protocol_major_version: u16,
+) -> Result<(Redeemer, EvalResult), Error> {
+    eval_redeemer_with_optional_protocol(
+        tx,
+        utxos,
+        slot_config,
+        redeemer,
+        lookup_table,
+        cost_mdls_opt,
+        initial_budget,
+        Some(protocol_major_version),
+    )
+}
+
+#[allow(clippy::too_many_arguments)]
+fn eval_redeemer_with_optional_protocol(
+    tx: &MintedTx,
+    utxos: &[ResolvedInput],
+    slot_config: &SlotConfig,
+    redeemer: &Redeemer,
+    lookup_table: &DataLookupTable,
+    cost_mdls_opt: Option<&CostModels>,
+    initial_budget: &ExBudget,
+    protocol_major_version: Option<u16>,
+) -> Result<(Redeemer, EvalResult), Error> {
     fn do_eval_redeemer(
         cost_mdl_opt: Option<&CostModel>,
         initial_budget: &ExBudget,
         lang: &Language,
+        protocol_major_version: Option<u16>,
         datum: Option<PlutusData>,
         redeemer: &Redeemer,
         tx_info: TxInfo,
@@ -50,7 +97,18 @@ pub fn eval_redeemer(
         };
 
         let eval_result = if let Some(costs) = cost_mdl_opt {
-            program.eval_as(lang, costs, Some(initial_budget))
+            if let Some(protocol_major_version) = protocol_major_version {
+                program.eval_as_with_protocol(
+                    lang,
+                    protocol_major_version,
+                    costs,
+                    Some(initial_budget),
+                )
+            } else {
+                program.eval_as(lang, costs, Some(initial_budget))
+            }
+        } else if let Some(protocol_major_version) = protocol_major_version {
+            program.eval_version_with_protocol(ExBudget::default(), lang, protocol_major_version)
         } else {
             program.eval_version(ExBudget::default(), lang)
         };
@@ -92,6 +150,7 @@ pub fn eval_redeemer(
                 .transpose()?,
             initial_budget,
             &Language::PlutusV1,
+            protocol_major_version,
             datum,
             redeemer,
             TxInfoV1::from_transaction(tx, utxos, slot_config)?,
@@ -109,6 +168,7 @@ pub fn eval_redeemer(
                 .transpose()?,
             initial_budget,
             &Language::PlutusV2,
+            protocol_major_version,
             datum,
             redeemer,
             TxInfoV2::from_transaction(tx, utxos, slot_config)?,
@@ -126,6 +186,7 @@ pub fn eval_redeemer(
                 .transpose()?,
             initial_budget,
             &Language::PlutusV3,
+            protocol_major_version,
             datum,
             redeemer,
             TxInfoV3::from_transaction(tx, utxos, slot_config)?,


### PR DESCRIPTION
## Summary

- add protocol-aware UPLC evaluator entry points while keeping existing language-only wrappers
- select ledger-style builtin semantics A/B/C/D/E by language and protocol major version
- parse PlutusV3 350-entry PV11 cost models, including the PV11 tail entries and updated integer costing forms
- add regressions for protocol semantics selection, PV11 divideInteger costing, PV11 tail parsing, string byte-length costing, and consByteString behavior
- add a changelog entry for the UPLC evaluator fix

## Why

PV11 changes builtin semantics and costing by protocol version even when the script language is still PlutusV3. The previous evaluator selected semantics from `Language` alone, so a 350-entry PV11 cost model could still be evaluated using the wrong builtin semantics/costing shape.

## Validation

- `cargo +1.94.1 fmt --all -- --check`
- `cargo +1.94.1 build --workspace`
- `cargo +1.94.1 test --workspace`
- `cargo +1.94.1 clippy --all-targets --all-features -- -D warnings`
- `git diff --check`

## 

This has been tested on a few live contracts on preprod and produces correct ex-units. It extends the uplc evaluator to accept major version so that the evaluator can serve multiple networks simultaneously (ie. when Preprod & Mainnet have different semantics, it can gracefully handle it and thus allows this to be updated prior to a mainnet hardfork such that when an HF happens apps that rely on it will be able to continue to operate). 