### PR TITLE
Convert multiScalarMul arguments from data lists to typed lists

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## v1.1.24 - UNRELEASED
+
+### Fixed
+
+- **uplc**: Convert `bls12_381_g1_multi_scalar_mul` / `bls12_381_g2_multi_scalar_mul` arguments from Aiken's data-encoded lists to the typed `List<Int>` and `List<G1Element>` / `List<G2Element>` constants expected by the builtins, like already done for `write_bits`. Fixes [#1378](https://github.com/aiken-lang/aiken/issues/1378). @perturbing
+
 ## v1.1.23 - 2026-06-26
 
 ### Added

--- a/crates/uplc/src/builder.rs
+++ b/crates/uplc/src/builder.rs
@@ -10,6 +10,8 @@ pub const CONSTR_INDEX_EXPOSER: &str = "__constr_index_exposer";
 pub const EXPECT_ON_LIST: &str = "__expect_on_list";
 pub const INNER_EXPECT_ON_LIST: &str = "__inner_expect_on_list";
 pub const INDICES_CONVERTER: &str = "__indices_converter";
+pub const G1_ELEMENTS_CONVERTER: &str = "__g1_elements_converter";
+pub const G2_ELEMENTS_CONVERTER: &str = "__g2_elements_converter";
 
 impl<T> Term<T>
 where
@@ -555,31 +557,55 @@ impl Term<Name> {
         )
     }
 
-    pub fn data_list_to_integer_list(self) -> Self {
-        self.lambda(INDICES_CONVERTER)
-            .apply(Term::var(INDICES_CONVERTER).apply(Term::var(INDICES_CONVERTER)))
-            .lambda(INDICES_CONVERTER)
+    /// Binds `converter_name` to a recursive function converting a list of
+    /// data into a list of `inner_type`, where each element is converted with
+    /// `convert_head`.
+    fn data_list_converter(
+        self,
+        converter_name: &str,
+        inner_type: Type,
+        convert_head: impl FnOnce(Term<Name>) -> Term<Name>,
+    ) -> Term<Name> {
+        self.lambda(converter_name)
+            .apply(Term::var(converter_name).apply(Term::var(converter_name)))
+            .lambda(converter_name)
             .apply(
                 Term::var("xs")
                     .delayed_choose_list(
-                        Term::int_values(vec![]),
+                        Term::Constant(Constant::ProtoList(inner_type, vec![]).into()),
                         Term::mk_cons()
                             .apply(Term::var("x"))
                             .apply(
-                                Term::var(INDICES_CONVERTER)
-                                    .apply(Term::var(INDICES_CONVERTER))
+                                Term::var(converter_name)
+                                    .apply(Term::var(converter_name))
                                     .apply(Term::var("rest")),
                             )
                             .lambda("rest")
                             .apply(Term::tail_list().apply(Term::var("xs")))
                             .lambda("x")
-                            .apply(
-                                Term::un_i_data().apply(Term::head_list().apply(Term::var("xs"))),
-                            ),
+                            .apply(convert_head(Term::head_list().apply(Term::var("xs")))),
                     )
                     .lambda("xs")
-                    .lambda(INDICES_CONVERTER),
+                    .lambda(converter_name),
             )
+    }
+
+    pub fn data_list_to_integer_list(self) -> Term<Name> {
+        self.data_list_converter(INDICES_CONVERTER, Type::Integer, |head| {
+            Term::un_i_data().apply(head)
+        })
+    }
+
+    pub fn data_list_to_g1_element_list(self) -> Term<Name> {
+        self.data_list_converter(G1_ELEMENTS_CONVERTER, Type::Bls12_381G1Element, |head| {
+            Term::bls12_381_g1_uncompress().apply(Term::un_b_data().apply(head))
+        })
+    }
+
+    pub fn data_list_to_g2_element_list(self) -> Term<Name> {
+        self.data_list_converter(G2_ELEMENTS_CONVERTER, Type::Bls12_381G2Element, |head| {
+            Term::bls12_381_g2_uncompress().apply(Term::un_b_data().apply(head))
+        })
     }
 
     /// Introduce a let-binding for a given term. The callback receives a Term::Var

--- a/crates/uplc/src/optimize/shrinker.rs
+++ b/crates/uplc/src/optimize/shrinker.rs
@@ -1,7 +1,10 @@
 use super::interner::CodeGenInterner;
 use crate::{
     ast::{Constant, Data, Name, NamedDeBruijn, Program, Term, Type},
-    builder::{CONSTR_FIELDS_EXPOSER, CONSTR_INDEX_EXPOSER, INDICES_CONVERTER},
+    builder::{
+        CONSTR_FIELDS_EXPOSER, CONSTR_INDEX_EXPOSER, G1_ELEMENTS_CONVERTER, G2_ELEMENTS_CONVERTER,
+        INDICES_CONVERTER,
+    },
     builtins::DefaultFunction,
     machine::{cost_model::ExBudget, runtime::Compressable, value::from_pallas_bigint},
 };
@@ -978,11 +981,15 @@ impl CurriedBuiltin {
 pub struct Context {
     pub inlined_apply_ids: Vec<usize>,
     pub constants_to_flip: Vec<usize>,
-    pub write_bits_indices_arg: Vec<usize>,
+    pub integer_list_args: Vec<usize>,
+    pub g1_element_list_args: Vec<usize>,
+    pub g2_element_list_args: Vec<usize>,
     pub builtins_map: IndexMap<DefaultFunction, ()>,
     pub blst_p1_list: Vec<blst_p1>,
     pub blst_p2_list: Vec<blst_p2>,
-    pub write_bits_convert: bool,
+    pub integer_list_convert: bool,
+    pub g1_element_list_convert: bool,
+    pub g2_element_list_convert: bool,
     pub node_count: usize,
 }
 
@@ -1750,10 +1757,16 @@ impl Term<Name> {
             }
         }
     }
-    // List<Int> in Aiken is actually List<Data<Int>>
-    // So now we want to convert writeBits arg List<Data<Int>> to List<Int>
+    // Aiken represents lists uniformly as lists of data: List<Int> is a
+    // list<data> of iData-wrapped integers, and List<G1Element> /
+    // List<G2Element> are list<data> of bData-wrapped *compressed* points.
+    // Some builtins (writeBits, bls12_381_gX_multiScalarMul) instead expect
+    // properly typed lists (list<integer>, list<bls12_381_gX_element> of
+    // native group elements), so we convert their arguments here: integers
+    // are unIData'ed, and points are unBData'ed and uncompressed back into
+    // group elements.
     // Important: Only runs once and at the end.
-    fn write_bits_convert_arg(
+    fn typed_list_convert_arg(
         &mut self,
         id: Option<usize>,
         mut arg_stack: Vec<Args>,
@@ -1764,7 +1777,7 @@ impl Term<Name> {
             Term::Apply { argument, .. } => {
                 let id = id.unwrap();
 
-                if context.write_bits_indices_arg.contains(&id) {
+                if context.integer_list_args.contains(&id) {
                     match Rc::make_mut(argument) {
                         Term::Constant(constant) => {
                             let Constant::ProtoList(tipo, items) = Rc::make_mut(constant) else {
@@ -1776,25 +1789,43 @@ impl Term<Name> {
 
                             for item in items {
                                 let Constant::Data(PlutusData::BigInt(i)) = item else {
-                                    unreachable!();
+                                    unreachable!("unexpected item in integer list arg: {item:#?}");
                                 };
 
                                 *item = Constant::Integer(from_pallas_bigint(i));
                             }
                         }
                         arg => {
-                            context.write_bits_convert = true;
+                            context.integer_list_convert = true;
 
                             *arg = Term::var(INDICES_CONVERTER)
                                 .apply(std::mem::replace(arg, Term::Error.force()));
                         }
                     }
+                } else if context.g1_element_list_args.contains(&id) {
+                    // BLS12-381 points cannot be represented as constants in a
+                    // serialized program, so they are always converted at
+                    // runtime, even when the list of (data-encoded) points is
+                    // a constant.
+                    context.g1_element_list_convert = true;
+
+                    let arg = Rc::make_mut(argument);
+
+                    *arg = Term::var(G1_ELEMENTS_CONVERTER)
+                        .apply(std::mem::replace(arg, Term::Error.force()));
+                } else if context.g2_element_list_args.contains(&id) {
+                    context.g2_element_list_convert = true;
+
+                    let arg = Rc::make_mut(argument);
+
+                    *arg = Term::var(G2_ELEMENTS_CONVERTER)
+                        .apply(std::mem::replace(arg, Term::Error.force()));
                 }
             }
 
             Term::Builtin(DefaultFunction::WriteBits) => {
                 if arg_stack.is_empty() {
-                    context.write_bits_convert = true;
+                    context.integer_list_convert = true;
 
                     *self = Term::write_bits()
                         .apply(Term::var("__arg_1"))
@@ -1804,14 +1835,62 @@ impl Term<Name> {
                         .lambda("__arg_2")
                         .lambda("__arg_1")
                 } else {
-                    // first arg not needed
+                    // args are in application order, so the last arg (the
+                    // bool) is popped first and not needed
                     arg_stack.pop();
 
                     let Some(Args::Apply(arg_id, _)) = arg_stack.pop() else {
                         return;
                     };
 
-                    context.write_bits_indices_arg.push(arg_id);
+                    context.integer_list_args.push(arg_id);
+                }
+            }
+
+            Term::Builtin(
+                func @ (DefaultFunction::Bls12_381_G1_MultiScalarMul
+                | DefaultFunction::Bls12_381_G2_MultiScalarMul),
+            ) => {
+                let is_g1 = matches!(func, DefaultFunction::Bls12_381_G1_MultiScalarMul);
+
+                if arg_stack.is_empty() {
+                    let func = *func;
+
+                    context.integer_list_convert = true;
+
+                    let elements_converter = if is_g1 {
+                        context.g1_element_list_convert = true;
+
+                        G1_ELEMENTS_CONVERTER
+                    } else {
+                        context.g2_element_list_convert = true;
+
+                        G2_ELEMENTS_CONVERTER
+                    };
+
+                    *self = Term::Builtin(func)
+                        .apply(Term::var(INDICES_CONVERTER).apply(Term::var("__arg_1")))
+                        .apply(Term::var(elements_converter).apply(Term::var("__arg_2")))
+                        .lambda("__arg_2")
+                        .lambda("__arg_1")
+                } else {
+                    // args are in application order, so the last arg (points)
+                    // is popped first
+                    let Some(Args::Apply(points_id, _)) = arg_stack.pop() else {
+                        return;
+                    };
+
+                    if is_g1 {
+                        context.g1_element_list_args.push(points_id);
+                    } else {
+                        context.g2_element_list_args.push(points_id);
+                    }
+
+                    let Some(Args::Apply(scalars_id, _)) = arg_stack.pop() else {
+                        return;
+                    };
+
+                    context.integer_list_args.push(scalars_id);
                 }
             }
             _ => (),
@@ -2380,11 +2459,15 @@ impl Program<Name> {
         let mut context = Context {
             inlined_apply_ids: vec![],
             constants_to_flip: vec![],
-            write_bits_indices_arg: vec![],
+            integer_list_args: vec![],
+            g1_element_list_args: vec![],
+            g2_element_list_args: vec![],
             builtins_map: IndexMap::new(),
             blst_p1_list: vec![],
             blst_p2_list: vec![],
-            write_bits_convert: false,
+            integer_list_convert: false,
+            g1_element_list_convert: false,
+            g2_element_list_convert: false,
             node_count: 0,
         };
 
@@ -2513,8 +2596,16 @@ impl Program<Name> {
                 term.remove_inlined_ids(id, vec![], scope, context);
             });
 
-        if context.write_bits_convert {
+        if context.integer_list_convert {
             program.term = program.term.data_list_to_integer_list();
+        }
+
+        if context.g1_element_list_convert {
+            program.term = program.term.data_list_to_g1_element_list();
+        }
+
+        if context.g2_element_list_convert {
+            program.term = program.term.data_list_to_g2_element_list();
         }
 
         program
@@ -2530,7 +2621,7 @@ impl Program<Name> {
     pub fn afterwards(self) -> Self {
         let (mut program, context) =
             self.traverse_uplc_with(true, &mut |id, term, arg_stack, scope, context| {
-                term.write_bits_convert_arg(id, arg_stack, scope, context);
+                term.typed_list_convert_arg(id, arg_stack, scope, context);
             });
 
         program = program
@@ -2540,8 +2631,16 @@ impl Program<Name> {
             })
             .0;
 
-        if context.write_bits_convert {
+        if context.integer_list_convert {
             program.term = program.term.data_list_to_integer_list();
+        }
+
+        if context.g1_element_list_convert {
+            program.term = program.term.data_list_to_g1_element_list();
+        }
+
+        if context.g2_element_list_convert {
+            program.term = program.term.data_list_to_g2_element_list();
         }
 
         let mut interner = CodeGenInterner::new();

--- a/examples/acceptance_tests/134/aiken.toml
+++ b/examples/acceptance_tests/134/aiken.toml
@@ -1,0 +1,2 @@
+name = "aiken-lang/acceptance_test_134"
+version = "0.0.0"

--- a/examples/acceptance_tests/134/lib/tests.ak
+++ b/examples/acceptance_tests/134/lib/tests.ak
@@ -1,0 +1,76 @@
+use aiken/builtin
+
+const generator_g1: G1Element =
+  #<Bls12_381, G1>"97f1d3a73197d7942695638c4fa9ac0fc3688c4f9774b905a14e3a3f171bac586c55e83ff97a1aeffb3af00adb22c6bb"
+
+const generator_g2: G2Element =
+  #<Bls12_381, G2>"93e02b6052719f607dacd3a088274f65596bd0d09920b61ab5da61bbdc7f5049334cf11213945d57e5ac7d055d042b7e024aa2b2f08f0a91260805272dc51051c6e47ad4fa403b02b4510b647ae3d1770bac0326a805bbefd48056c8c121bdb8"
+
+fn count_down(n: Int) -> List<Int> {
+  if n <= 0 {
+    []
+  } else {
+    [n, ..count_down(n - 1)]
+  }
+}
+
+fn replicate_g1(point: G1Element, n: Int) -> List<G1Element> {
+  if n <= 0 {
+    []
+  } else {
+    [point, ..replicate_g1(point, n - 1)]
+  }
+}
+
+fn replicate_g2(point: G2Element, n: Int) -> List<G2Element> {
+  if n <= 0 {
+    []
+  } else {
+    [point, ..replicate_g2(point, n - 1)]
+  }
+}
+
+// 2*G + 3*G == 5*G, with constant argument lists
+test bls12_381_g1_multi_scalar_mul_constant() {
+  builtin.bls12_381_g1_multi_scalar_mul(
+    [2, 3],
+    [generator_g1, generator_g1],
+  ) == builtin.bls12_381_g1_scalar_mul(5, generator_g1)
+}
+
+test bls12_381_g2_multi_scalar_mul_constant() {
+  builtin.bls12_381_g2_multi_scalar_mul(
+    [2, 3],
+    [generator_g2, generator_g2],
+  ) == builtin.bls12_381_g2_scalar_mul(5, generator_g2)
+}
+
+// 1*G + 2*G + 3*G + 4*G == 10*G, with argument lists built at runtime
+test bls12_381_g1_multi_scalar_mul_dynamic() {
+  builtin.bls12_381_g1_multi_scalar_mul(
+    count_down(4),
+    replicate_g1(generator_g1, 4),
+  ) == builtin.bls12_381_g1_scalar_mul(10, generator_g1)
+}
+
+test bls12_381_g2_multi_scalar_mul_dynamic() {
+  builtin.bls12_381_g2_multi_scalar_mul(
+    count_down(4),
+    replicate_g2(generator_g2, 4),
+  ) == builtin.bls12_381_g2_scalar_mul(10, generator_g2)
+}
+
+// The builtin used as a value rather than being called directly
+test bls12_381_g1_multi_scalar_mul_as_value() {
+  let multi_scalar_mul =
+    if count_down(1) == [1] {
+      builtin.bls12_381_g1_multi_scalar_mul
+    } else {
+      fn(_scalars: List<Int>, _points: List<G1Element>) { generator_g1 }
+    }
+
+  multi_scalar_mul([2, 3], [generator_g1, generator_g1]) == builtin.bls12_381_g1_scalar_mul(
+    5,
+    generator_g1,
+  )
+}


### PR DESCRIPTION
Fixes #1378.

## Problem

Any non-empty call to `builtin.bls12_381_g1_multi_scalar_mul` or
`builtin.bls12_381_g2_multi_scalar_mul` type-checked but failed at runtime with:

```
type mismatch
  Expected integer
       Got data
```

Aiken represents every list uniformly as a `list<data>`: `List<Int>` holds
iData-wrapped integers and `List<G1Element>` / `List<G2Element>` hold
bData-wrapped *compressed* points. The multiScalarMul builtins, matching
strict on-chain Plutus semantics, expect properly typed lists
(`list<integer>` and `list<bls12_381_gX_element>` of native group elements).
Codegen never inserted the conversion.

The existing acceptance tests (132/133) only exercised *empty* lists, which
slip through because the machine validates list elements rather than the
list's type tag — so the gap went unnoticed.
