### PR TITLE
fix(aiken-lang): use canonical keys for expect decoders

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [next] - YYYY-MM-DD
+
+### Fixed
+
+- **aiken-lang**: Use canonical type identity for cached `expect` decoder names to avoid collisions across modules and generic type shapes.
+
 ## v1.1.22 - 2026-05-15
 
 ### Added

--- a/crates/aiken-lang/src/gen_uplc.rs
+++ b/crates/aiken-lang/src/gen_uplc.rs
@@ -33,10 +33,9 @@ use crate::{
     line_numbers::LineNumbers,
     plutus_version::PlutusVersion,
     tipo::{
-        ModuleValueConstructor, PatternConstructor, Type, TypeInfo, ValueConstructor,
+        ModuleValueConstructor, PatternConstructor, Type, TypeInfo, TypeVar, ValueConstructor,
         ValueConstructorVariant, check_replaceable_opaque_type, convert_opaque_type,
-        find_and_replace_generics, get_arg_type_name, get_generic_id_and_type,
-        lookup_data_type_by_tipo,
+        find_and_replace_generics, get_generic_id_and_type, lookup_data_type_by_tipo,
     },
 };
 use builder::{
@@ -63,6 +62,89 @@ type Otherwise = Option<AirTree>;
 
 const DELAY_ERROR: fn() -> AirTree =
     || AirTree::anon_func(vec![], AirTree::error(Type::void(), false), true);
+
+fn expect_decoder_function_name(tipo: &Type, has_otherwise: bool) -> String {
+    let mut name = "__expect".to_string();
+    push_type_identity(&mut name, tipo);
+
+    if has_otherwise {
+        name.push_str("_otherwise");
+    }
+
+    name
+}
+
+fn push_type_identity(name: &mut String, tipo: &Type) {
+    match tipo {
+        Type::App {
+            module,
+            name: type_name,
+            args,
+            ..
+        } => {
+            name.push_str("_app");
+            push_key_segment(name, module);
+            push_key_segment(name, type_name);
+            push_key_count(name, args.len());
+
+            for arg in args {
+                push_type_identity(name, arg);
+            }
+        }
+        Type::Fn { args, ret, .. } => {
+            name.push_str("_fn");
+            push_key_count(name, args.len());
+
+            for arg in args {
+                push_type_identity(name, arg);
+            }
+
+            push_type_identity(name, ret);
+        }
+        Type::Var { tipo, .. } => {
+            let tipo = tipo.borrow();
+
+            match &*tipo {
+                TypeVar::Link { tipo } => push_type_identity(name, tipo),
+                TypeVar::Unbound { id } => {
+                    unreachable!(
+                        "expect decoder key requires a bound type, found unbound variable {id}"
+                    )
+                }
+                TypeVar::Generic { id } => {
+                    unreachable!(
+                        "expect decoder key requires a concrete type, found generic variable {id}"
+                    )
+                }
+            }
+        }
+        Type::Tuple { elems, .. } => {
+            name.push_str("_tuple");
+            push_key_count(name, elems.len());
+
+            for elem in elems {
+                push_type_identity(name, elem);
+            }
+        }
+        Type::Pair { fst, snd, .. } => {
+            name.push_str("_pair");
+            push_type_identity(name, fst);
+            push_type_identity(name, snd);
+        }
+    }
+}
+
+fn push_key_segment(name: &mut String, segment: &str) {
+    name.push('_');
+    name.push_str(&segment.len().to_string());
+    name.push('_');
+    name.push_str(&hex::encode(segment));
+}
+
+fn push_key_count(name: &mut String, count: usize) {
+    name.push('_');
+    name.push_str(&count.to_string());
+}
 
 #[derive(Clone)]
 pub struct CodeGenerator<'a> {
@@ -2241,12 +2323,6 @@ impl<'a> CodeGenerator<'a> {
                         unreachable!("We need a data type definition for type {:#?}", tipo)
                     });
 
-                let data_type_variant = tipo
-                    .get_inner_types()
-                    .iter()
-                    .map(|arg| get_arg_type_name(arg))
-                    .join(DISCARDED);
-
                 assert!(data_type.typed_parameters.len() == tipo.arg_types().unwrap().len());
 
                 let mono_types: IndexMap<u64, Rc<Type>> = if !data_type.typed_parameters.is_empty()
@@ -2261,14 +2337,7 @@ impl<'a> CodeGenerator<'a> {
                     IndexMap::new()
                 };
 
-                let data_type_name = if otherwise.is_some() {
-                    format!(
-                        "__expect_{}_{}_otherwise",
-                        data_type.name, data_type_variant
-                    )
-                } else {
-                    format!("__expect_{}_{}", data_type.name, data_type_variant)
-                };
+                let data_type_name = expect_decoder_function_name(tipo, otherwise.is_some());
                 let function = self.code_gen_functions.get(&data_type_name);
 
                 // mutate code_gen_funcs and defined_data_types in this if branch

--- a/crates/aiken-lang/src/tipo.rs
+++ b/crates/aiken-lang/src/tipo.rs
@@ -7,7 +7,6 @@ use crate::{
     tipo::fields::FieldMap,
 };
 use indexmap::IndexMap;
-use itertools::Itertools;
 use std::{cell::RefCell, collections::HashMap, ops::Deref, rc::Rc};
 use uplc::{ast::Type as UplcType, builtins::DefaultFunction};
 
@@ -711,31 +710,6 @@ pub fn get_generic_id_and_type(tipo: &Type, param: &Type) -> Vec<(u64, Rc<Type>)
         generics_ids.append(&mut get_generic_id_and_type(tipo, param_type));
     }
     generics_ids
-}
-
-pub fn get_arg_type_name(tipo: &Type) -> String {
-    match tipo {
-        Type::App { name, args, .. } => {
-            let inner_args = args.iter().map(|arg| get_arg_type_name(arg)).collect_vec();
-            format!("{}_{}", name, inner_args.join("_"))
-        }
-        Type::Var { tipo, .. } => match tipo.borrow().clone() {
-            TypeVar::Link { tipo } => get_arg_type_name(tipo.as_ref()),
-            _ => unreachable!(),
-        },
-        Type::Tuple { elems, .. } => {
-            let inner_args = elems.iter().map(|arg| get_arg_type_name(arg)).collect_vec();
-            inner_args.join("_")
-        }
-        Type::Pair { fst, snd, .. } => {
-            let inner_args = [fst, snd]
-                .iter()
-                .map(|arg| get_arg_type_name(arg))
-                .collect_vec();
-            inner_args.join("_")
-        }
-        _ => unreachable!("WTF {:#?}", tipo),
-    }
 }
 
 pub fn convert_opaque_type(

--- a/crates/aiken-project/src/tests/mod.rs
+++ b/crates/aiken-project/src/tests/mod.rs
@@ -1,7 +1,8 @@
 use crate::{
-    builtins,
+    Project, builtins,
     module::{CheckedModule, ParsedModule},
     package_name::PackageName,
+    telemetry::{CoverageMode, EventListener},
     utils,
 };
 use aiken_lang::{
@@ -18,7 +19,12 @@ use aiken_lang::{
     tipo::TypeInfo,
 };
 use indexmap::IndexMap;
-use std::{collections::HashMap, path::PathBuf};
+use std::{
+    collections::HashMap,
+    fs,
+    path::PathBuf,
+    time::{SystemTime, UNIX_EPOCH},
+};
 
 mod gen_uplc;
 
@@ -140,4 +146,179 @@ impl TestProject {
 
         checked_module
     }
+}
+
+#[derive(Debug, Clone, Copy)]
+struct NoopEventListener;
+
+impl EventListener for NoopEventListener {}
+
+#[test]
+fn expect_decoder_cache_key_uses_canonical_type_identity() {
+    let unique = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .expect("clock should be after epoch")
+        .as_nanos();
+    let root = std::env::temp_dir().join(format!("aiken-expect-decoder-key-{unique}"));
+
+    let _ = fs::remove_dir_all(&root);
+    fs::create_dir_all(root.join("lib")).expect("should create lib dir");
+    fs::write(
+        root.join("aiken.toml"),
+        r#"name = "aiken-lang/expect-decoder-key"
+version = "0.0.0"
+compiler = "v1.1.22"
+plutus = "v3"
+license = "Apache-2.0"
+"#,
+    )
+    .expect("should write aiken.toml");
+
+    fs::write(
+        root.join("lib/mod_a.ak"),
+        r#"pub type ActionType {
+  Variant { payload: ByteArray }
+}
+
+pub type RedeemerA {
+  tag: Int,
+  action: ActionType,
+}
+"#,
+    )
+    .expect("should write mod_a");
+
+    fs::write(
+        root.join("lib/mod_b.ak"),
+        r#"pub type ActionType {
+  Variant { payload: Int }
+}
+
+pub type RedeemerB {
+  tag: Int,
+  action: ActionType,
+}
+"#,
+    )
+    .expect("should write mod_b");
+
+    fs::write(
+        root.join("lib/common.ak"),
+        r#"pub type Wrapper<a> {
+  Wrapped { payload: a }
+}
+"#,
+    )
+    .expect("should write common");
+
+    fs::write(
+        root.join("lib/shapes.ak"),
+        r#"pub type Box<a> {
+  Box { payload: a }
+}
+
+pub type A_B {
+  AB { payload: ByteArray }
+}
+
+pub type A<a> {
+  A { payload: a }
+}
+
+pub type B {
+  B { payload: Int }
+}
+"#,
+    )
+    .expect("should write shapes");
+
+    fs::write(
+        root.join("lib/collision.ak"),
+        r#"use common
+use mod_a
+use mod_b
+use shapes
+
+pub fn expect_both_direct(a_raw: Data, b_raw: Data) -> Bool {
+  expect _a: mod_a.RedeemerA = a_raw
+  expect _b: mod_b.RedeemerB = b_raw
+  True
+}
+
+pub fn expect_both_wrapper(a_raw: Data, b_raw: Data) -> Bool {
+  expect _a: common.Wrapper<mod_a.ActionType> = a_raw
+  expect _b: common.Wrapper<mod_b.ActionType> = b_raw
+  True
+}
+
+pub fn expect_both_option(a_raw: Data, b_raw: Data) -> Bool {
+  expect _a: Option<mod_a.ActionType> = a_raw
+  expect _b: Option<mod_b.ActionType> = b_raw
+  True
+}
+
+pub fn expect_boxes(a_raw: Data, b_raw: Data) -> Bool {
+  expect _a: shapes.Box<shapes.A_B> = a_raw
+  expect _b: shapes.Box<shapes.A<shapes.B>> = b_raw
+  True
+}
+
+test direct_same_local_type_name_collision() {
+  let a_raw: Data =
+    mod_a.RedeemerA { tag: 1, action: mod_a.Variant { payload: #"deadbeef" } }
+
+  let b_raw: Data =
+    mod_b.RedeemerB { tag: 2, action: mod_b.Variant { payload: 42 } }
+
+  expect_both_direct(a_raw, b_raw)
+}
+
+test wrapper_argument_same_local_type_name_collision() {
+  let a_raw: Data =
+    common.Wrapped { payload: mod_a.Variant { payload: #"deadbeef" } }
+
+  let b_raw: Data =
+    common.Wrapped { payload: mod_b.Variant { payload: 42 } }
+
+  expect_both_wrapper(a_raw, b_raw)
+}
+
+test option_argument_same_local_type_name_collision() {
+  let a_raw: Data = Some(mod_a.Variant { payload: #"deadbeef" })
+  let b_raw: Data = Some(mod_b.Variant { payload: 42 })
+
+  expect_both_option(a_raw, b_raw)
+}
+
+test flattened_generic_name_shape_collision() {
+  let a_raw: Data = shapes.Box { payload: shapes.AB { payload: #"deadbeef" } }
+  let b_raw: Data = shapes.Box { payload: shapes.A { payload: shapes.B { payload: 42 } } }
+
+  expect_boxes(a_raw, b_raw)
+}
+"#,
+    )
+    .expect("should write collision module");
+
+    let mut project = Project::new(root.clone(), NoopEventListener).expect("should load project");
+
+    let result = project.check(
+        false,
+        None,
+        false,
+        false,
+        1,
+        1,
+        CoverageMode::default(),
+        Tracing::All(TraceLevel::Verbose),
+        true,
+        None,
+    );
+
+    let _ = fs::remove_dir_all(&root);
+
+    assert!(
+        result.is_ok(),
+        "expect decoders should use canonical type identity as their cache key: {result:#?}"
+    );
 }


### PR DESCRIPTION
Include the full type identity in generated expect-decoder cache keys instead of using only the local type name plus flattened generic argument names.

This prevents decoder reuse between distinct types that share a local name across modules, such as mod_a.ActionType and mod_b.ActionType, and also avoids collisions between different generic shapes with the same flattened name.