### PR TITLE
parser: avoid exponential backtracking for parenthesized expressions

### DIFF
--- a/crates/aiken-lang/src/parser/expr/block.rs
+++ b/crates/aiken-lang/src/parser/expr/block.rs
@@ -1,6 +1,7 @@
 use chumsky::prelude::*;
 
 use crate::{
+    ast::Span,
     expr::UntypedExpr,
     parser::{error::ParseError, token::Token},
 };
@@ -8,25 +9,20 @@ use crate::{
 pub fn parser(
     sequence: Recursive<'_, Token, UntypedExpr, ParseError>,
 ) -> impl Parser<Token, UntypedExpr, Error = ParseError> + '_ {
-    choice((
-        sequence
-            .clone()
-            .delimited_by(just(Token::LeftBrace), just(Token::RightBrace)),
-        sequence.clone().delimited_by(
-            choice((just(Token::LeftParen), just(Token::NewLineLeftParen))),
-            just(Token::RightParen),
-        ),
-    ))
-    .map_with_span(|e, span| {
-        if matches!(e, UntypedExpr::Assignment { .. }) {
-            UntypedExpr::Sequence {
-                location: span,
-                expressions: vec![e],
-            }
-        } else {
-            e
+    sequence
+        .delimited_by(just(Token::LeftBrace), just(Token::RightBrace))
+        .map_with_span(assignment_into_sequence)
+}
+
+pub(super) fn assignment_into_sequence(expression: UntypedExpr, location: Span) -> UntypedExpr {
+    if matches!(expression, UntypedExpr::Assignment { .. }) {
+        UntypedExpr::Sequence {
+            location,
+            expressions: vec![expression],
         }
-    })
+    } else {
+        expression
+    }
 }
 
 #[cfg(test)]
@@ -83,6 +79,44 @@ mod tests {
               True
             }
             "#
+        );
+    }
+
+    #[test]
+    fn parse_simple_grouping() {
+        assert_expr!("(x)");
+    }
+
+    #[test]
+    fn parse_nested_grouping() {
+        assert_expr!("((x))");
+    }
+
+    #[test]
+    fn parse_parenthesized_assignment() {
+        assert_expr!("(let x = 1)");
+    }
+
+    #[test]
+    fn parse_bare_parenthesized_assignment() {
+        assert_expr!("(x = 1)");
+    }
+
+    #[test]
+    fn parse_parenthesized_sequence() {
+        assert_expr!(
+            r#"(
+              let x = 1
+              x
+            )"#
+        );
+    }
+
+    #[test]
+    fn parse_newline_left_paren() {
+        assert_expr!(
+            r#"x
+            (x)"#
         );
     }
 }

--- a/crates/aiken-lang/src/parser/expr/chained.rs
+++ b/crates/aiken-lang/src/parser/expr/chained.rs
@@ -2,8 +2,8 @@ use super::{
     and_or_chain, anonymous_binop::parser as anonymous_binop,
     anonymous_function::parser as anonymous_function, assignment, block::parser as block,
     bytearray::parser as bytearray, if_else::parser as if_else, int::parser as int,
-    list::parser as list, pair::parser as pair, record::parser as record,
-    record_update::parser as record_update, string::parser as string, tuple::parser as tuple,
+    list::parser as list, pair::parser as pair, parenthesized::parser as parenthesized,
+    record::parser as record, record_update::parser as record_update, string::parser as string,
     var::parser as var, when::parser as when,
 };
 use crate::{
@@ -55,7 +55,7 @@ pub fn chain_start<'a>(
         record(expression.clone()),
         and_or_chain(expression.clone()),
         var(),
-        tuple(expression.clone()),
+        parenthesized(sequence.clone(), expression.clone()),
         bytearray(),
         list(expression.clone()),
         anonymous_function(sequence.clone()),

--- a/crates/aiken-lang/src/parser/expr/mod.rs
+++ b/crates/aiken-lang/src/parser/expr/mod.rs
@@ -13,6 +13,7 @@ mod if_else;
 mod int;
 mod list;
 mod pair;
+mod parenthesized;
 mod record;
 mod record_update;
 mod sequence;

--- a/crates/aiken-lang/src/parser/expr/parenthesized.rs
+++ b/crates/aiken-lang/src/parser/expr/parenthesized.rs
@@ -1,0 +1,81 @@
+use chumsky::prelude::*;
+
+use crate::{
+    expr::UntypedExpr,
+    parser::{error::ParseError, token::Token},
+};
+
+enum ParenthesizedTail {
+    Tuple(Vec<UntypedExpr>),
+    Sequence(Vec<UntypedExpr>),
+}
+
+pub fn parser<'a>(
+    sequence: Recursive<'a, Token, UntypedExpr, ParseError>,
+    expression: Recursive<'a, Token, UntypedExpr, ParseError>,
+) -> impl Parser<Token, UntypedExpr, Error = ParseError> + 'a {
+    expression
+        .clone()
+        .then(choice((
+            just(Token::Comma)
+                .ignore_then(
+                    expression
+                        .separated_by(just(Token::Comma))
+                        .at_least(1)
+                        .allow_trailing(),
+                )
+                .map(ParenthesizedTail::Tuple),
+            just(Token::Comma)
+                .not()
+                .rewind()
+                .ignore_then(sequence.repeated())
+                .map(ParenthesizedTail::Sequence),
+        )))
+        .delimited_by(
+            choice((just(Token::LeftParen), just(Token::NewLineLeftParen))),
+            just(Token::RightParen),
+        )
+        .map_with_span(|(first, tail), span| match tail {
+            ParenthesizedTail::Tuple(tail) => {
+                let mut elems = Vec::with_capacity(tail.len() + 1);
+                elems.push(first);
+                elems.extend(tail);
+
+                UntypedExpr::Tuple {
+                    location: span,
+                    elems,
+                }
+            }
+            ParenthesizedTail::Sequence(tail) => {
+                let expression = tail
+                    .into_iter()
+                    .fold(first, UntypedExpr::append_in_sequence);
+
+                super::block::assignment_into_sequence(expression, span)
+            }
+        })
+}
+
+#[cfg(test)]
+mod tests {
+    use chumsky::{Parser, Stream};
+
+    use crate::{
+        ast::Span,
+        parser::{expr, lexer},
+    };
+
+    #[test]
+    fn parse_deeply_nested_grouping() {
+        for depth in [16, 32, 64, 128] {
+            let source = format!("{}x{}", "(".repeat(depth), ")".repeat(depth));
+            let lexer::LexInfo { tokens, .. } =
+                lexer::run(&source).expect("nested grouping should lex");
+            let stream = Stream::from_iter(Span::create(tokens.len(), 1), tokens.into_iter());
+
+            expr::sequence()
+                .parse(stream)
+                .unwrap_or_else(|errors| panic!("depth {depth} failed to parse: {errors:?}"));
+        }
+    }
+}

--- a/crates/aiken-lang/src/parser/expr/snapshots/parse_bare_parenthesized_assignment.snap
+++ b/crates/aiken-lang/src/parser/expr/snapshots/parse_bare_parenthesized_assignment.snap
@@ -1,0 +1,5 @@
+---
+source: crates/aiken-lang/src/parser/expr/block.rs
+description: "Invalid code (parse error):\n\n(x = 1)"
+---
+I found an unexpected token '='.

--- a/crates/aiken-lang/src/parser/expr/snapshots/parse_nested_grouping.snap
+++ b/crates/aiken-lang/src/parser/expr/snapshots/parse_nested_grouping.snap
@@ -1,0 +1,8 @@
+---
+source: crates/aiken-lang/src/parser/expr/block.rs
+description: "Code:\n\n((x))"
+---
+Var {
+    location: 2..3,
+    name: "x",
+}

--- a/crates/aiken-lang/src/parser/expr/snapshots/parse_nested_tuple.snap
+++ b/crates/aiken-lang/src/parser/expr/snapshots/parse_nested_tuple.snap
@@ -1,0 +1,17 @@
+---
+source: crates/aiken-lang/src/parser/expr/tuple.rs
+description: "Code:\n\n((x, y))"
+---
+Tuple {
+    location: 1..7,
+    elems: [
+        Var {
+            location: 2..3,
+            name: "x",
+        },
+        Var {
+            location: 5..6,
+            name: "y",
+        },
+    ],
+}

--- a/crates/aiken-lang/src/parser/expr/snapshots/parse_newline_left_paren.snap
+++ b/crates/aiken-lang/src/parser/expr/snapshots/parse_newline_left_paren.snap
@@ -1,0 +1,17 @@
+---
+source: crates/aiken-lang/src/parser/expr/block.rs
+description: "Code:\n\nx\n(x)"
+---
+Sequence {
+    location: 0..4,
+    expressions: [
+        Var {
+            location: 0..1,
+            name: "x",
+        },
+        Var {
+            location: 3..4,
+            name: "x",
+        },
+    ],
+}

--- a/crates/aiken-lang/src/parser/expr/snapshots/parse_parenthesized_assignment.snap
+++ b/crates/aiken-lang/src/parser/expr/snapshots/parse_parenthesized_assignment.snap
@@ -1,0 +1,33 @@
+---
+source: crates/aiken-lang/src/parser/expr/block.rs
+description: "Code:\n\n(let x = 1)"
+---
+Sequence {
+    location: 0..11,
+    expressions: [
+        Assignment {
+            location: 1..10,
+            value: UInt {
+                location: 9..10,
+                value: "1",
+                base: Decimal {
+                    numeric_underscore: false,
+                },
+            },
+            patterns: [
+                AssignmentPattern {
+                    pattern: Var {
+                        location: 5..6,
+                        name: "x",
+                    },
+                    annotation: None,
+                    location: 5..6,
+                },
+            ],
+            kind: Let {
+                backpassing: false,
+            },
+            comment: None,
+        },
+    ],
+}

--- a/crates/aiken-lang/src/parser/expr/snapshots/parse_parenthesized_sequence.snap
+++ b/crates/aiken-lang/src/parser/expr/snapshots/parse_parenthesized_sequence.snap
@@ -1,0 +1,37 @@
+---
+source: crates/aiken-lang/src/parser/expr/block.rs
+description: "Code:\n\n(\n  let x = 1\n  x\n)"
+---
+Sequence {
+    location: 4..17,
+    expressions: [
+        Assignment {
+            location: 4..13,
+            value: UInt {
+                location: 12..13,
+                value: "1",
+                base: Decimal {
+                    numeric_underscore: false,
+                },
+            },
+            patterns: [
+                AssignmentPattern {
+                    pattern: Var {
+                        location: 8..9,
+                        name: "x",
+                    },
+                    annotation: None,
+                    location: 8..9,
+                },
+            ],
+            kind: Let {
+                backpassing: false,
+            },
+            comment: None,
+        },
+        Var {
+            location: 16..17,
+            name: "x",
+        },
+    ],
+}

--- a/crates/aiken-lang/src/parser/expr/snapshots/parse_simple_grouping.snap
+++ b/crates/aiken-lang/src/parser/expr/snapshots/parse_simple_grouping.snap
@@ -1,0 +1,8 @@
+---
+source: crates/aiken-lang/src/parser/expr/block.rs
+description: "Code:\n\n(x)"
+---
+Var {
+    location: 1..2,
+    name: "x",
+}

--- a/crates/aiken-lang/src/parser/expr/snapshots/parse_simple_tuple.snap
+++ b/crates/aiken-lang/src/parser/expr/snapshots/parse_simple_tuple.snap
@@ -1,0 +1,17 @@
+---
+source: crates/aiken-lang/src/parser/expr/tuple.rs
+description: "Code:\n\n(x, y)"
+---
+Tuple {
+    location: 0..6,
+    elems: [
+        Var {
+            location: 1..2,
+            name: "x",
+        },
+        Var {
+            location: 4..5,
+            name: "y",
+        },
+    ],
+}

--- a/crates/aiken-lang/src/parser/expr/snapshots/parse_singleton_tuple.snap
+++ b/crates/aiken-lang/src/parser/expr/snapshots/parse_singleton_tuple.snap
@@ -1,0 +1,5 @@
+---
+source: crates/aiken-lang/src/parser/expr/tuple.rs
+description: "Invalid code (parse error):\n\n(x,)"
+---
+I found an unexpected token ')'.

--- a/crates/aiken-lang/src/parser/expr/snapshots/parse_tuple_with_trailing_comma.snap
+++ b/crates/aiken-lang/src/parser/expr/snapshots/parse_tuple_with_trailing_comma.snap
@@ -1,0 +1,17 @@
+---
+source: crates/aiken-lang/src/parser/expr/tuple.rs
+description: "Code:\n\n(x, y,)"
+---
+Tuple {
+    location: 0..7,
+    elems: [
+        Var {
+            location: 1..2,
+            name: "x",
+        },
+        Var {
+            location: 4..5,
+            name: "y",
+        },
+    ],
+}

--- a/crates/aiken-lang/src/parser/expr/tuple.rs
+++ b/crates/aiken-lang/src/parser/expr/tuple.rs
@@ -45,4 +45,24 @@ mod tests {
             "#
         );
     }
+
+    #[test]
+    fn parse_singleton_tuple() {
+        assert_expr!("(x,)");
+    }
+
+    #[test]
+    fn parse_simple_tuple() {
+        assert_expr!("(x, y)");
+    }
+
+    #[test]
+    fn parse_nested_tuple() {
+        assert_expr!("((x, y))");
+    }
+
+    #[test]
+    fn parse_tuple_with_trailing_comma() {
+        assert_expr!("(x, y,)");
+    }
 }


### PR DESCRIPTION
Left-factor the shared '(' prefix of tuples and grouped expressions so the first interior expression is parsed exactly once, instead of being fully parsed by the tuple alternative, discarded, and re-parsed as a group. Nested grouping previously cost O(2^depth); it is now linear.

Preserves tuple, trailing-comma, grouping, parenthesized sequence/assignment, and NewLineLeftParen semantics, along with source spans. Adds depth-based regression tests (16–128 levels).

Closes #1377