### PR TITLE
compiler: make deeply nested expressions stack-safe

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -30,6 +30,10 @@ jobs:
           cargo install --path=crates/aiken --target=x86_64-unknown-linux-musl
           mv $(which aiken) aiken
           ldd aiken
+      - name: Run deep-expression regressions with release musl binary
+        env:
+          AIKEN_BIN: ${{ github.workspace }}/aiken
+        run: cargo test --release -p aiken --test deep_nesting
       - uses: actions/upload-artifact@v5
         with:
           name: aiken-${{ github.sha }}-${{ runner.arch }}-${{ runner.os }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## Unreleased
+
+### Fixed
+
+- **aiken-lang**: Compile deeply nested expressions safely on native targets up to 6,147 expression levels; WebAssembly accepts up to 512. Inputs above the platform limit now produce a normal diagnostic. Fixes [#1390](https://github.com/aiken-lang/aiken/issues/1390).
+
+### Changed
+
+- **aiken-lang** (Rust API): Replace recursive expression payloads in `Error::CastDataNoAnn`, `Error::LastExpressionIsAssignment`, and `Warning::SingleWhenClause` with source spans; remove `Error::MustInferFirst`; and add `Error::ExpressionNestingLimitExceeded`. Downstream exhaustive matches and field destructuring must be updated.
+
 ## v1.1.23 - 2026-06-26
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -106,6 +106,7 @@ dependencies = [
  "pretty_assertions",
  "proptest",
  "serde",
+ "stacker",
  "strum",
  "thiserror 1.0.69",
  "uplc",

--- a/crates/aiken-lang/Cargo.toml
+++ b/crates/aiken-lang/Cargo.toml
@@ -35,6 +35,7 @@ vec1 = "1.10.1"
 
 [target.'cfg(not(target_family="wasm"))'.dependencies]
 chumsky = "0.9.2"
+stacker = "0.1.21"
 [target.'cfg(target_family="wasm")'.dependencies]
 chumsky = { version = "0.9.2", features = [
     "ahash",

--- a/crates/aiken-lang/src/ast.rs
+++ b/crates/aiken-lang/src/ast.rs
@@ -4,6 +4,8 @@
 
 pub mod well_known;
 
+#[cfg(not(target_family = "wasm"))]
+use crate::expr::with_native_stack_segment;
 use crate::{
     ast::well_known::VALIDATOR_ELSE,
     builtins,
@@ -149,7 +151,7 @@ impl TypedModule {
                             module_name: self.name.clone(),
                             function_name: func.name.clone(),
                         },
-                        func.clone(),
+                        func.stack_safe_clone(),
                     );
                 }
 
@@ -159,7 +161,7 @@ impl TypedModule {
                             module_name: self.name.clone(),
                             function_name: test.name.clone(),
                         },
-                        test.clone().into(),
+                        test.stack_safe_clone().into(),
                     );
                 }
 
@@ -169,7 +171,7 @@ impl TypedModule {
                             module_name: self.name.clone(),
                             function_name: benchmark.name.clone(),
                         },
-                        benchmark.clone().into(),
+                        benchmark.stack_safe_clone().into(),
                     );
                 }
 
@@ -197,7 +199,7 @@ impl TypedModule {
                             module_name: self.name.clone(),
                             function_name: name.clone(),
                         },
-                        value.clone(),
+                        value.stack_safe_clone(),
                     );
                 }
 
@@ -285,6 +287,18 @@ impl<T, Expr, Arg> Function<T, Expr, Arg> {
 
     pub fn is_mint(&self) -> bool {
         self.name == HANDLER_MINT
+    }
+}
+impl<Arg: Clone> Function<Rc<Type>, TypedExpr, Arg> {
+    pub(crate) fn stack_safe_clone(&self) -> Self {
+        #[cfg(not(target_family = "wasm"))]
+        {
+            let stack_size = self.body.stack_segment_size();
+            with_native_stack_segment(stack_size, || self.clone())
+        }
+
+        #[cfg(target_family = "wasm")]
+        self.clone()
     }
 }
 
@@ -791,7 +805,7 @@ impl TypedValidator {
             .iter()
             .chain(std::iter::once(&self.fallback))
             .map(|handler| {
-                let mut handler = handler.clone();
+                let mut handler = handler.stack_safe_clone();
 
                 handler.arguments = self
                     .params

--- a/crates/aiken-lang/src/expr.rs
+++ b/crates/aiken-lang/src/expr.rs
@@ -203,6 +203,106 @@ impl<T> From<Vec1Ref<T>> for Vec1<T> {
 }
 
 impl TypedExpr {
+    pub fn nesting_depth(&self) -> usize {
+        let mut maximum = 0;
+        let mut pending = vec![(self, 1)];
+
+        while let Some((expression, depth)) = pending.pop() {
+            maximum = maximum.max(depth);
+            let child_depth = depth + 1;
+
+            match expression {
+                Self::Sequence { expressions, .. }
+                | Self::Pipeline { expressions, .. }
+                | Self::Tuple {
+                    elems: expressions, ..
+                } => {
+                    pending.extend(
+                        expressions
+                            .iter()
+                            .map(|expression| (expression, child_depth)),
+                    );
+                }
+                Self::Fn { body, .. } => pending.push((body, child_depth)),
+                Self::List { elements, tail, .. } => {
+                    pending.extend(elements.iter().map(|expression| (expression, child_depth)));
+                    if let Some(tail) = tail {
+                        pending.push((tail, child_depth));
+                    }
+                }
+                Self::Call { fun, args, .. } => {
+                    pending.push((fun, child_depth));
+                    pending.extend(args.iter().map(|argument| (&argument.value, child_depth)));
+                }
+                Self::BinOp { left, right, .. }
+                | Self::Pair {
+                    fst: left,
+                    snd: right,
+                    ..
+                } => {
+                    pending.push((left, child_depth));
+                    pending.push((right, child_depth));
+                }
+                Self::Assignment { value, .. }
+                | Self::RecordAccess { record: value, .. }
+                | Self::TupleIndex { tuple: value, .. }
+                | Self::UnOp { value, .. } => pending.push((value, child_depth)),
+                Self::Trace { then, text, .. } => {
+                    pending.push((then, child_depth));
+                    pending.push((text, child_depth));
+                }
+                Self::When {
+                    subject, clauses, ..
+                } => {
+                    pending.push((subject, child_depth));
+                    pending.extend(clauses.iter().map(|clause| (&clause.then, child_depth)));
+                }
+                Self::If {
+                    branches,
+                    final_else,
+                    ..
+                } => {
+                    pending.push((final_else, child_depth));
+                    for branch in branches {
+                        pending.push((&branch.condition, child_depth));
+                        pending.push((&branch.body, child_depth));
+                    }
+                }
+                Self::RecordUpdate { spread, args, .. } => {
+                    pending.push((spread, child_depth));
+                    pending.extend(args.iter().map(|argument| (&argument.value, child_depth)));
+                }
+                Self::UInt { .. }
+                | Self::String { .. }
+                | Self::ByteArray { .. }
+                | Self::CurvePoint { .. }
+                | Self::Var { .. }
+                | Self::ModuleSelect { .. }
+                | Self::ErrorTerm { .. } => {}
+            }
+        }
+
+        maximum
+    }
+
+    #[cfg(not(target_family = "wasm"))]
+    pub(crate) fn stack_segment_size(&self) -> usize {
+        native_stack_segment_size(self.nesting_depth())
+    }
+
+    pub(crate) fn stack_safe_clone(&self) -> Self {
+        #[cfg(not(target_family = "wasm"))]
+        {
+            let stack_size = self.stack_segment_size();
+            with_native_stack_segment(stack_size, || self.clone())
+        }
+
+        #[cfg(target_family = "wasm")]
+        {
+            self.clone()
+        }
+    }
+
     pub fn is_simple_expr_to_format(&self) -> bool {
         match self {
             Self::String { .. } | Self::UInt { .. } | Self::ByteArray { .. } | Self::Var { .. } => {
@@ -782,11 +882,164 @@ pub enum UntypedExpr {
     },
 }
 
+/// Native expression depth accepted by every recursive compiler phase. The
+/// end-to-end fixture with 6,144 nested constructor calls reaches 6,147 after
+/// its sequence, assignment, and leaf nodes are included.
+#[cfg(not(target_family = "wasm"))]
+pub const MAX_EXPRESSION_NESTING: usize = 6_147;
+
+/// WebAssembly has no segmented-stack support. Keep successful recursive paths
+/// within a conservative depth while using the same iterative over-limit
+/// cleanup as native builds.
+#[cfg(target_family = "wasm")]
+pub const MAX_EXPRESSION_NESTING: usize = 512;
+
+// The 100 KiB red zone and 1 MiB minimum are the checkpoints used by stacker
+// before entering recursive compiler phases. Depth-sized segments reserve
+// 16 KiB per AST level: the constrained-stack inference fixtures cover the
+// supported expression forms, and the 4,096-level failing CLI fixture covers
+// evaluation, assertion reification, debug rendering, and destruction. Capping
+// at the configured native limit bounds a segment below 97 MiB.
+#[cfg(not(target_family = "wasm"))]
+const NATIVE_STACK_RED_ZONE: usize = 100 * 1024;
+#[cfg(not(target_family = "wasm"))]
+const NATIVE_STACK_SEGMENT: usize = 1024 * 1024;
+#[cfg(not(target_family = "wasm"))]
+const NATIVE_STACK_BYTES_PER_LEVEL: usize = 16 * 1024;
+#[cfg(not(target_family = "wasm"))]
+const NATIVE_STACK_MAXIMUM: usize = MAX_EXPRESSION_NESTING * NATIVE_STACK_BYTES_PER_LEVEL;
+
+#[cfg(not(target_family = "wasm"))]
+pub(crate) fn native_stack_segment_size(depth: usize) -> usize {
+    depth
+        .saturating_mul(NATIVE_STACK_BYTES_PER_LEVEL)
+        .clamp(NATIVE_STACK_SEGMENT, NATIVE_STACK_MAXIMUM)
+}
+
+#[cfg(not(target_family = "wasm"))]
+pub(crate) fn with_native_stack_growth<T>(operation: impl FnOnce() -> T) -> T {
+    stacker::maybe_grow(NATIVE_STACK_RED_ZONE, NATIVE_STACK_SEGMENT, operation)
+}
+
+#[cfg(not(target_family = "wasm"))]
+pub(crate) fn with_native_stack_segment<T>(stack_size: usize, operation: impl FnOnce() -> T) -> T {
+    stacker::maybe_grow(stack_size, stack_size, operation)
+}
+
 pub const DEFAULT_TODO_STR: &str = "aiken::todo";
 
 pub const DEFAULT_ERROR_STR: &str = "aiken::error";
 
 impl UntypedExpr {
+    pub fn nesting_depth(&self) -> usize {
+        let mut maximum = 0;
+        let mut pending = vec![(self, 1)];
+
+        while let Some((expression, depth)) = pending.pop() {
+            maximum = maximum.max(depth);
+            let child_depth = depth + 1;
+
+            match expression {
+                Self::Sequence { expressions, .. }
+                | Self::Tuple {
+                    elems: expressions, ..
+                }
+                | Self::LogicalOpChain { expressions, .. } => {
+                    pending.extend(
+                        expressions
+                            .iter()
+                            .map(|expression| (expression, child_depth)),
+                    );
+                }
+                Self::PipeLine { expressions, .. } => {
+                    pending.extend(
+                        expressions
+                            .iter()
+                            .map(|expression| (expression, child_depth)),
+                    );
+                }
+                Self::Fn { body, .. } => pending.push((body, child_depth)),
+                Self::List { elements, tail, .. } => {
+                    pending.extend(elements.iter().map(|expression| (expression, child_depth)));
+                    if let Some(tail) = tail {
+                        pending.push((tail, child_depth));
+                    }
+                }
+                Self::Call { fun, arguments, .. } => {
+                    pending.push((fun, child_depth));
+                    pending.extend(
+                        arguments
+                            .iter()
+                            .map(|argument| (&argument.value, child_depth)),
+                    );
+                }
+                Self::BinOp { left, right, .. }
+                | Self::Pair {
+                    fst: left,
+                    snd: right,
+                    ..
+                } => {
+                    pending.push((left, child_depth));
+                    pending.push((right, child_depth));
+                }
+                Self::Assignment { value, .. }
+                | Self::TraceIfFalse { value, .. }
+                | Self::UnOp { value, .. } => pending.push((value, child_depth)),
+                Self::Trace {
+                    then,
+                    label,
+                    arguments,
+                    ..
+                } => {
+                    pending.push((then, child_depth));
+                    pending.push((label, child_depth));
+                    pending.extend(arguments.iter().map(|argument| (argument, child_depth)));
+                }
+                Self::When {
+                    subject, clauses, ..
+                } => {
+                    pending.push((subject, child_depth));
+                    pending.extend(clauses.iter().map(|clause| (&clause.then, child_depth)));
+                }
+                Self::If {
+                    branches,
+                    final_else,
+                    ..
+                } => {
+                    pending.push((final_else, child_depth));
+                    for branch in branches {
+                        pending.push((&branch.condition, child_depth));
+                        pending.push((&branch.body, child_depth));
+                    }
+                }
+                Self::FieldAccess { container, .. } => pending.push((container, child_depth)),
+                Self::TupleIndex { tuple, .. } => pending.push((tuple, child_depth)),
+                Self::RecordUpdate {
+                    constructor,
+                    spread,
+                    arguments,
+                    ..
+                } => {
+                    pending.push((constructor, child_depth));
+                    pending.push((&spread.base, child_depth));
+                    pending.extend(
+                        arguments
+                            .iter()
+                            .map(|argument| (&argument.value, child_depth)),
+                    );
+                }
+                Self::UInt { .. }
+                | Self::String { .. }
+                | Self::Var { .. }
+                | Self::ByteArray { .. }
+                | Self::CurvePoint { .. }
+                | Self::ErrorTerm { .. } => {}
+            }
+        }
+
+        maximum
+    }
+
     // Reify some opaque 'Constant' into an 'UntypedExpr', using a Type annotation. We also need
     // an extra map to lookup record & enum constructor's names as they're completely erased when
     // in their PlutusData form, and the Type annotation only contains type name.
@@ -1424,19 +1677,19 @@ impl UntypedExpr {
             end: next.location().end,
         };
 
-        match (self.clone(), next.clone()) {
+        match (self, next) {
             (left @ Self::Sequence { .. }, right @ Self::Sequence { .. }) => Self::Sequence {
                 location,
                 expressions: vec![left, right],
             },
             (
-                _,
+                current,
                 Self::Sequence {
                     expressions: mut next_expressions,
                     ..
                 },
             ) => {
-                let mut current_expressions = vec![self];
+                let mut current_expressions = vec![current];
 
                 current_expressions.append(&mut next_expressions);
 
@@ -1446,9 +1699,9 @@ impl UntypedExpr {
                 }
             }
 
-            (_, _) => Self::Sequence {
+            (left, right) => Self::Sequence {
                 location,
-                expressions: vec![self, next],
+                expressions: vec![left, right],
             },
         }
     }
@@ -1553,6 +1806,86 @@ impl UntypedExpr {
             }
             .into(),
             return_annotation: None,
+        }
+    }
+
+    pub(crate) fn drop_iteratively(self) {
+        let mut pending = vec![self];
+
+        while let Some(expression) = pending.pop() {
+            match expression {
+                Self::Sequence { expressions, .. }
+                | Self::Tuple {
+                    elems: expressions, ..
+                }
+                | Self::LogicalOpChain { expressions, .. } => pending.extend(expressions),
+                Self::PipeLine { expressions, .. } => pending.extend(expressions),
+                Self::Fn { body, .. } => pending.push(*body),
+                Self::List { elements, tail, .. } => {
+                    pending.extend(elements);
+                    pending.extend(tail.map(|tail| *tail));
+                }
+                Self::Call { fun, arguments, .. } => {
+                    pending.push(*fun);
+                    pending.extend(arguments.into_iter().map(|argument| argument.value));
+                }
+                Self::BinOp { left, right, .. } => {
+                    pending.push(*left);
+                    pending.push(*right);
+                }
+                Self::Pair { fst, snd, .. } => {
+                    pending.push(*fst);
+                    pending.push(*snd);
+                }
+                Self::Assignment { value, .. }
+                | Self::TraceIfFalse { value, .. }
+                | Self::UnOp { value, .. } => pending.push(*value),
+                Self::Trace {
+                    then,
+                    label,
+                    arguments,
+                    ..
+                } => {
+                    pending.push(*then);
+                    pending.push(*label);
+                    pending.extend(arguments);
+                }
+                Self::When {
+                    subject, clauses, ..
+                } => {
+                    pending.push(*subject);
+                    pending.extend(clauses.into_iter().map(|clause| clause.then));
+                }
+                Self::If {
+                    branches,
+                    final_else,
+                    ..
+                } => {
+                    pending.push(*final_else);
+                    for branch in branches {
+                        pending.push(branch.condition);
+                        pending.push(branch.body);
+                    }
+                }
+                Self::FieldAccess { container, .. } => pending.push(*container),
+                Self::TupleIndex { tuple, .. } => pending.push(*tuple),
+                Self::RecordUpdate {
+                    constructor,
+                    spread,
+                    arguments,
+                    ..
+                } => {
+                    pending.push(*constructor);
+                    pending.push(*spread.base);
+                    pending.extend(arguments.into_iter().map(|argument| argument.value));
+                }
+                Self::UInt { .. }
+                | Self::String { .. }
+                | Self::Var { .. }
+                | Self::ByteArray { .. }
+                | Self::CurvePoint { .. }
+                | Self::ErrorTerm { .. } => {}
+            }
         }
     }
 }

--- a/crates/aiken-lang/src/gen_uplc.rs
+++ b/crates/aiken-lang/src/gen_uplc.rs
@@ -5,6 +5,9 @@ pub mod interner;
 pub mod stick_break_set;
 pub mod tree;
 
+#[cfg(not(target_family = "wasm"))]
+use crate::expr::{with_native_stack_growth, with_native_stack_segment};
+
 use self::{
     air::Air,
     builder::{
@@ -255,6 +258,26 @@ impl<'a> CodeGenerator<'a> {
         args: &[TypedArg],
         module_name: &str,
     ) -> Program<Name> {
+        #[cfg(not(target_family = "wasm"))]
+        {
+            let stack_size = body.stack_segment_size();
+            with_native_stack_segment(stack_size, || {
+                self.generate_raw_inner(body, args, module_name)
+            })
+        }
+
+        #[cfg(target_family = "wasm")]
+        {
+            self.generate_raw_inner(body, args, module_name)
+        }
+    }
+
+    fn generate_raw_inner(
+        &mut self,
+        body: &TypedExpr,
+        args: &[TypedArg],
+        module_name: &str,
+    ) -> Program<Name> {
         args.iter().for_each(|arg| {
             arg.get_variable_name()
                 .iter()
@@ -313,9 +336,26 @@ impl<'a> CodeGenerator<'a> {
         program
     }
 
+    fn build(
+        &mut self,
+        body: &TypedExpr,
+        module_build_name: &str,
+        context: &[TypedExpr],
+    ) -> AirTree {
+        #[cfg(not(target_family = "wasm"))]
+        {
+            with_native_stack_growth(|| self.build_inner(body, module_build_name, context))
+        }
+
+        #[cfg(target_family = "wasm")]
+        {
+            self.build_inner(body, module_build_name, context)
+        }
+    }
+
     // TODO: pass mono types to build so monomorphization
     // happens as we build the AIR Tree rather than after
-    fn build(
+    fn build_inner(
         &mut self,
         body: &TypedExpr,
         module_build_name: &str,

--- a/crates/aiken-lang/src/gen_uplc/tree.rs
+++ b/crates/aiken-lang/src/gen_uplc/tree.rs
@@ -1,3 +1,6 @@
+#[cfg(not(target_family = "wasm"))]
+use crate::expr::with_native_stack_growth;
+
 use super::air::{Air, ExpectLevel, FunctionVariants};
 use crate::{
     ast::{BinOp, Curve, Span, UnOp},
@@ -869,6 +872,18 @@ impl AirTree {
     }
 
     fn create_air_vec(&self, air_vec: &mut Vec<Air>) {
+        #[cfg(not(target_family = "wasm"))]
+        {
+            with_native_stack_growth(|| self.create_air_vec_inner(air_vec))
+        }
+
+        #[cfg(target_family = "wasm")]
+        {
+            self.create_air_vec_inner(air_vec)
+        }
+    }
+
+    fn create_air_vec_inner(&self, air_vec: &mut Vec<Air>) {
         match self {
             AirTree::Let { name, value, then } => {
                 air_vec.push(Air::Let { name: name.clone() });

--- a/crates/aiken-lang/src/test_framework.rs
+++ b/crates/aiken-lang/src/test_framework.rs
@@ -1,3 +1,6 @@
+#[cfg(not(target_family = "wasm"))]
+use crate::expr::{native_stack_segment_size, with_native_stack_segment};
+
 use crate::{
     ast::{
         BinOp, DataTypeKey, IfBranch, OnTestFailure, Span, TraceLevel, Tracing, TypedArg,
@@ -27,7 +30,7 @@ use std::{
     rc::Rc,
 };
 use uplc::{
-    ast::{Constant, Data, Name, NamedDeBruijn, Program, Term},
+    ast::{Constant, Data, Name, NamedDeBruijn, Program, Term, plutus_data_nesting_depth},
     machine::{cost_model::ExBudget, eval_result::EvalResult},
 };
 use vec1::{Vec1, vec1};
@@ -64,6 +67,44 @@ pub enum Test {
 
 unsafe impl Send for Test {}
 
+#[cfg(not(target_family = "wasm"))]
+fn uplc_program_stack_size<T>(program: &Program<T>) -> usize {
+    native_stack_segment_size(program.nesting_depth())
+}
+
+#[cfg(not(target_family = "wasm"))]
+fn unit_test_stack_size(test: &UnitTest) -> usize {
+    uplc_program_stack_size(&test.program)
+}
+
+#[cfg(not(target_family = "wasm"))]
+fn property_test_stack_size(test: &PropertyTest) -> usize {
+    uplc_program_stack_size(&test.program).max(uplc_program_stack_size(&test.fuzzer.program))
+}
+
+#[cfg(not(target_family = "wasm"))]
+fn program_with_data_nesting_depth<T>(program: &Program<T>, data: &PlutusData) -> usize {
+    let applied_program_depth = program.nesting_depth().saturating_add(1);
+    let applied_data_depth = plutus_data_nesting_depth(data).saturating_add(3);
+    applied_program_depth.max(applied_data_depth)
+}
+
+#[cfg(not(target_family = "wasm"))]
+fn program_with_data_stack_size<T>(program: &Program<T>, data: &PlutusData) -> usize {
+    native_stack_segment_size(program_with_data_nesting_depth(program, data))
+}
+
+fn test_program_source(program: &Program<Name>) -> String {
+    #[cfg(not(target_family = "wasm"))]
+    {
+        let stack_size = uplc_program_stack_size(program);
+        with_native_stack_segment(stack_size, || program.to_pretty())
+    }
+
+    #[cfg(target_family = "wasm")]
+    program.to_pretty()
+}
+
 impl Test {
     pub fn unit_test(
         generator: &mut CodeGenerator<'_>,
@@ -71,33 +112,18 @@ impl Test {
         module_name: String,
         input_path: PathBuf,
     ) -> Test {
+        #[cfg(not(target_family = "wasm"))]
+        let stack_size = test.body.stack_segment_size();
+
         let program = generator.generate_raw(&test.body, &[], &module_name);
+        let body = test.body;
 
-        let assertion = match test.body.try_into() {
-            Err(..) => None,
-            Ok(Assertion { bin_op, head, tail }) => {
-                let as_constant = |generator: &mut CodeGenerator<'_>, side| {
-                    Program::<NamedDeBruijn>::try_from(generator.generate_raw(
-                        &side,
-                        &[],
-                        &module_name,
-                    ))
-                    .expect("failed to convert assertion operand to NamedDeBruijn")
-                    .eval(ExBudget::max())
-                    .unwrap_constant()
-                    .map(|cst| (cst, side.tipo()))
-                };
+        #[cfg(not(target_family = "wasm"))]
+        let assertion =
+            with_native_stack_segment(stack_size, || body.try_into().ok().map(Box::new));
 
-                // Assertion at this point is evaluated so it's not just a normal assertion
-                Some(Assertion {
-                    bin_op,
-                    head: as_constant(generator, head.expect("cannot be Err at this point")),
-                    tail: tail
-                        .expect("cannot be Err at this point")
-                        .try_mapped(|e| as_constant(generator, e)),
-                })
-            }
-        };
+        #[cfg(target_family = "wasm")]
+        let assertion = body.try_into().ok().map(Box::new);
 
         Test::UnitTest(UnitTest {
             input_path,
@@ -129,11 +155,13 @@ impl Test {
 
     pub fn from_function_definition(
         generator: &mut CodeGenerator<'_>,
-        test: TypedTest,
+        test: &TypedTest,
         module_name: String,
         input_path: PathBuf,
         kind: RunnableKind,
     ) -> Test {
+        let test = test.stack_safe_clone();
+
         if test.arguments.is_empty() {
             if matches!(kind, RunnableKind::Bench) {
                 unreachable!("benchmark must have at least one argument");
@@ -192,6 +220,16 @@ impl Test {
         }
     }
 
+    #[cfg(not(target_family = "wasm"))]
+    #[doc(hidden)]
+    pub fn native_stack_size(&self) -> Option<usize> {
+        match self {
+            Test::UnitTest(test) => Some(unit_test_stack_size(test)),
+            Test::PropertyTest(test) => Some(property_test_stack_size(test)),
+            Test::Benchmark(_) => None,
+        }
+    }
+
     pub fn run(
         self,
         seed: u32,
@@ -222,13 +260,28 @@ pub struct UnitTest {
     pub name: String,
     pub on_test_failure: OnTestFailure,
     pub program: Program<Name>,
-    pub assertion: Option<Assertion<(Constant, Rc<Type>)>>,
+    pub assertion: Option<Box<Assertion<TypedExpr>>>,
 }
 
 unsafe impl Send for UnitTest {}
 
 impl UnitTest {
     pub fn run(
+        self,
+        plutus_version: &PlutusVersion,
+        tracing: Tracing,
+    ) -> UnitTestResult<(Constant, Rc<Type>)> {
+        #[cfg(not(target_family = "wasm"))]
+        {
+            let stack_size = unit_test_stack_size(&self);
+            with_native_stack_segment(stack_size, || self.run_inner(plutus_version, tracing))
+        }
+
+        #[cfg(target_family = "wasm")]
+        self.run_inner(plutus_version, tracing)
+    }
+
+    fn run_inner(
         self,
         plutus_version: &PlutusVersion,
         tracing: Tracing,
@@ -256,11 +309,17 @@ impl UnitTest {
 
         UnitTestResult {
             success,
-            test: self.to_owned(),
+            test: self,
             spent_budget: eval_result.cost(),
             logs,
-            assertion: self.assertion,
+            assertion: None,
+            #[cfg(not(target_family = "wasm"))]
+            assertion_stack_size: native_stack_segment_size(0),
         }
+    }
+
+    pub fn program_source(&self) -> String {
+        test_program_source(&self.program)
     }
 }
 
@@ -362,6 +421,22 @@ impl PropertyTest {
         n: usize,
         plutus_version: &PlutusVersion,
     ) -> PropertyTestResult<PlutusData> {
+        #[cfg(not(target_family = "wasm"))]
+        {
+            let stack_size = property_test_stack_size(&self);
+            with_native_stack_segment(stack_size, || self.run_inner(seed, n, plutus_version))
+        }
+
+        #[cfg(target_family = "wasm")]
+        self.run_inner(seed, n, plutus_version)
+    }
+
+    fn run_inner(
+        self,
+        seed: u32,
+        n: usize,
+        plutus_version: &PlutusVersion,
+    ) -> PropertyTestResult<PlutusData> {
         let mut labels = BTreeMap::new();
         let mut remaining = n;
 
@@ -372,11 +447,9 @@ impl PropertyTest {
             plutus_version,
         ) {
             Ok(None) => (Vec::new(), Ok(None), n),
-            Ok(Some(counterexample)) => (
-                self.eval(&counterexample.value, plutus_version).logs(),
-                Ok(Some(counterexample.value)),
-                n - remaining,
-            ),
+            Ok(Some(counterexample)) => {
+                self.finish_counterexample(counterexample, n - remaining, plutus_version)
+            }
             Err(FuzzerError { logs, uplc_error }) => (logs, Err(uplc_error), n - remaining + 1),
         };
 
@@ -387,6 +460,20 @@ impl PropertyTest {
             labels,
             logs,
         }
+    }
+    fn finish_counterexample(
+        &self,
+        counterexample: Counterexample<'_>,
+        iterations: usize,
+        plutus_version: &PlutusVersion,
+    ) -> (
+        Vec<String>,
+        Result<Option<PlutusData>, uplc::machine::Error>,
+        usize,
+    ) {
+        let logs = self.eval(&counterexample.value, plutus_version).logs();
+        let Counterexample { value, .. } = counterexample;
+        (logs, Ok(Some(value)), iterations)
     }
 
     pub fn run_n_times<'a>(
@@ -406,6 +493,16 @@ impl PropertyTest {
 
         Ok(counterexample)
     }
+    fn sample_fuzzer(&self, prng: &Prng) -> Result<Option<(Prng, PlutusData)>, FuzzerError> {
+        #[cfg(not(target_family = "wasm"))]
+        {
+            let stack_size = program_with_data_stack_size(&self.fuzzer.program, prng.uplc_ref());
+            with_native_stack_segment(stack_size, || prng.sample(&self.fuzzer.program))
+        }
+
+        #[cfg(target_family = "wasm")]
+        prng.sample(&self.fuzzer.program)
+    }
 
     fn run_once<'a>(
         &'a self,
@@ -415,10 +512,9 @@ impl PropertyTest {
     ) -> Result<(Prng, Option<Counterexample<'a>>), FuzzerError> {
         use OnTestFailure::*;
 
-        let (next_prng, value) = prng
-            .sample(&self.fuzzer.program)?
+        let (next_prng, value) = self
+            .sample_fuzzer(&prng)?
             .expect("A seeded PRNG returned 'None' which indicates a fuzzer is ill-formed and implemented wrongly; please contact library's authors.");
-
         let result = self.eval(&value, plutus_version);
 
         for label in result.labels() {
@@ -432,7 +528,6 @@ impl PropertyTest {
         }
 
         let is_failure = result.failed(true, &plutus_version.into());
-
         let is_success = !is_failure;
 
         let keep_counterexample = match self.on_test_failure {
@@ -445,32 +540,9 @@ impl PropertyTest {
                 value,
                 choices: next_prng.choices(),
                 cache: Cache::new(|choices| {
-                    match Prng::from_choices(choices).sample(&self.fuzzer.program) {
-                        Err(..) => Status::Invalid,
-                        Ok(None) => Status::Invalid,
-                        Ok(Some((_, value))) => {
-                            let is_failure = self
-                                .eval(&value, plutus_version)
-                                .failed(true, &plutus_version.into());
-
-                            match self.on_test_failure {
-                                FailImmediately | SucceedImmediately => {
-                                    if is_failure {
-                                        Status::Keep(value)
-                                    } else {
-                                        Status::Ignore
-                                    }
-                                }
-
-                                SucceedEventually => {
-                                    if is_failure {
-                                        Status::Ignore
-                                    } else {
-                                        Status::Keep(value)
-                                    }
-                                }
-                            }
-                        }
+                    match self.sample_fuzzer(&Prng::from_choices(choices)) {
+                        Err(..) | Ok(None) => Status::Invalid,
+                        Ok(Some((_, value))) => self.status_for_value(value, plutus_version),
                     }
                 }),
             };
@@ -485,12 +557,45 @@ impl PropertyTest {
         }
     }
 
+    fn status_for_value(
+        &self,
+        value: PlutusData,
+        plutus_version: &PlutusVersion,
+    ) -> Status<PlutusData> {
+        use OnTestFailure::*;
+
+        let is_failure = self
+            .eval(&value, plutus_version)
+            .failed(true, &plutus_version.into());
+
+        match self.on_test_failure {
+            FailImmediately | SucceedImmediately if is_failure => Status::Keep(value),
+            SucceedEventually if !is_failure => Status::Keep(value),
+            _ => Status::Ignore,
+        }
+    }
+
     pub fn eval(&self, value: &PlutusData, plutus_version: &PlutusVersion) -> EvalResult {
+        #[cfg(not(target_family = "wasm"))]
+        {
+            let stack_size = program_with_data_stack_size(&self.program, value);
+            with_native_stack_segment(stack_size, || self.eval_inner(value, plutus_version))
+        }
+
+        #[cfg(target_family = "wasm")]
+        self.eval_inner(value, plutus_version)
+    }
+
+    fn eval_inner(&self, value: &PlutusData, plutus_version: &PlutusVersion) -> EvalResult {
         let program = self.program.apply_data(value.clone());
 
         Program::<NamedDeBruijn>::try_from(program)
             .unwrap()
             .eval_version(ExBudget::max(), &plutus_version.into())
+    }
+
+    pub fn program_source(&self) -> String {
+        test_program_source(&self.program)
     }
 }
 
@@ -607,6 +712,10 @@ impl Benchmark {
             .unwrap()
             .eval_version(ExBudget::max(), &plutus_version.into())
     }
+
+    pub fn program_source(&self) -> String {
+        self.program.to_pretty()
+    }
 }
 
 /// ----- PRNG -----------------------------------------------------------------
@@ -645,9 +754,12 @@ impl Prng {
     const NONE: u64 = 1;
 
     pub fn uplc(&self) -> PlutusData {
+        self.uplc_ref().clone()
+    }
+
+    fn uplc_ref(&self) -> &PlutusData {
         match self {
-            Prng::Seeded { uplc, .. } => uplc.clone(),
-            Prng::Replayed { uplc, .. } => uplc.clone(),
+            Prng::Seeded { uplc, .. } | Prng::Replayed { uplc, .. } => uplc,
         }
     }
 
@@ -702,13 +814,20 @@ impl Prng {
     ) -> Result<Option<(Prng, PlutusData)>, FuzzerError> {
         let program = Program::<NamedDeBruijn>::try_from(fuzzer.apply_data(self.uplc())).unwrap();
         let result = program.eval(ExBudget::max());
+        Self::from_eval_result(result)
+    }
+
+    fn from_eval_result(result: EvalResult) -> Result<Option<(Prng, PlutusData)>, FuzzerError> {
+        let EvalResult { result, traces, .. } = result;
         result
-            .result()
-            .map_err(|uplc_error| FuzzerError {
-                logs: result.logs(),
+            .map(Prng::from_result)
+            .map_err(move |uplc_error| FuzzerError {
+                logs: traces
+                    .into_iter()
+                    .filter_map(uplc::machine::Trace::unwrap_log)
+                    .collect(),
                 uplc_error,
             })
-            .map(Prng::from_result)
     }
 
     /// Obtain a Prng back from a fuzzer execution. As a reminder, fuzzers have the following
@@ -799,7 +918,12 @@ impl Counterexample<'_> {
             return true;
         }
 
-        match self.cache.get(choices) {
+        let status = self.cache.get(choices);
+        self.consider_status(choices, status)
+    }
+
+    fn consider_status(&mut self, choices: &[u8], status: Status<PlutusData>) -> bool {
+        match status {
             Status::Invalid | Status::Ignore => false,
             Status::Keep(value) => {
                 // If these new choices are shorter or smaller, then we pick them
@@ -1080,33 +1204,41 @@ where
     }
 
     pub fn get(&mut self, choices: &[u8]) -> Status<T> {
-        if let Some((prefix, status)) = self.db.get_longest_common_prefix(choices) {
-            let status = status.clone();
-            if status != Status::Invalid || prefix == choices {
-                return status;
-            }
+        if let Some(status) = self.cached(choices) {
+            return status;
         }
 
         let status = self.run.deref()(choices);
+        self.store(choices, status)
+    }
 
+    fn cached(&self, choices: &[u8]) -> Option<Status<T>> {
+        self.db
+            .get_longest_common_prefix(choices)
+            .and_then(|(prefix, status)| {
+                let status = status.clone();
+                (!matches!(status, Status::Invalid) || prefix == choices).then_some(status)
+            })
+    }
+
+    fn store(&mut self, choices: &[u8], status: Status<T>) -> Status<T> {
         // Clear longer path on non-invalid cases, as we will never reach them
         // again due to a now-shorter prefix found.
         //
         // This hopefully keeps the cache under a reasonable size as we prune
         // the tree as we discover shorter paths.
-        if status != Status::Invalid {
+        if !matches!(status, Status::Invalid) {
             let keys = self
                 .db
                 .iter_prefix(choices)
-                .map(|(k, _)| k)
+                .map(|(key, _)| key)
                 .collect::<Vec<_>>();
-            for k in keys {
-                self.db.remove(k);
+            for key in keys {
+                self.db.remove(key);
             }
         }
 
         self.db.insert(choices, status.clone());
-
         status
     }
 }
@@ -1179,6 +1311,30 @@ impl<U, T> TestResult<U, T> {
         }
     }
 
+    #[cfg(not(target_family = "wasm"))]
+    fn native_stack_size(&self) -> usize {
+        match self {
+            TestResult::UnitTestResult(UnitTestResult {
+                test,
+                assertion_stack_size,
+                ..
+            }) => unit_test_stack_size(test).max(*assertion_stack_size),
+            TestResult::PropertyTestResult(PropertyTestResult { test, .. }) => {
+                property_test_stack_size(test)
+            }
+            TestResult::BenchmarkResult(_) => native_stack_segment_size(0),
+        }
+    }
+
+    #[cfg(not(target_family = "wasm"))]
+    #[doc(hidden)]
+    pub fn with_native_stack<R>(tests: Vec<Self>, operation: impl FnOnce(Vec<Self>) -> R) -> R {
+        match tests.iter().map(Self::native_stack_size).max() {
+            Some(stack_size) => with_native_stack_segment(stack_size, || operation(tests)),
+            None => operation(tests),
+        }
+    }
+
     pub fn logs(&self) -> &[String] {
         match self {
             TestResult::UnitTestResult(UnitTestResult { logs, .. })
@@ -1197,6 +1353,8 @@ pub struct UnitTestResult<T> {
     pub logs: Vec<String>,
     pub test: UnitTest,
     pub assertion: Option<Assertion<T>>,
+    #[cfg(not(target_family = "wasm"))]
+    assertion_stack_size: usize,
 }
 
 unsafe impl<T> Send for UnitTestResult<T> {}
@@ -1206,32 +1364,67 @@ impl UnitTestResult<(Constant, Rc<Type>)> {
         self,
         data_types: &IndexMap<&DataTypeKey, &TypedDataType>,
     ) -> UnitTestResult<UntypedExpr> {
+        #[cfg(not(target_family = "wasm"))]
+        {
+            let assertion_depth = self
+                .assertion
+                .as_ref()
+                .map(|assertion| {
+                    let head_depth = assertion
+                        .head
+                        .as_ref()
+                        .map(|(constant, _)| constant.nesting_depth())
+                        .unwrap_or_default();
+                    let tail_depth = assertion
+                        .tail
+                        .as_ref()
+                        .map(|constants| {
+                            constants
+                                .iter()
+                                .map(|(constant, _)| constant.nesting_depth())
+                                .max()
+                                .unwrap_or_default()
+                        })
+                        .unwrap_or_default();
+
+                    head_depth.max(tail_depth)
+                })
+                .unwrap_or_default();
+            let assertion_stack_size = native_stack_segment_size(assertion_depth);
+            let stack_size = unit_test_stack_size(&self.test).max(assertion_stack_size);
+            let mut result = self;
+            result.assertion_stack_size = assertion_stack_size;
+            with_native_stack_segment(stack_size, || result.reify_inner(data_types))
+        }
+
+        #[cfg(target_family = "wasm")]
+        self.reify_inner(data_types)
+    }
+
+    fn reify_inner(
+        self,
+        data_types: &IndexMap<&DataTypeKey, &TypedDataType>,
+    ) -> UnitTestResult<UntypedExpr> {
         UnitTestResult {
             success: self.success,
             spent_budget: self.spent_budget,
             logs: self.logs,
             test: self.test,
-            assertion: self.assertion.and_then(|assertion| {
-                // No need to spend time/cpu on reifying assertions for successful
-                // tests since they aren't shown.
-                if self.success {
-                    return None;
-                }
-
-                Some(Assertion {
-                    bin_op: assertion.bin_op,
-                    head: assertion.head.map(|(cst, tipo)| {
-                        UntypedExpr::reify_constant(data_types, cst, tipo)
+            assertion: self.assertion.map(|assertion| Assertion {
+                bin_op: assertion.bin_op,
+                head: assertion.head.map(|(constant, tipo)| {
+                    UntypedExpr::reify_constant(data_types, constant, tipo)
+                        .expect("failed to reify assertion operand?")
+                }),
+                tail: assertion.tail.map(|expressions| {
+                    expressions.mapped(|(constant, tipo)| {
+                        UntypedExpr::reify_constant(data_types, constant, tipo)
                             .expect("failed to reify assertion operand?")
-                    }),
-                    tail: assertion.tail.map(|xs| {
-                        xs.mapped(|(cst, tipo)| {
-                            UntypedExpr::reify_constant(data_types, cst, tipo)
-                                .expect("failed to reify assertion operand?")
-                        })
-                    }),
-                })
+                    })
+                }),
             }),
+            #[cfg(not(target_family = "wasm"))]
+            assertion_stack_size: self.assertion_stack_size,
         }
     }
 }
@@ -1252,21 +1445,40 @@ impl PropertyTestResult<PlutusData> {
         self,
         data_types: &IndexMap<&DataTypeKey, &TypedDataType>,
     ) -> PropertyTestResult<UntypedExpr> {
-        PropertyTestResult {
-            counterexample: self.counterexample.map(|ok| {
-                ok.map(|counterexample| {
-                    UntypedExpr::reify_data(
-                        data_types,
-                        counterexample,
-                        self.test.fuzzer.type_info.clone(),
-                    )
+        #[cfg(not(target_family = "wasm"))]
+        {
+            let stack_size = property_test_stack_size(&self.test);
+            with_native_stack_segment(stack_size, || self.reify_inner(data_types))
+        }
+
+        #[cfg(target_family = "wasm")]
+        self.reify_inner(data_types)
+    }
+
+    fn reify_inner(
+        self,
+        data_types: &IndexMap<&DataTypeKey, &TypedDataType>,
+    ) -> PropertyTestResult<UntypedExpr> {
+        let PropertyTestResult {
+            test,
+            counterexample,
+            iterations,
+            labels,
+            logs,
+        } = self;
+        let counterexample = counterexample.map(|ok| {
+            ok.map(|counterexample| {
+                UntypedExpr::reify_data(data_types, counterexample, test.fuzzer.type_info.clone())
                     .expect("failed to reify counterexample?")
-                })
-            }),
-            iterations: self.iterations,
-            test: self.test,
-            labels: self.labels,
-            logs: self.logs,
+            })
+        });
+
+        PropertyTestResult {
+            test,
+            counterexample,
+            iterations,
+            labels,
+            logs,
         }
     }
 }
@@ -1276,6 +1488,84 @@ pub struct Assertion<T> {
     pub bin_op: BinOp,
     pub head: Result<T, ()>,
     pub tail: Result<Vec1<T>, ()>,
+}
+
+impl Assertion<TypedExpr> {
+    #[cfg(not(target_family = "wasm"))]
+    fn stack_segment_size(&self) -> usize {
+        let head_depth = self
+            .head
+            .as_ref()
+            .map(TypedExpr::nesting_depth)
+            .unwrap_or_default();
+        let tail_depth = self
+            .tail
+            .as_ref()
+            .map(|expressions| {
+                expressions
+                    .iter()
+                    .map(TypedExpr::nesting_depth)
+                    .max()
+                    .unwrap_or_default()
+            })
+            .unwrap_or_default();
+
+        native_stack_segment_size(head_depth.max(tail_depth))
+    }
+
+    pub fn evaluate(
+        self,
+        generator: &mut CodeGenerator<'_>,
+        module_name: &str,
+    ) -> Assertion<(Constant, Rc<Type>)> {
+        #[cfg(not(target_family = "wasm"))]
+        {
+            let stack_size = self.stack_segment_size();
+            with_native_stack_segment(stack_size, || self.evaluate_inner(generator, module_name))
+        }
+
+        #[cfg(target_family = "wasm")]
+        self.evaluate_inner(generator, module_name)
+    }
+
+    fn evaluate_inner(
+        self,
+        generator: &mut CodeGenerator<'_>,
+        module_name: &str,
+    ) -> Assertion<(Constant, Rc<Type>)> {
+        let Assertion { bin_op, head, tail } = self;
+        let as_constant = |generator: &mut CodeGenerator<'_>, expression: TypedExpr| {
+            let tipo = expression.tipo();
+            Program::<NamedDeBruijn>::try_from(generator.generate_raw(
+                &expression,
+                &[],
+                module_name,
+            ))
+            .expect("failed to convert assertion operand to NamedDeBruijn")
+            .eval(ExBudget::max())
+            .unwrap_constant()
+            .map(|constant| (constant, tipo))
+        };
+
+        Assertion {
+            bin_op,
+            head: as_constant(generator, head.expect("cannot be Err at this point")),
+            tail: tail
+                .expect("cannot be Err at this point")
+                .try_mapped(|expression| as_constant(generator, expression)),
+        }
+    }
+
+    pub fn discard(self) {
+        #[cfg(not(target_family = "wasm"))]
+        {
+            let stack_size = self.stack_segment_size();
+            with_native_stack_segment(stack_size, || drop(self));
+        }
+
+        #[cfg(target_family = "wasm")]
+        drop(self);
+    }
 }
 
 impl TryFrom<TypedExpr> for Assertion<TypedExpr> {
@@ -1662,6 +1952,71 @@ unsafe impl Sync for BenchmarkResult {}
 #[cfg(test)]
 mod test {
     use super::*;
+
+    #[cfg(not(target_family = "wasm"))]
+    #[test]
+    fn deeply_nested_program_constant_renders_on_a_small_native_stack() {
+        use std::thread;
+        use uplc::ast::Type as UplcType;
+
+        let mut constant = Constant::Unit;
+        for _ in 0..4_096 {
+            constant = Constant::ProtoPair(
+                UplcType::Unit,
+                UplcType::Unit,
+                Rc::new(Constant::Unit),
+                Rc::new(constant),
+            );
+        }
+
+        let test = UnitTest {
+            input_path: PathBuf::new(),
+            module: String::new(),
+            name: String::new(),
+            on_test_failure: OnTestFailure::FailImmediately,
+            program: Program::<Name> {
+                version: (1, 0, 0),
+                term: Term::Constant(Rc::new(constant)),
+            },
+            assertion: None,
+        };
+
+        thread::Builder::new()
+            .name("deep-program-constant-small-stack".to_string())
+            .stack_size(128 * 1024)
+            .spawn(move || {
+                let source = test.program_source();
+                assert!(source.contains("pair"));
+
+                let stack_size = unit_test_stack_size(&test);
+                with_native_stack_segment(stack_size, || drop(test));
+            })
+            .expect("spawn small-stack program rendering thread")
+            .join()
+            .expect("render deeply nested program constant");
+    }
+
+    #[cfg(not(target_family = "wasm"))]
+    #[test]
+    fn applied_data_nesting_matches_the_constructed_program() {
+        let program = Program::<Name> {
+            version: (1, 0, 0),
+            term: Term::Constant(Rc::new(Constant::Unit)),
+        };
+        let shallow = Data::list(Vec::new());
+        let mut nested = shallow.clone();
+
+        for _ in 0..8 {
+            nested = Data::list(vec![nested]);
+        }
+
+        for data in [shallow, nested] {
+            assert_eq!(
+                program_with_data_nesting_depth(&program, &data),
+                program.apply_data(data.clone()).nesting_depth(),
+            );
+        }
+    }
 
     #[test]
     fn test_cache() {

--- a/crates/aiken-lang/src/tests/check.rs
+++ b/crates/aiken-lang/src/tests/check.rs
@@ -1092,10 +1092,12 @@ fn assignement_last_expr_if_first_branch() {
         }
     "#;
 
-    assert!(matches!(
-        check(parse(source_code)),
-        Err((_, Error::LastExpressionIsAssignment { .. }))
-    ))
+    let Err((_, Error::LastExpressionIsAssignment { value_location, .. })) =
+        check(parse(source_code))
+    else {
+        panic!("expected last-assignment error");
+    };
+    assert_eq!(&source_code[value_location.start..value_location.end], "1");
 }
 
 #[test]
@@ -3346,6 +3348,119 @@ fn mutually_recursive_1() {
     "#;
 
     assert!(check(parse(source_code)).is_ok());
+}
+
+#[test]
+fn acyclic_forward_dependency_is_generalised_before_use() {
+    let source_code = r#"
+        fn use_later_identity(value) {
+            later_identity(value)
+        }
+
+        fn later_identity(value) {
+            value
+        }
+
+        test use_forward_dependency_at_multiple_types() {
+            use_later_identity(1) == 1 && use_later_identity(True)
+        }
+    "#;
+
+    check(parse(source_code)).expect("acyclic forward dependency should type check");
+}
+
+#[test]
+fn pending_function_inference_preserves_shadowing_caller_binding() {
+    let source_code = r#"
+        fn caller(third) {
+            second() + third
+        }
+
+        fn second() {
+            third()
+        }
+
+        fn third() {
+            41
+        }
+
+        test caller_local_shadowing() {
+            caller(1) == 42
+        }
+    "#;
+
+    check(parse(source_code)).expect("caller argument should continue to shadow module function");
+}
+
+#[test]
+fn pending_function_generalisation_survives_local_shadowing() {
+    let source_code = r#"
+        fn caller(identity) {
+            later() + identity
+        }
+
+        fn later() {
+            identity(1)
+        }
+
+        fn identity(value) {
+            value
+        }
+
+        test identity_remains_polymorphic() {
+            caller(0) == 1
+                && identity(1) == 1
+                && identity(True)
+        }
+    "#;
+
+    check(parse(source_code)).expect("shadowed pending module function should remain polymorphic");
+}
+
+#[test]
+fn direct_recursion_remains_ungeneralised_during_inference() {
+    let source_code = r#"
+        fn directly_recursive(value, recurse) {
+            if recurse {
+                directly_recursive(value, False)
+            } else {
+                value
+            }
+        }
+
+        test use_direct_recursion() {
+            directly_recursive(1, True) == 1
+        }
+    "#;
+
+    check(parse(source_code)).expect("direct recursion should type check");
+}
+
+#[test]
+fn mutual_recursion_remains_ungeneralised_during_inference() {
+    let source_code = r#"
+        fn mutually_recursive_left(value, recurse) {
+            if recurse {
+                mutually_recursive_right(value, False)
+            } else {
+                value
+            }
+        }
+
+        fn mutually_recursive_right(value, recurse) {
+            if recurse {
+                mutually_recursive_left(value, False)
+            } else {
+                value
+            }
+        }
+
+        test use_mutual_recursion() {
+            mutually_recursive_left(1, True) == 1
+        }
+    "#;
+
+    check(parse(source_code)).expect("mutual recursion should type check");
 }
 
 #[test]

--- a/crates/aiken-lang/src/tests/deep_nesting.rs
+++ b/crates/aiken-lang/src/tests/deep_nesting.rs
@@ -1,0 +1,237 @@
+#[cfg(not(target_family = "wasm"))]
+use crate::expr::{native_stack_segment_size, with_native_stack_segment};
+use crate::{
+    IdGenerator,
+    ast::{Definition, ModuleKind, TraceLevel, Tracing, TypedModule, UntypedModule},
+    builtins,
+    expr::{MAX_EXPRESSION_NESTING, UntypedExpr},
+    parser,
+    tipo::{
+        TypeInfo,
+        error::{Error, Warning},
+    },
+};
+
+use std::collections::HashMap;
+
+const MODULE_NAME: &str = "deep_nesting";
+const PACKAGE_NAME: &str = "local/deep_nesting";
+
+fn push_deep_constructor(source: &mut String, depth: usize) {
+    for _ in 0..depth {
+        source.push_str("S(");
+    }
+
+    source.push('Z');
+
+    for _ in 0..depth {
+        source.push(')');
+    }
+}
+
+fn deep_module(depth: usize) -> String {
+    let mut source = String::with_capacity(160 + depth * 3);
+    source.push_str("type Natural {\n  Z\n  S(Natural)\n}\n\ntest deeply_nested_constructor() {\n  let value = ");
+    push_deep_constructor(&mut source, depth);
+    source.push_str("\n  value == value\n}\n");
+    source
+}
+
+fn deep_single_when_module(depth: usize) -> String {
+    let mut source = String::with_capacity(200 + depth * 3);
+    source.push_str("type Natural {\n  Z\n  S(Natural)\n}\n\ntest deeply_nested_when() {\n  when ");
+    push_deep_constructor(&mut source, depth);
+    source.push_str(" is {\n    value -> value == value\n  }\n}\n");
+    source
+}
+
+fn deep_if_module(depth: usize) -> String {
+    let mut source = String::with_capacity(220 + depth * 3);
+    source.push_str(
+        "type Natural {\n  Z\n  S(Natural)\n}\n\ntest deeply_nested_if() {\n  let value = if True {\n    ",
+    );
+    push_deep_constructor(&mut source, depth);
+    source.push_str("\n  } else {\n    Z\n  }\n  value == value\n}\n");
+    source
+}
+
+fn deep_record_update_module(depth: usize) -> String {
+    let mut source = String::with_capacity(280 + depth * 3);
+    source.push_str(
+        "type Natural {\n  Z\n  S(Natural)\n}\n\ntype Boxed {\n  value: Natural\n}\n\ntest deeply_nested_record_update() {\n  let original = Boxed { value: Z }\n  let updated = Boxed { ..original, value: ",
+    );
+    push_deep_constructor(&mut source, depth);
+    source.push_str(" }\n  updated == updated\n}\n");
+    source
+}
+
+fn deep_discarded_void_expression_module(depth: usize) -> String {
+    let mut source = String::with_capacity(260 + depth * 3);
+    source.push_str(
+        "type Natural {\n  Z\n  S(Natural)\n}\n\nfn discard(_value: Natural) {\n  Void\n}\n\ntest deeply_nested_discarded_void_expression() {\n  discard(",
+    );
+    push_deep_constructor(&mut source, depth);
+    source.push_str(")\n  True\n}\n");
+    source
+}
+
+fn parse_generated(source: String, expectation: &str) -> UntypedModule {
+    let (mut module, _) = parser::module(&source, ModuleKind::Lib).expect(expectation);
+    module.name = MODULE_NAME.to_string();
+    module
+}
+
+fn parse(depth: usize) -> UntypedModule {
+    parse_generated(deep_module(depth), "deep module should parse")
+}
+
+fn parse_deep_single_when(depth: usize) -> UntypedModule {
+    parse_generated(
+        deep_single_when_module(depth),
+        "deep single-when module should parse",
+    )
+}
+
+fn test_body(module: &UntypedModule) -> &UntypedExpr {
+    module
+        .definitions
+        .iter()
+        .find_map(|definition| match definition {
+            Definition::Test(test) => Some(&test.body),
+            _ => None,
+        })
+        .expect("generated module contains a test")
+}
+
+fn infer_result(module: UntypedModule) -> Result<TypedModule, Error> {
+    let id_gen = IdGenerator::new();
+    let mut module_types = HashMap::<String, TypeInfo>::new();
+    module_types.insert(builtins::PRELUDE.to_string(), builtins::prelude(&id_gen));
+    module_types.insert(builtins::BUILTIN.to_string(), builtins::plutus(&id_gen));
+    let mut warnings = Vec::<Warning>::new();
+
+    module.infer(
+        &id_gen,
+        ModuleKind::Lib,
+        PACKAGE_NAME,
+        &module_types,
+        Tracing::All(TraceLevel::Verbose),
+        &mut warnings,
+        None,
+    )
+}
+
+fn infer(module: UntypedModule) -> TypedModule {
+    infer_result(module).expect("deep module should infer")
+}
+
+#[test]
+fn parses_and_drops_deep_constructor_sequence() {
+    let module = parse(2_048);
+    drop(module);
+}
+
+#[test]
+fn infers_deep_constructor_sequence() {
+    let module = infer(parse(2_048));
+    drop(module);
+}
+
+#[cfg(not(target_family = "wasm"))]
+#[test]
+fn configured_native_limit_matches_the_covered_constructor_chain() {
+    let module = parse(6_144);
+    assert_eq!(test_body(&module).nesting_depth(), MAX_EXPRESSION_NESTING);
+
+    let stack_size = native_stack_segment_size(MAX_EXPRESSION_NESTING);
+    with_native_stack_segment(stack_size, || drop(module));
+}
+
+#[test]
+fn rejects_excessive_nesting_with_a_normal_error() {
+    for constructor_depth in [
+        MAX_EXPRESSION_NESTING + 1,
+        MAX_EXPRESSION_NESTING.saturating_mul(10),
+    ] {
+        let error = infer_result(parse(constructor_depth))
+            .expect_err("excessively nested module should be rejected");
+
+        assert_eq!(
+            error.to_string(),
+            "Expression nesting exceeds the supported limit."
+        );
+
+        assert!(matches!(
+            error,
+            Error::ExpressionNestingLimitExceeded {
+                depth,
+                limit: MAX_EXPRESSION_NESTING,
+                ..
+            } if depth > MAX_EXPRESSION_NESTING
+        ));
+    }
+}
+
+#[cfg(not(target_family = "wasm"))]
+fn infer_on_small_native_stack(module: UntypedModule, thread_name: &str) {
+    let fixture_depth = test_body(&module).nesting_depth();
+    std::thread::Builder::new()
+        .name(thread_name.to_string())
+        .stack_size(128 * 1024)
+        .spawn(move || {
+            let typed_module = infer(module);
+            let stack_size = native_stack_segment_size(fixture_depth);
+            with_native_stack_segment(stack_size, || drop(typed_module));
+        })
+        .expect("spawn small-stack inference thread")
+        .join()
+        .expect("infer generated module on small native stack");
+}
+
+#[cfg(not(target_family = "wasm"))]
+#[test]
+fn infers_on_an_intentionally_small_native_stack() {
+    infer_on_small_native_stack(parse(4_096), "deep-inference-small-stack");
+}
+
+#[cfg(not(target_family = "wasm"))]
+#[test]
+fn infers_deep_single_when_subject_on_a_small_native_stack() {
+    infer_on_small_native_stack(
+        parse_deep_single_when(4_096),
+        "deep-single-when-small-stack",
+    );
+}
+
+#[cfg(not(target_family = "wasm"))]
+#[test]
+fn infers_deep_if_branch_on_a_small_native_stack() {
+    infer_on_small_native_stack(
+        parse_generated(deep_if_module(4_096), "deep if module should parse"),
+        "deep-if-small-stack",
+    );
+}
+
+#[cfg(not(target_family = "wasm"))]
+#[test]
+fn infers_deep_record_update_on_a_small_native_stack() {
+    infer_on_small_native_stack(
+        parse_generated(
+            deep_record_update_module(4_096),
+            "deep record update module should parse",
+        ),
+        "deep-record-update-small-stack",
+    );
+}
+
+#[cfg(not(target_family = "wasm"))]
+#[test]
+fn infers_deep_discarded_void_expression_on_a_small_native_stack() {
+    infer_on_small_native_stack(
+        parse_generated(
+            deep_discarded_void_expression_module(4_096),
+            "deep discarded void expression module should parse",
+        ),
+        "deep-discarded-void-expression-small-stack",
+    );
+}

--- a/crates/aiken-lang/src/tests/mod.rs
+++ b/crates/aiken-lang/src/tests/mod.rs
@@ -1,3 +1,4 @@
 mod check;
+mod deep_nesting;
 mod format;
 mod lexer;

--- a/crates/aiken-lang/src/tipo/environment.rs
+++ b/crates/aiken-lang/src/tipo/environment.rs
@@ -24,6 +24,12 @@ use std::{
 #[derive(Debug, Clone)]
 pub struct ScopeResetData {
     local_values: HashMap<String, ValueConstructor>,
+    entity_usage_depth: usize,
+}
+
+pub(crate) struct SuspendedScopes {
+    local_values: HashMap<String, ValueConstructor>,
+    entity_usages: Vec<HashMap<String, (EntityKind, Span, bool)>>,
 }
 
 #[derive(Debug)]
@@ -55,8 +61,13 @@ pub struct Environment<'a> {
     /// Values defined in the current module (or the prelude)
     pub module_values: HashMap<String, ValueConstructor>,
 
-    /// Top-level function definitions from the module
-    pub module_functions: HashMap<String, &'a UntypedFunction>,
+    /// Top-level function definitions waiting to be inferred
+    pub pending_functions: HashMap<String, UntypedFunction>,
+    /// Authoritative constructors for functions defined in the current module.
+    ///
+    /// Lexical bindings in `scope` may shadow these while a function body is
+    /// inferred, so generalisation must not rely on the scoped copy surviving.
+    module_function_bindings: HashMap<String, ValueConstructor>,
 
     /// Top-level validator definitions from the module
     pub module_validators: HashMap<String, (Span, Vec<String>)>,
@@ -136,6 +147,12 @@ impl<'a> Environment<'a> {
         })
     }
 
+    /// Restore only lexical bindings; current-module function constructors are
+    /// retained independently in `module_function_bindings`.
+    fn restore_scope(&mut self, local_values: HashMap<String, ValueConstructor>) {
+        self.scope = local_values;
+    }
+
     pub fn close_scope(&mut self, data: ScopeResetData) {
         let unused = self
             .entity_usages
@@ -144,7 +161,7 @@ impl<'a> Environment<'a> {
 
         self.handle_unused(unused);
 
-        self.scope = data.local_values;
+        self.restore_scope(data.local_values);
     }
 
     pub fn annotate(&mut self, return_type: Rc<Type>, annotation: &Annotation) -> Rc<Type> {
@@ -289,22 +306,21 @@ impl<'a> Environment<'a> {
                     tipo
                 };
 
-                // Insert the function into the module's interface
-                self.insert_module_value(
-                    &name,
-                    ValueConstructor {
-                        public,
-                        tipo,
-                        variant: ValueConstructorVariant::ModuleFn {
-                            name: name.clone(),
-                            field_map,
-                            module: module_name.to_owned(),
-                            arity: args.len(),
-                            location,
-                            builtin: None,
-                        },
+                let constructor = ValueConstructor {
+                    public,
+                    tipo,
+                    variant: ValueConstructorVariant::ModuleFn {
+                        name: name.clone(),
+                        field_map,
+                        module: module_name.to_owned(),
+                        arity: args.len(),
+                        location,
+                        builtin: None,
                     },
-                );
+                };
+
+                self.insert_module_function(name.clone(), constructor.clone());
+                self.insert_module_value(&name, constructor);
 
                 Definition::Fn(Function {
                     doc,
@@ -588,7 +604,10 @@ impl<'a> Environment<'a> {
 
     /// Lookup a variable in the current scope.
     pub fn get_variable(&self, name: &str) -> Option<&ValueConstructor> {
-        self.scope.get(name)
+        match self.scope.get(name) {
+            Some(constructor) if constructor.is_local_variable() => Some(constructor),
+            scoped => self.module_function_bindings.get(name).or(scoped),
+        }
     }
 
     fn handle_unused(&mut self, unused: HashMap<String, (EntityKind, Span, bool)>) {
@@ -705,6 +724,30 @@ impl<'a> Environment<'a> {
 
     pub fn insert_accessors(&mut self, type_name: &str, accessors: AccessorsMap) {
         self.accessors.insert(type_name.to_string(), accessors);
+    }
+
+    /// Record the authoritative constructor for a current-module function and
+    /// keep the top-level lexical copy in sync.
+    pub(crate) fn insert_module_function(&mut self, name: String, constructor: ValueConstructor) {
+        self.scope.insert(name.clone(), constructor.clone());
+        self.module_function_bindings.insert(name, constructor);
+    }
+
+    pub(crate) fn update_module_function_type(&mut self, name: &str, tipo: Rc<Type>) {
+        self.module_function_bindings
+            .get_mut(name)
+            .expect("Could not find preregistered type for function")
+            .tipo = tipo.clone();
+
+        if let Some(constructor) = self.scope.get_mut(name)
+            && matches!(
+                &constructor.variant,
+                ValueConstructorVariant::ModuleFn { module, .. }
+                    if module == self.current_module
+            )
+        {
+            constructor.tipo = tipo;
+        }
     }
 
     /// Insert a value into the current module.
@@ -932,7 +975,8 @@ impl<'a> Environment<'a> {
             module_types: prelude.types.clone(),
             module_types_constructors: prelude.types_constructors.clone(),
             module_values: HashMap::new(),
-            module_functions: HashMap::new(),
+            pending_functions: HashMap::new(),
+            module_function_bindings: HashMap::new(),
             module_validators: HashMap::new(),
             imported_modules: HashMap::new(),
             unused_modules: HashMap::new(),
@@ -970,10 +1014,29 @@ impl<'a> Environment<'a> {
 
     pub fn open_new_scope(&mut self) -> ScopeResetData {
         let local_values = self.scope.clone();
+        let entity_usage_depth = self.entity_usages.len();
 
         self.entity_usages.push(HashMap::new());
 
-        ScopeResetData { local_values }
+        ScopeResetData {
+            local_values,
+            entity_usage_depth,
+        }
+    }
+
+    pub(crate) fn suspend_scopes(&mut self, root: &ScopeResetData) -> SuspendedScopes {
+        let local_values = std::mem::replace(&mut self.scope, root.local_values.clone());
+        let entity_usages = self.entity_usages.split_off(root.entity_usage_depth + 1);
+
+        SuspendedScopes {
+            local_values,
+            entity_usages,
+        }
+    }
+
+    pub(crate) fn resume_scopes(&mut self, suspended: SuspendedScopes) {
+        self.restore_scope(suspended.local_values);
+        self.entity_usages.extend(suspended.entity_usages);
     }
 
     pub fn previous_uid(&self) -> u64 {
@@ -1140,12 +1203,12 @@ impl<'a> Environment<'a> {
 
     /// Iterate over a module, registering any new types created by the module into the typer
     #[allow(clippy::result_large_err)]
-    pub fn register_types(
+    pub fn register_types<'definition>(
         &mut self,
-        definitions: Vec<&'a UntypedDefinition>,
+        definitions: Vec<&'definition UntypedDefinition>,
         module: &String,
         hydrators: &mut HashMap<String, Hydrator>,
-        names: &mut HashMap<&'a str, &'a Span>,
+        names: &mut HashMap<&'definition str, &'definition Span>,
     ) -> Result<(), Error> {
         let known_types_before = names.keys().copied().collect::<Vec<_>>();
 
@@ -1222,12 +1285,12 @@ impl<'a> Environment<'a> {
     }
 
     #[allow(clippy::result_large_err)]
-    pub fn register_type(
+    pub fn register_type<'definition>(
         &mut self,
-        def: &'a UntypedDefinition,
+        def: &'definition UntypedDefinition,
         module: &String,
         hydrators: &mut HashMap<String, Hydrator>,
-        names: &mut HashMap<&'a str, &'a Span>,
+        names: &mut HashMap<&'definition str, &'definition Span>,
     ) -> Result<(), Error> {
         match def {
             Definition::DataType(DataType {
@@ -1343,15 +1406,15 @@ impl<'a> Environment<'a> {
 
     #[allow(clippy::too_many_arguments)]
     #[allow(clippy::result_large_err)]
-    fn register_function(
+    fn register_function<'definition>(
         &mut self,
         name: &str,
         arguments: &[UntypedArg],
         return_annotation: &Option<Annotation>,
         module_name: &String,
         hydrators: &mut HashMap<String, Hydrator>,
-        names: &mut HashMap<String, &'a Span>,
-        location: &'a Span,
+        names: &mut HashMap<String, &'definition Span>,
+        location: &'definition Span,
     ) -> Result<(), Error> {
         assert_unique_value_name(names, name, location)?;
 
@@ -1385,30 +1448,33 @@ impl<'a> Environment<'a> {
         // inference of the function body.
         hydrators.insert(name.to_string(), hydrator);
 
-        // Insert the function into the environment
-        self.insert_variable(
+        // Insert the function into the module environment.
+        self.insert_module_function(
             name.to_string(),
-            ValueConstructorVariant::ModuleFn {
-                name: name.to_string(),
-                field_map,
-                module: module_name.to_owned(),
-                arity: arguments.len(),
-                location: *location,
-                builtin: None,
+            ValueConstructor {
+                public: false,
+                variant: ValueConstructorVariant::ModuleFn {
+                    name: name.to_string(),
+                    field_map,
+                    module: module_name.to_owned(),
+                    arity: arguments.len(),
+                    location: *location,
+                    builtin: None,
+                },
+                tipo,
             },
-            tipo,
         );
 
         Ok(())
     }
 
     #[allow(clippy::result_large_err)]
-    pub fn register_values(
+    pub fn register_values<'definition>(
         &mut self,
-        def: &'a UntypedDefinition,
+        def: &'definition UntypedDefinition,
         module_name: &String,
         hydrators: &mut HashMap<String, Hydrator>,
-        names: &mut HashMap<String, &'a Span>,
+        names: &mut HashMap<String, &'definition Span>,
         kind: ModuleKind,
     ) -> Result<(), Error> {
         match def {
@@ -1422,8 +1488,6 @@ impl<'a> Environment<'a> {
                     names,
                     &fun.location,
                 )?;
-
-                self.module_functions.insert(fun.name.clone(), fun);
 
                 if !fun.public {
                     self.init_usage(fun.name.clone(), EntityKind::PrivateFunction, fun.location);

--- a/crates/aiken-lang/src/tipo/error.rs
+++ b/crates/aiken-lang/src/tipo/error.rs
@@ -4,12 +4,9 @@
 
 use super::Type;
 use crate::{
-    ast::{
-        Annotation, BinOp, CallArg, LogicalOpChainKind, Namespace, Span, UntypedFunction,
-        UntypedPattern,
-    },
+    ast::{Annotation, BinOp, CallArg, LogicalOpChainKind, Namespace, Span, UntypedPattern},
     error::ExtraData,
-    expr::{self, AssignmentPattern, UntypedAssignmentKind, UntypedExpr},
+    expr::{AssignmentPattern, UntypedAssignmentKind, UntypedExpr},
     format::Formatter,
     levenshtein,
     pretty::Documentable,
@@ -75,11 +72,12 @@ pub enum Error {
 
     #[error("I discovered a type cast from Data without an annotation.")]
     #[diagnostic(code("illegal::type_cast"))]
-    #[diagnostic(help("Try adding an annotation...\n\n{}", format_suggestion(value)))]
+    #[diagnostic(help("Try adding a type annotation to the assignment pattern."))]
     CastDataNoAnn {
-        #[label("missing annotation")]
+        #[label("cast from Data")]
         location: Span,
-        value: Box<UntypedExpr>,
+        #[label("add a concrete type here")]
+        pattern_location: Span,
     },
 
     #[error("I struggled to unify the types of two expressions.\n")]
@@ -523,17 +521,13 @@ Perhaps, try the following:
     #[error("I discovered a block which is ending with an assignment.\n")]
     #[diagnostic(url("https://aiken-lang.org/language-tour/functions#named-functions"))]
     #[diagnostic(code("illegal::return"))]
-    #[diagnostic(help(r#"In Aiken, code blocks (such as function bodies) must return an explicit result in the form of an expression. While assignments are technically speaking expressions, they aren't allowed to be the last expression of a function because they convey a different meaning and this could be error-prone.
-
-If you really meant to return that last expression, try to replace it with the following:
-
-{sample}"#
-        , sample = format_suggestion(expr)
+    #[diagnostic(help(
+        "In Aiken, code blocks (such as function bodies) must return an explicit result in the form of an expression. Add the value you want to return after this assignment."
     ))]
     LastExpressionIsAssignment {
         #[label("let-binding as last expression")]
         location: Span,
-        expr: Box<expr::UntypedExpr>,
+        value_location: Span,
         patterns: Vec1<AssignmentPattern>,
         kind: UntypedAssignmentKind,
     },
@@ -1118,8 +1112,17 @@ The best thing to do from here is to remove it."#))]
         location: Span,
     },
 
-    #[error("Cannot infer caller without inferring callee first")]
-    MustInferFirst { function: Box<UntypedFunction> },
+    #[error("Expression nesting exceeds the supported limit.")]
+    #[diagnostic(code("too_deep::expression"))]
+    #[diagnostic(help(
+        "This expression is nested {depth} levels deep, but the supported limit is {limit}. Construct the value through a helper function or reduce the literal nesting."
+    ))]
+    ExpressionNestingLimitExceeded {
+        #[label("nested {depth} levels deep")]
+        location: Span,
+        depth: usize,
+        limit: usize,
+    },
 
     #[error("I found a validator handler referring to an unknown purpose.\n")]
     #[diagnostic(code("unknown::purpose"))]
@@ -1234,6 +1237,7 @@ impl ExtraData for Error {
             | Error::IncorrectTestArity { .. }
             | Error::IllegalTestType { .. }
             | Error::GenericLeftAtBoundary { .. }
+            | Error::ExpressionNestingLimitExceeded { .. }
             | Error::UnexpectedMultiPatternAssignment { .. }
             | Error::ExpectOnOpaqueType { .. }
             | Error::ValidatorMustReturnBool { .. }
@@ -1241,7 +1245,6 @@ impl ExtraData for Error {
             | Error::UnknownValidatorHandler { .. }
             | Error::UnexpectedValidatorFallback { .. }
             | Error::IncorrectBenchmarkArity { .. }
-            | Error::MustInferFirst { .. }
             | Error::DecoratorValidation { .. }
             | Error::ConflictingDecorators { .. }
             | Error::DecoratorTagOverlap { .. }
@@ -1670,15 +1673,15 @@ pub enum Warning {
     #[diagnostic(
         code("single_when_clause"),
         help(
-            "Prefer using a {} binding like so...\n\n{}",
+            "Prefer using a {} binding instead.",
             "let".if_supports_color(Stderr, |s| s.purple()),
-            format_suggestion(sample)
         )
     )]
     SingleWhenClause {
-        #[label("use let")]
+        #[label("bind this pattern")]
         location: Span,
-        sample: Box<UntypedExpr>,
+        #[label("to this value")]
+        value_location: Span,
     },
 
     #[error(

--- a/crates/aiken-lang/src/tipo/expr.rs
+++ b/crates/aiken-lang/src/tipo/expr.rs
@@ -8,6 +8,8 @@ use super::{
     pattern::PatternTyper,
     pipe::PipeTyper,
 };
+#[cfg(not(target_family = "wasm"))]
+use crate::expr::with_native_stack_growth;
 use crate::{
     IdGenerator,
     ast::{
@@ -19,34 +21,55 @@ use crate::{
         UntypedIfBranch, UntypedPattern, UntypedRecordUpdateArg,
     },
     builtins::{BUILTIN, from_default_function},
-    expr::{FnStyle, TypedExpr, UntypedExpr},
+    expr::{FnStyle, MAX_EXPRESSION_NESTING, TypedExpr, UntypedExpr},
     format,
     parser::token::Base,
     tipo::{
         DefaultFunction, ModuleKind, PatternConstructor, TypeConstructor, TypeVar, fields::FieldMap,
     },
 };
-use std::{
-    cmp::Ordering,
-    collections::{BTreeSet, HashMap},
-    ops::Deref,
-    rc::Rc,
-};
+
+use std::{cmp::Ordering, collections::HashMap, ops::Deref, rc::Rc};
 use vec1::Vec1;
 
+#[allow(clippy::too_many_arguments)]
 #[allow(clippy::result_large_err)]
-pub(crate) fn infer_function(
-    fun: &UntypedFunction,
+pub(crate) fn infer_registered_function(
+    name: String,
     module_name: &str,
     hydrators: &mut HashMap<String, Hydrator>,
     environment: &mut Environment<'_>,
     tracing: Tracing,
     top_level_scope: &ScopeResetData,
 ) -> Result<Function<Rc<Type>, TypedExpr, TypedArg>, Error> {
-    if let Some(typed_fun) = environment.inferred_functions.get(&fun.name) {
-        return Ok(typed_fun.clone());
-    };
+    if let Some(function) = environment.inferred_functions.remove(&name) {
+        return Ok(function);
+    }
 
+    let function = environment
+        .pending_functions
+        .remove(&name)
+        .unwrap_or_else(|| panic!("Could not find registered function: {name}"));
+
+    infer_function(
+        function,
+        module_name,
+        hydrators,
+        environment,
+        tracing,
+        top_level_scope,
+    )
+}
+
+#[allow(clippy::result_large_err)]
+pub(crate) fn infer_function(
+    fun: UntypedFunction,
+    module_name: &str,
+    hydrators: &mut HashMap<String, Hydrator>,
+    environment: &mut Environment<'_>,
+    tracing: Tracing,
+    top_level_scope: &ScopeResetData,
+) -> Result<Function<Rc<Type>, TypedExpr, TypedArg>, Error> {
     let Function {
         doc,
         location,
@@ -61,176 +84,121 @@ pub(crate) fn infer_function(
     } = fun;
 
     let mut extra_let_assignments = Vec::new();
-    for (i, arg) in arguments.iter().enumerate() {
-        let let_assignment = arg.by.clone().into_extra_assignment(
-            &arg.arg_name(i),
-            arg.annotation.as_ref(),
-            arg.location,
-        );
-        match let_assignment {
-            None => {}
-            Some(expr) => extra_let_assignments.push(expr),
+    for (index, argument) in arguments.iter().enumerate() {
+        if let Some(expression) = argument.by.clone().into_extra_assignment(
+            &argument.arg_name(index),
+            argument.annotation.as_ref(),
+            argument.location,
+        ) {
+            extra_let_assignments.push(expression);
         }
     }
 
-    let sequence;
-
+    let body_location = body.location();
     let body = if extra_let_assignments.is_empty() {
         body
-    } else if let UntypedExpr::Sequence { expressions, .. } = body {
-        extra_let_assignments.extend(expressions.clone());
-        sequence = UntypedExpr::Sequence {
+    } else if let UntypedExpr::Sequence {
+        expressions,
+        location,
+    } = body
+    {
+        extra_let_assignments.extend(expressions);
+        UntypedExpr::Sequence {
             expressions: extra_let_assignments,
-            location: *location,
-        };
-        &sequence
+            location,
+        }
     } else {
-        extra_let_assignments.extend([body.clone()]);
-        sequence = UntypedExpr::Sequence {
+        extra_let_assignments.push(body);
+        UntypedExpr::Sequence {
             expressions: extra_let_assignments,
-            location: body.location(),
-        };
-        &sequence
+            location: body_location,
+        }
     };
 
     let preregistered_fn = environment
-        .get_variable(name)
+        .get_variable(&name)
         .unwrap_or_else(|| panic!("Could not find preregistered type for function: {name}"));
-
     let field_map = preregistered_fn.field_map().cloned();
-
     let preregistered_type = preregistered_fn.tipo.clone();
-
     let (args_types, return_type) = preregistered_type
         .function_types()
         .unwrap_or_else(|| panic!("Preregistered type for fn {name} was not a fn"));
-
-    let warnings = environment.warnings.clone();
 
     // ━━━ open new scope ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
     let initial_scope = environment.open_new_scope();
 
     let arguments = arguments
-        .iter()
+        .into_iter()
         .zip(&args_types)
         .enumerate()
-        .map(|(ix, (arg_name, tipo))| arg_name.to_owned().set_type(tipo.clone(), ix))
+        .map(|(index, (argument, tipo))| argument.set_type(tipo.clone(), index))
         .collect();
 
     let hydrator = hydrators
-        .remove(name)
+        .remove(&name)
         .unwrap_or_else(|| panic!("Could not find hydrator for fn {name}"));
 
-    let mut expr_typer = ExprTyper::new(environment, tracing);
+    let mut expr_typer =
+        ExprTyper::new_for_function(environment, tracing, hydrators, top_level_scope);
     expr_typer.hydrator = hydrator;
-    expr_typer.not_yet_inferred = BTreeSet::from_iter(hydrators.keys().cloned());
 
-    // Infer the type using the preregistered args + return types as a starting point
-    let inferred =
-        expr_typer.infer_fn_with_known_types(arguments, body.to_owned(), Some(return_type));
-
-    // We try to always perform a deep-first inferrence. So callee are inferred before callers,
-    // since this provides better -- and necessary -- information in particular with regards to
-    // generics.
-    //
-    // In principle, the compiler requires function definitions to be processed *in order*. So if
-    // A calls B, we must have inferred B before A. This is detected during inferrence, and we
-    // raise an error about it. Here however, we backtrack from that error and infer the caller
-    // first. Then, re-attempt to infer the current function. It may takes multiple attempts, but
-    // should eventually succeed.
-    //
-    // Note that we need to close the scope before backtracking to not mess with the scope of the
-    // callee. Otherwise, identifiers present in the caller's scope may become available to the
-    // callee.
-
-    if let Err(Error::MustInferFirst { function, .. }) = inferred {
-        // Reset the environment & scope.
-        hydrators.insert(name.to_string(), expr_typer.hydrator);
-        environment.close_scope(initial_scope);
-        *environment.warnings = warnings;
-
-        // Backtrack and infer callee first.
-        let temp_scope = environment.open_new_scope();
-        environment.close_scope(top_level_scope.clone());
-        infer_function(
-            &function,
-            environment.current_module,
-            hydrators,
-            environment,
-            tracing,
-            top_level_scope,
-        )?;
-
-        environment.open_new_scope();
-        environment.close_scope(temp_scope);
-
-        // Then, try again the entire function definition.
-        return infer_function(
-            fun,
-            module_name,
-            hydrators,
-            environment,
-            tracing,
-            top_level_scope,
-        );
-    }
-
-    let (arguments, body, return_type) = inferred?;
-
-    let args_types = arguments.iter().map(|a| a.tipo.clone()).collect();
-
-    let tipo = Type::function(args_types, return_type);
-
+    let inferred = expr_typer.infer_fn_with_known_types(arguments, body, Some(return_type));
     let safe_to_generalise = !expr_typer.ungeneralised_function_used;
 
-    environment.close_scope(initial_scope);
+    expr_typer.environment.close_scope(initial_scope);
     // ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
 
+    let (arguments, body, return_type) = inferred?;
+    let args_types = arguments
+        .iter()
+        .map(|argument| argument.tipo.clone())
+        .collect();
+    let tipo = Type::function(args_types, return_type);
+
     // Assert that the inferred type matches the type of any recursive call
-    environment.unify(preregistered_type, tipo.clone(), *location, false)?;
+    environment.unify(preregistered_type, tipo.clone(), location, false)?;
 
     // Generalise the function if safe to do so
     let tipo = if safe_to_generalise {
-        environment.ungeneralised_functions.remove(name);
+        environment.ungeneralised_functions.remove(&name);
 
         let tipo = generalise(tipo, 0);
-
         let module_fn = ValueConstructorVariant::ModuleFn {
             name: name.clone(),
             field_map,
             module: module_name.to_owned(),
             arity: arguments.len(),
-            location: *location,
+            location,
             builtin: None,
         };
 
-        environment.insert_variable(name.clone(), module_fn, tipo.clone());
-
+        environment.insert_module_function(
+            name.clone(),
+            ValueConstructor {
+                public,
+                variant: module_fn,
+                tipo: tipo.clone(),
+            },
+        );
         tipo
     } else {
         tipo
     };
 
-    let inferred_fn = Function {
-        doc: doc.clone(),
-        location: *location,
-        name: name.clone(),
-        public: *public,
+    Ok(Function {
+        doc,
+        location,
+        name,
+        public,
         arguments,
-        return_annotation: return_annotation.clone(),
+        return_annotation,
         return_type: tipo
             .return_type()
             .expect("Could not find return type for fn"),
         body,
-        on_test_failure: on_test_failure.clone(),
-        end_position: *end_position,
-    };
-
-    environment
-        .inferred_functions
-        .insert(name.to_string(), inferred_fn.clone());
-
-    Ok(inferred_fn)
+        on_test_failure,
+        end_position,
+    })
 }
 
 #[derive(Debug)]
@@ -244,23 +212,44 @@ pub(crate) struct ExprTyper<'a, 'b> {
     // Type hydrator for creating types from annotations
     pub(crate) hydrator: Hydrator,
 
-    // A static set of remaining function names that are known but not yet inferred
-    pub(crate) not_yet_inferred: BTreeSet<String>,
+    function_hydrators: Option<&'a mut HashMap<String, Hydrator>>,
+    top_level_scope: Option<&'a ScopeResetData>,
 
     // We keep track of whether any ungeneralised functions have been used
     // to determine whether it is safe to generalise this expression after
     // it has been inferred.
     pub(crate) ungeneralised_function_used: bool,
+
+    inference_depth: usize,
 }
 
 impl<'a, 'b> ExprTyper<'a, 'b> {
     pub fn new(environment: &'a mut Environment<'b>, tracing: Tracing) -> Self {
         Self {
             hydrator: Hydrator::new(),
-            not_yet_inferred: BTreeSet::new(),
+            function_hydrators: None,
+            top_level_scope: None,
             environment,
             tracing,
             ungeneralised_function_used: false,
+            inference_depth: 0,
+        }
+    }
+
+    fn new_for_function(
+        environment: &'a mut Environment<'b>,
+        tracing: Tracing,
+        function_hydrators: &'a mut HashMap<String, Hydrator>,
+        top_level_scope: &'a ScopeResetData,
+    ) -> Self {
+        Self {
+            hydrator: Hydrator::new(),
+            function_hydrators: Some(function_hydrators),
+            top_level_scope: Some(top_level_scope),
+            environment,
+            tracing,
+            ungeneralised_function_used: false,
+            inference_depth: 0,
         }
     }
 
@@ -451,6 +440,36 @@ impl<'a, 'b> ExprTyper<'a, 'b> {
     /// returning an error.
     #[allow(clippy::result_large_err)]
     pub fn infer(&mut self, expr: UntypedExpr) -> Result<TypedExpr, Error> {
+        if self.inference_depth == 0 {
+            let depth = expr.nesting_depth();
+
+            if depth > MAX_EXPRESSION_NESTING {
+                let error = Error::ExpressionNestingLimitExceeded {
+                    location: expr.location(),
+                    depth,
+                    limit: MAX_EXPRESSION_NESTING,
+                };
+
+                expr.drop_iteratively();
+
+                return Err(error);
+            }
+        }
+
+        self.inference_depth += 1;
+
+        #[cfg(not(target_family = "wasm"))]
+        let inferred = with_native_stack_growth(|| self.infer_inner(expr));
+
+        #[cfg(target_family = "wasm")]
+        let inferred = self.infer_inner(expr);
+
+        self.inference_depth -= 1;
+        inferred
+    }
+
+    #[allow(clippy::result_large_err)]
+    fn infer_inner(&mut self, expr: UntypedExpr) -> Result<TypedExpr, Error> {
         match expr {
             UntypedExpr::ErrorTerm { location } => Ok(self.infer_error_term(location)),
 
@@ -812,7 +831,8 @@ impl<'a, 'b> ExprTyper<'a, 'b> {
         args: Vec<UntypedRecordUpdateArg>,
         location: Span,
     ) -> Result<TypedExpr, Error> {
-        let (module, name): (Option<Namespace>, String) = match self.infer(constructor.clone())? {
+        let constructor_location = constructor.location();
+        let (module, name): (Option<Namespace>, String) = match self.infer(constructor)? {
             TypedExpr::ModuleSelect {
                 module_alias,
                 label,
@@ -845,7 +865,7 @@ impl<'a, 'b> ExprTyper<'a, 'b> {
             } => (field_map, *constructors_count),
             _ => {
                 return Err(Error::RecordUpdateInvalidConstructor {
-                    location: constructor.location(),
+                    location: constructor_location,
                 });
             }
         };
@@ -855,7 +875,7 @@ impl<'a, 'b> ExprTyper<'a, 'b> {
         // could be one of the other variants.
         if constructors_count != 1 {
             return Err(Error::UpdateMultiConstructorType {
-                location: constructor.location(),
+                location: constructor_location,
             });
         }
 
@@ -864,7 +884,7 @@ impl<'a, 'b> ExprTyper<'a, 'b> {
             Type::Fn { ret, .. } => ret,
             _ => {
                 return Err(Error::RecordUpdateInvalidConstructor {
-                    location: constructor.location(),
+                    location: constructor_location,
                 });
             }
         };
@@ -892,7 +912,7 @@ impl<'a, 'b> ExprTyper<'a, 'b> {
                 });
             }
 
-            let value = self.infer(value.clone())?;
+            let value = self.infer(value)?;
             let spread_field =
                 self.infer_known_record_access(spread.clone(), label.to_string(), location)?;
 
@@ -1031,7 +1051,7 @@ impl<'a, 'b> ExprTyper<'a, 'b> {
                                         .any(|(_, constructor)| constructor.public);
                                     let export_functions = self
                                         .environment
-                                        .module_functions
+                                        .pending_functions
                                         .iter()
                                         .any(|(_, function)| function.public);
                                     let export_validators =
@@ -1454,7 +1474,13 @@ impl<'a, 'b> ExprTyper<'a, 'b> {
         comment: Option<String>,
         location: Span,
     ) -> Result<TypedExpr, Error> {
-        let typed_value = self.infer(untyped_value.clone())?;
+        let value_location = untyped_value.location();
+        let pattern_location = untyped_pattern.location();
+        let is_backpassing = matches!(
+            &untyped_value,
+            UntypedExpr::Var { name, .. } if name == ast::BACKPASS_VARIABLE
+        );
+        let typed_value = self.infer(untyped_value)?;
 
         let mut value_typ = typed_value.tipo();
 
@@ -1484,27 +1510,9 @@ impl<'a, 'b> ExprTyper<'a, 'b> {
             )
         } else if value_is_data && !kind.is_let() {
             let cast_data_no_ann = || {
-                let ann = Annotation::Constructor {
-                    location: Span::empty(),
-                    module: None,
-                    name: "Type".to_string(),
-                    arguments: vec![],
-                };
-
                 Err(Error::CastDataNoAnn {
                     location,
-                    value: Box::new(UntypedExpr::Assignment {
-                        location,
-                        value: untyped_value.clone().into(),
-                        patterns: AssignmentPattern::new(
-                            untyped_pattern.clone(),
-                            Some(ann),
-                            Span::empty(),
-                        )
-                        .into(),
-                        comment: comment.clone(),
-                        kind,
-                    }),
+                    pattern_location,
                 })
             };
 
@@ -1597,36 +1605,24 @@ impl<'a, 'b> ExprTyper<'a, 'b> {
                                 end: location.start + kind.location_offset(),
                             },
                             pattern_location: untyped_pattern.location(),
-                            value_location: untyped_value.location(),
-                            sample: Box::new(match untyped_value {
-                                UntypedExpr::Var { name, .. } if name == ast::BACKPASS_VARIABLE => {
-                                    UntypedExpr::Assignment {
-                                        location: Span::empty(),
-                                        value: Box::new(UntypedExpr::Var {
-                                            name: "...".to_string(),
-                                            location: Span::empty(),
-                                        }),
-                                        patterns: AssignmentPattern::new(
-                                            untyped_pattern,
-                                            None,
-                                            Span::empty(),
-                                        )
-                                        .into(),
-                                        comment: None,
-                                        kind: AssignmentKind::Let { backpassing: true },
-                                    }
-                                }
-                                _ => UntypedExpr::Assignment {
+                            value_location,
+                            sample: Box::new(UntypedExpr::Assignment {
+                                location: Span::empty(),
+                                value: Box::new(UntypedExpr::Var {
+                                    name: "...".to_string(),
                                     location: Span::empty(),
-                                    value: Box::new(untyped_value),
-                                    patterns: AssignmentPattern::new(
-                                        untyped_pattern,
-                                        None,
-                                        Span::empty(),
-                                    )
-                                    .into(),
-                                    comment: None,
-                                    kind: AssignmentKind::let_(),
+                                }),
+                                patterns: AssignmentPattern::new(
+                                    untyped_pattern,
+                                    None,
+                                    Span::empty(),
+                                )
+                                .into(),
+                                comment: None,
+                                kind: if is_backpassing {
+                                    AssignmentKind::Let { backpassing: true }
+                                } else {
+                                    AssignmentKind::let_()
                                 },
                             }),
                         });
@@ -1824,7 +1820,16 @@ impl<'a, 'b> ExprTyper<'a, 'b> {
 
     #[allow(clippy::result_large_err)]
     fn infer_if_branch(&mut self, branch: UntypedIfBranch) -> Result<TypedIfBranch, Error> {
-        let (condition, body, is) = match branch.is {
+        let UntypedIfBranch {
+            condition,
+            body,
+            is,
+            location,
+        } = branch;
+        let condition_location = condition.location();
+        let body_location = body.location();
+
+        let (condition, body, is) = match is {
             Some(is) => self.in_new_scope(|typer| {
                 let AssignmentPattern {
                     pattern,
@@ -1839,7 +1844,7 @@ impl<'a, 'b> ExprTyper<'a, 'b> {
                     ..
                 } = typer.infer_assignment(
                     pattern,
-                    branch.condition.clone(),
+                    condition,
                     AssignmentKind::is(),
                     &annotation,
                     None,
@@ -1851,23 +1856,22 @@ impl<'a, 'b> ExprTyper<'a, 'b> {
 
                 if !value.tipo().is_data() {
                     typer.environment.warnings.push(Warning::UseWhenInstead {
-                        location: branch.condition.location().union(location),
+                        location: condition_location.union(location),
                     })
                 }
 
-                let body = if let Some(filler) = recover_from_no_assignment(
-                    assert_no_assignment(&branch.body),
-                    branch.body.location(),
-                )? {
-                    typer.infer(branch.body.clone())?.and_then(filler)
+                let body = if let Some(filler) =
+                    recover_from_no_assignment(assert_no_assignment(&body), body_location)?
+                {
+                    typer.infer(body)?.and_then(filler)
                 } else {
-                    typer.infer(branch.body.clone())?
+                    typer.infer(body)?
                 };
 
                 Ok((*value, body, Some((pattern, tipo))))
             })?,
             None => {
-                let condition = self.infer(branch.condition.clone())?;
+                let condition = self.infer(condition)?;
 
                 self.unify(
                     Type::bool(),
@@ -1876,13 +1880,12 @@ impl<'a, 'b> ExprTyper<'a, 'b> {
                     false,
                 )?;
 
-                let body = if let Some(filler) = recover_from_no_assignment(
-                    assert_no_assignment(&branch.body),
-                    branch.body.location(),
-                )? {
-                    self.infer(branch.body.clone())?.and_then(filler)
+                let body = if let Some(filler) =
+                    recover_from_no_assignment(assert_no_assignment(&body), body_location)?
+                {
+                    self.infer(body)?.and_then(filler)
                 } else {
-                    self.infer(branch.body.clone())?
+                    self.infer(body)?
                 };
 
                 (condition, body, None)
@@ -1893,7 +1896,7 @@ impl<'a, 'b> ExprTyper<'a, 'b> {
             body,
             condition,
             is,
-            location: branch.location,
+            location,
         })
     }
 
@@ -2129,16 +2132,15 @@ impl<'a, 'b> ExprTyper<'a, 'b> {
             unreachable!("backpass misuse: breakpoint isn't an Assignment ?!");
         };
 
+        let value_location = value.location();
         if continuation.is_empty() {
             return Err(Error::LastExpressionIsAssignment {
                 location,
-                expr: Box::new(*value),
+                value_location,
                 patterns: patterns.clone(),
                 kind,
             });
         }
-
-        let value_location = value.location();
 
         let call_location = Span {
             start: location.start,
@@ -2637,6 +2639,45 @@ impl<'a, 'b> ExprTyper<'a, 'b> {
     }
 
     #[allow(clippy::result_large_err)]
+    fn infer_pending_function(&mut self, name: &str) -> Result<bool, Error> {
+        if self.function_hydrators.is_none() || self.top_level_scope.is_none() {
+            return Ok(false);
+        }
+
+        let Some(function) = self.environment.pending_functions.remove(name) else {
+            return Ok(false);
+        };
+
+        let module_name = self.environment.current_module.clone();
+        let top_level_scope = self
+            .top_level_scope
+            .expect("function inference has a top-level scope");
+        let suspended = self.environment.suspend_scopes(top_level_scope);
+        let function_hydrators = self
+            .function_hydrators
+            .as_deref_mut()
+            .expect("function inference has registered hydrators");
+
+        let inferred = infer_function(
+            function,
+            &module_name,
+            function_hydrators,
+            self.environment,
+            self.tracing,
+            top_level_scope,
+        );
+
+        self.environment.resume_scopes(suspended);
+
+        let function = inferred?;
+        self.environment
+            .inferred_functions
+            .insert(name.to_string(), function);
+
+        Ok(true)
+    }
+
+    #[allow(clippy::result_large_err)]
     pub fn infer_value_constructor(
         &mut self,
         module: &Option<String>,
@@ -2646,7 +2687,7 @@ impl<'a, 'b> ExprTyper<'a, 'b> {
         let constructor = match module {
             // Look in the current scope for a binding with this name
             None => {
-                let constructor =
+                let mut constructor =
                     self.environment
                         .get_variable(name)
                         .cloned()
@@ -2659,7 +2700,7 @@ impl<'a, 'b> ExprTyper<'a, 'b> {
                                         .environment
                                         .local_value_names()
                                         .into_iter()
-                                        .filter(|s| TypeConstructor::might_be(s))
+                                        .filter(|value| TypeConstructor::might_be(value))
                                         .collect::<Vec<_>>(),
                                 }
                             } else {
@@ -2670,7 +2711,7 @@ impl<'a, 'b> ExprTyper<'a, 'b> {
                                         .environment
                                         .local_value_names()
                                         .into_iter()
-                                        .filter(|s| !TypeConstructor::might_be(s))
+                                        .filter(|value| !TypeConstructor::might_be(value))
                                         .collect::<Vec<_>>(),
                                 }
                             }
@@ -2679,37 +2720,25 @@ impl<'a, 'b> ExprTyper<'a, 'b> {
                 if let ValueConstructorVariant::ModuleFn { name: fn_name, .. } =
                     &constructor.variant
                 {
-                    // Note whether we are using an ungeneralised function so that we can
-                    // tell if it is safe to generalise this function after inference has
-                    // completed.
-                    let is_ungeneralised = self.environment.ungeneralised_functions.contains(name);
+                    let fn_name = fn_name.clone();
 
-                    self.ungeneralised_function_used =
-                        self.ungeneralised_function_used || is_ungeneralised;
-
-                    // In case we use another function, infer it first before going further.
-                    // This ensures we have as much information possible about the function
-                    // when we start inferring expressions using it (i.e. calls).
-                    //
-                    // In a way, this achieves a cheap topological processing of definitions
-                    // where we infer used definitions first. And as a consequence, it solves
-                    // issues where expressions would be wrongly assigned generic variables
-                    // from other definitions.
-                    if let Some(fun) = self.environment.module_functions.remove(fn_name) {
-                        // NOTE: Recursive functions should not run into this multiple time.
-                        // If we have no hydrator for this function, it means that we have already
-                        // encountered it.
-                        if self.not_yet_inferred.contains(&fun.name) {
-                            return Err(Error::MustInferFirst {
-                                function: Box::new(fun.clone()),
-                            });
-                        }
+                    // Infer callees before using their types. The pending-function map owns the
+                    // complete AST, so neither the callee nor the caller body needs to be cloned.
+                    if self.infer_pending_function(&fn_name)? {
+                        constructor = self
+                            .environment
+                            .get_variable(name)
+                            .cloned()
+                            .expect("inferred function remains registered");
                     }
+
+                    // Acyclic pending callees may have been generalised during inference. Only
+                    // record a dependency when the refreshed constructor is still monomorphic.
+                    self.ungeneralised_function_used |=
+                        self.environment.ungeneralised_functions.contains(name);
                 }
 
-                // Register the value as seen for detection of unused values
                 self.environment.increment_usage(name);
-
                 constructor
             }
 
@@ -2771,27 +2800,16 @@ impl<'a, 'b> ExprTyper<'a, 'b> {
         clauses: Vec<UntypedClause>,
         location: Span,
     ) -> Result<TypedExpr, Error> {
-        // if there is only one clause we want to present a warning
-        // that suggests that a `let` binding should be used instead.
-        let mut sample = None;
-
-        if clauses.len() == 1 && clauses[0].patterns.len() == 1 {
-            sample = Some(Warning::SingleWhenClause {
+        // If there is only one clause, suggest a `let` binding instead. Keep only
+        // spans here: cloning a deeply nested subject can exhaust the native stack.
+        let single_clause_warning = if clauses.len() == 1 && clauses[0].patterns.len() == 1 {
+            Some(Warning::SingleWhenClause {
                 location: clauses[0].patterns[0].location(),
-                sample: Box::new(UntypedExpr::Assignment {
-                    location: Span::empty(),
-                    value: Box::new(subject.clone()),
-                    patterns: AssignmentPattern::new(
-                        clauses[0].patterns[0].clone(),
-                        None,
-                        Span::empty(),
-                    )
-                    .into(),
-                    kind: AssignmentKind::let_(),
-                    comment: None,
-                }),
-            });
-        }
+                value_location: subject.location(),
+            })
+        } else {
+            None
+        };
 
         let typed_subject = self.infer(subject)?;
         let subject_type = typed_subject.tipo();
@@ -2814,8 +2832,8 @@ impl<'a, 'b> ExprTyper<'a, 'b> {
 
         self.check_when_exhaustiveness(&typed_clauses, location)?;
 
-        if let Some(sample) = sample {
-            self.environment.warnings.push(sample);
+        if let Some(warning) = single_clause_warning {
+            self.environment.warnings.push(warning);
         }
 
         Ok(TypedExpr::When {
@@ -2883,13 +2901,13 @@ fn recover_from_no_assignment(
 fn assert_no_assignment(expr: &UntypedExpr) -> Result<(), Error> {
     match expr {
         UntypedExpr::Assignment {
-            value,
             patterns,
             kind,
+            value,
             ..
         } => Err(Error::LastExpressionIsAssignment {
             location: expr.location(),
-            expr: Box::new(*value.clone()),
+            value_location: value.location(),
             patterns: patterns.clone(),
             kind: *kind,
         }),
@@ -2922,14 +2940,16 @@ fn assert_no_assignment(expr: &UntypedExpr) -> Result<(), Error> {
 #[allow(clippy::result_large_err)]
 fn assert_assignment(expr: TypedExpr) -> Result<TypedExpr, Error> {
     if !matches!(expr, TypedExpr::Assignment { .. }) {
+        let location = expr.location();
+
         if expr.tipo().is_void() {
             return Ok(TypedExpr::Assignment {
-                location: expr.location(),
+                location,
                 tipo: Type::void(),
-                value: expr.clone().into(),
+                value: expr.into(),
                 pattern: Pattern::Constructor {
                     is_record: false,
-                    location: expr.location(),
+                    location,
                     name: "Void".to_string(),
                     constructor: PatternConstructor::Record {
                         name: "Void".to_string(),
@@ -2945,9 +2965,7 @@ fn assert_assignment(expr: TypedExpr) -> Result<TypedExpr, Error> {
             });
         }
 
-        return Err(Error::ImplicitlyDiscardedExpression {
-            location: expr.location(),
-        });
+        return Err(Error::ImplicitlyDiscardedExpression { location });
     }
 
     Ok(expr)

--- a/crates/aiken-lang/src/tipo/infer.rs
+++ b/crates/aiken-lang/src/tipo/infer.rs
@@ -2,7 +2,7 @@ use super::{
     TypeInfo, ValueConstructor, ValueConstructorVariant,
     environment::{EntityKind, Environment},
     error::{Error, UnifyErrorSituation, Warning},
-    expr::ExprTyper,
+    expr::{ExprTyper, infer_function, infer_registered_function},
     hydrator::Hydrator,
 };
 use crate::{
@@ -16,7 +16,7 @@ use crate::{
     },
     expr::{TypedExpr, UntypedAssignmentKind, UntypedExpr},
     parser::token::Token,
-    tipo::{Span, Type, TypeVar, expr::infer_function},
+    tipo::{Span, Type, TypeVar},
 };
 use std::{
     borrow::Borrow,
@@ -25,6 +25,11 @@ use std::{
     ops::Deref,
     rc::Rc,
 };
+
+enum DefinitionToInfer {
+    Function(String),
+    Other(Box<UntypedDefinition>),
+}
 
 impl UntypedModule {
     #[allow(clippy::too_many_arguments)]
@@ -80,26 +85,68 @@ impl UntypedModule {
         // anywhere in the module.
         let mut definitions = Vec::with_capacity(self.definitions.len());
         let mut consts = vec![];
-        let mut not_consts = vec![];
+        let mut definitions_to_infer = vec![];
 
-        for def in self.definitions().cloned() {
+        drop(type_names);
+        drop(value_names);
+
+        for def in std::mem::take(&mut self.definitions) {
             match def {
-                Definition::ModuleConstant { .. } => consts.push(def),
-                Definition::Validator { .. } if kind.is_validator() => not_consts.push(def),
-                Definition::Validator { .. } => (),
-                Definition::Fn { .. }
-                | Definition::Test { .. }
+                Definition::ModuleConstant { .. } => {
+                    consts.push(def);
+                }
+                Definition::Validator { .. } if kind.is_validator() => {
+                    definitions_to_infer.push(DefinitionToInfer::Other(Box::new(def)));
+                }
+                Definition::Validator { .. } => {}
+                Definition::Fn(function) => {
+                    let name = function.name.clone();
+                    environment.pending_functions.insert(name.clone(), function);
+                    definitions_to_infer.push(DefinitionToInfer::Function(name));
+                }
+                Definition::Test { .. }
                 | Definition::Benchmark { .. }
                 | Definition::TypeAlias { .. }
                 | Definition::DataType { .. }
-                | Definition::Use { .. } => not_consts.push(def),
+                | Definition::Use { .. } => {
+                    definitions_to_infer.push(DefinitionToInfer::Other(Box::new(def)));
+                }
             }
         }
 
-        for def in consts.into_iter().chain(not_consts) {
-            let definition =
-                infer_definition(def, &module_name, &mut hydrators, &mut environment, tracing)?;
+        for definition in consts {
+            definitions.push(infer_definition(
+                definition,
+                &module_name,
+                &mut hydrators,
+                &mut environment,
+                tracing,
+            )?);
+        }
 
+        for def in definitions_to_infer {
+            let definition = match def {
+                DefinitionToInfer::Function(name) => {
+                    let top_level_scope = environment.open_new_scope();
+                    let inferred = infer_registered_function(
+                        name,
+                        &module_name,
+                        &mut hydrators,
+                        &mut environment,
+                        tracing,
+                        &top_level_scope,
+                    );
+                    environment.close_scope(top_level_scope);
+                    Definition::Fn(inferred?)
+                }
+                DefinitionToInfer::Other(definition) => infer_definition(
+                    *definition,
+                    &module_name,
+                    &mut hydrators,
+                    &mut environment,
+                    tracing,
+                )?,
+            };
             definitions.push(definition);
         }
 
@@ -192,7 +239,7 @@ fn infer_definition(
         Definition::Fn(f) => {
             let top_level_scope = environment.open_new_scope();
             let ret = Definition::Fn(infer_function(
-                &f,
+                f,
                 module_name,
                 hydrators,
                 environment,
@@ -234,7 +281,7 @@ fn infer_definition(
                         handler.name = handler_name;
 
                         let mut typed_fun = infer_function(
-                            &handler,
+                            handler,
                             module_name,
                             hydrators,
                             environment,
@@ -314,7 +361,7 @@ fn infer_definition(
                     fallback.name = fallback_name;
 
                     let mut typed_fallback = infer_function(
-                        &fallback,
+                        fallback,
                         module_name,
                         hydrators,
                         environment,
@@ -399,7 +446,7 @@ fn infer_definition(
             }?;
 
             let typed_f = infer_function(
-                &f.into(),
+                f.into(),
                 module_name,
                 hydrators,
                 environment,
@@ -482,7 +529,7 @@ fn infer_definition(
             }?;
 
             let typed_f = infer_function(
-                &f.into(),
+                f.into(),
                 module_name,
                 hydrators,
                 environment,
@@ -803,21 +850,25 @@ where
 
     // Replace the pre-registered type for the test function, to allow inferring
     // the function body with the right type arguments.
-    let scope = environment
-        .scope
-        .get_mut(&f.name)
-        .expect("Could not find preregistered type for test");
+    let function_type = environment
+        .get_variable(&f.name)
+        .expect("Could not find preregistered type for test")
+        .tipo
+        .as_ref();
     if let Type::Fn {
         ret,
         alias,
         args: _,
-    } = scope.tipo.as_ref()
+    } = function_type
     {
-        scope.tipo = Rc::new(Type::Fn {
-            ret: ret.clone(),
-            args: vec![inferred_inner_type.clone()],
-            alias: alias.clone(),
-        })
+        environment.update_module_function_type(
+            &f.name,
+            Rc::new(Type::Fn {
+                ret: ret.clone(),
+                args: vec![inferred_inner_type.clone()],
+                alias: alias.clone(),
+            }),
+        );
     }
 
     Ok(((typed_via, inferred_inner_type), arg.arg.annotation.clone()))

--- a/crates/aiken-project/src/error.rs
+++ b/crates/aiken-project/src/error.rs
@@ -26,6 +26,13 @@ use std::{
 };
 use zip::result::ZipError;
 
+const MAX_INLINE_SUGGESTION_BYTES: usize = 512;
+
+fn source_snippet(source: &str, location: Span) -> Option<&str> {
+    let snippet = source.get(location.start..location.end)?.trim();
+    (!snippet.is_empty() && snippet.len() <= MAX_INLINE_SUGGESTION_BYTES).then_some(snippet)
+}
+
 pub enum TomlLoadingContext {
     Project,
     Manifest,
@@ -304,17 +311,29 @@ impl Error {
             TestResult::UnitTestResult(UnitTestResult { test, .. }) => (
                 test.name.to_string(),
                 test.input_path.to_path_buf(),
-                test.program.to_pretty(),
+                if verbose {
+                    test.program_source()
+                } else {
+                    String::new()
+                },
             ),
             TestResult::PropertyTestResult(PropertyTestResult { test, .. }) => (
                 test.name.to_string(),
                 test.input_path.to_path_buf(),
-                test.program.to_pretty(),
+                if verbose {
+                    test.program_source()
+                } else {
+                    String::new()
+                },
             ),
             TestResult::BenchmarkResult(BenchmarkResult { bench, .. }) => (
                 bench.name.to_string(),
                 bench.input_path.to_path_buf(),
-                bench.program.to_pretty(),
+                if verbose {
+                    bench.program_source()
+                } else {
+                    String::new()
+                },
             ),
         };
 
@@ -504,7 +523,27 @@ impl Diagnostic for Error {
                 modules.join("\n- ")
             ))),
             Error::Parse { error, .. } => error.help(),
-            Error::Type { error, .. } => error.help(),
+            Error::Type { src, error, .. } => match error.as_ref() {
+                tipo::error::Error::CastDataNoAnn {
+                    pattern_location, ..
+                } => source_snippet(src, *pattern_location)
+                    .map(|pattern| {
+                        Box::new(format!(
+                            "Add a concrete type annotation to the pattern, for example:\n\n╰─▶ {pattern}: YourType"
+                        )) as Box<dyn Display>
+                    })
+                    .or_else(|| error.help()),
+                tipo::error::Error::LastExpressionIsAssignment { value_location, .. } => {
+                    source_snippet(src, *value_location)
+                        .map(|value| {
+                            Box::new(format!(
+                                "Code blocks must return an expression. Add the value to return after this assignment, for example:\n\n╰─▶ {value}"
+                            )) as Box<dyn Display>
+                        })
+                        .or_else(|| error.help())
+                }
+                _ => error.help(),
+            },
             Error::MissingManifest { .. } => Some(Box::new(
                 "Try running `aiken new <REPOSITORY/PROJECT>` to initialise a project with an example manifest.",
             )),
@@ -798,7 +837,20 @@ impl Diagnostic for Warning {
 
     fn help<'a>(&'a self) -> Option<Box<dyn Display + 'a>> {
         match self {
-            Warning::Type { warning, .. } => warning.help(),
+            Warning::Type { src, warning, .. } => match warning {
+                tipo::error::Warning::SingleWhenClause {
+                    location,
+                    value_location,
+                } => source_snippet(src, *location)
+                    .zip(source_snippet(src, *value_location))
+                    .map(|(pattern, value)| {
+                        Box::new(format!(
+                            "Prefer using a let binding instead:\n\n╰─▶ let {pattern} = {value}"
+                        )) as Box<dyn Display>
+                    })
+                    .or_else(|| warning.help()),
+                _ => warning.help(),
+            },
             Warning::NoValidators => None,
             Warning::CompilerVersionMismatch { demanded, .. } => Some(Box::new(format!(
                 "You may want to switch to {}",
@@ -915,4 +967,107 @@ fn default_miette_handler(context_lines: usize) -> MietteHandler {
         .terminal_links(true)
         .context_lines(context_lines)
         .build()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use aiken_lang::ast::{AssignmentKind, AssignmentPattern, UntypedPattern};
+
+    fn span_of(source: &str, needle: &str) -> Span {
+        let start = source.find(needle).expect("source contains test snippet");
+        Span {
+            start,
+            end: start + needle.len(),
+        }
+    }
+
+    fn type_error(source: &str, error: tipo::error::Error) -> Error {
+        let path = PathBuf::from("test.ak");
+        let source = source.to_string();
+
+        Error::Type {
+            path: Box::new(path.clone()),
+            src: Box::new(source.clone()),
+            named: Box::new(NamedSource::new(path.display().to_string(), source)),
+            error: Box::new(error),
+        }
+    }
+
+    #[test]
+    fn cast_help_reconstructs_the_pattern_from_its_span() {
+        let source = "expect Some(value) = data";
+        let pattern_location = span_of(source, "Some(value)");
+        let error = type_error(
+            source,
+            tipo::error::Error::CastDataNoAnn {
+                location: Span {
+                    start: 0,
+                    end: source.len(),
+                },
+                pattern_location,
+            },
+        );
+
+        assert_eq!(
+            error.help().expect("cast error has help").to_string(),
+            "Add a concrete type annotation to the pattern, for example:\n\n╰─▶ Some(value): YourType"
+        );
+    }
+
+    #[test]
+    fn last_assignment_help_reconstructs_the_return_value_from_its_span() {
+        let source = "let answer = 42";
+        let pattern_location = span_of(source, "answer");
+        let value_location = span_of(source, "42");
+        let error = type_error(
+            source,
+            tipo::error::Error::LastExpressionIsAssignment {
+                location: Span {
+                    start: 0,
+                    end: source.len(),
+                },
+                value_location,
+                patterns: AssignmentPattern::new(
+                    UntypedPattern::Var {
+                        location: pattern_location,
+                        name: "answer".to_string(),
+                    },
+                    None,
+                    pattern_location,
+                )
+                .into(),
+                kind: AssignmentKind::let_(),
+            },
+        );
+
+        assert_eq!(
+            error
+                .help()
+                .expect("last-assignment error has help")
+                .to_string(),
+            "Code blocks must return an expression. Add the value to return after this assignment, for example:\n\n╰─▶ 42"
+        );
+    }
+
+    #[test]
+    fn single_when_help_reconstructs_the_binding_from_source_spans() {
+        let source = "when subject is { value -> value }";
+        let warning = Warning::from_type_warning(
+            tipo::error::Warning::SingleWhenClause {
+                location: span_of(source, "value"),
+                value_location: span_of(source, "subject"),
+            },
+            PathBuf::from("test.ak"),
+            source.to_string(),
+        );
+
+        assert_eq!(
+            warning
+                .help()
+                .expect("single-when warning has help")
+                .to_string(),
+            "Prefer using a let binding instead:\n\n╰─▶ let value = subject"
+        );
+    }
 }

--- a/crates/aiken-project/src/lib.rs
+++ b/crates/aiken-project/src/lib.rs
@@ -30,6 +30,7 @@ use crate::{
     options::BlueprintExport,
     telemetry::{CoverageMode, Event},
 };
+
 use aiken_lang::{
     IdGenerator,
     ast::{
@@ -64,6 +65,8 @@ use uplc::{
     PlutusData,
     ast::{Constant, Name, Program},
 };
+#[cfg(not(target_family = "wasm"))]
+const NATIVE_PARALLEL_RUNNABLE_STACK_LIMIT: usize = 16 * 1024 * 1024;
 
 #[derive(Debug)]
 pub struct Source {
@@ -492,6 +495,17 @@ where
                     })
                     .collect();
 
+                #[cfg(not(target_family = "wasm"))]
+                TestResult::with_native_stack(tests, |tests| {
+                    self.event_listener.handle_event(Event::FinishedTests {
+                        seed,
+                        coverage_mode,
+                        tests,
+                        plain_numbers,
+                    })
+                });
+
+                #[cfg(target_family = "wasm")]
                 self.event_listener.handle_event(Event::FinishedTests {
                     seed,
                     coverage_mode,
@@ -1080,7 +1094,7 @@ where
 
             tests.push(Test::from_function_definition(
                 &mut generator,
-                test.to_owned(),
+                test,
                 module_name,
                 input_path,
                 kind,
@@ -1147,7 +1161,7 @@ where
 
     fn run_runnables(
         &self,
-        tests: Vec<Test>,
+        mut tests: Vec<Test>,
         seed: u32,
         max_success: usize,
         tracing: Tracing,
@@ -1158,10 +1172,66 @@ where
 
         let plutus_version = &self.config.plutus;
 
-        tests
-            .into_par_iter()
-            .map(|test| test.run(seed, max_success, plutus_version, tracing))
-            .collect::<Vec<TestResult<(Constant, Rc<Type>), PlutusData>>>()
+        let assertions = tests
+            .iter_mut()
+            .map(|test| match test {
+                Test::UnitTest(unit_test) => unit_test.assertion.take(),
+                Test::PropertyTest(_) | Test::Benchmark(_) => None,
+            })
+            .collect::<Vec<_>>();
+
+        let mut results = {
+            #[cfg(not(target_family = "wasm"))]
+            {
+                let (large, parallel): (Vec<_>, Vec<_>) =
+                    tests.into_iter().enumerate().partition(|(_, test)| {
+                        test.native_stack_size()
+                            .is_some_and(|size| size > NATIVE_PARALLEL_RUNNABLE_STACK_LIMIT)
+                    });
+
+                let mut results = parallel
+                    .into_par_iter()
+                    .map(|(index, test)| {
+                        (index, test.run(seed, max_success, plutus_version, tracing))
+                    })
+                    .collect::<Vec<_>>();
+
+                results.extend(large.into_iter().map(|(index, test)| {
+                    (index, test.run(seed, max_success, plutus_version, tracing))
+                }));
+                results.sort_unstable_by_key(|(index, _)| *index);
+                results
+                    .into_iter()
+                    .map(|(_, result)| result)
+                    .collect::<Vec<TestResult<(Constant, Rc<Type>), PlutusData>>>()
+            }
+
+            #[cfg(target_family = "wasm")]
+            tests
+                .into_par_iter()
+                .map(|test| test.run(seed, max_success, plutus_version, tracing))
+                .collect::<Vec<TestResult<(Constant, Rc<Type>), PlutusData>>>()
+        };
+
+        let mut generator = None;
+        for (result, assertion) in results.iter_mut().zip(assertions) {
+            let Some(assertion) = assertion else {
+                continue;
+            };
+
+            if let TestResult::UnitTestResult(unit_test) = result
+                && !unit_test.success
+            {
+                unit_test.assertion = Some((*assertion).evaluate(
+                    generator.get_or_insert_with(|| self.new_generator(tracing)),
+                    &unit_test.test.module,
+                ));
+            } else {
+                (*assertion).discard();
+            }
+        }
+
+        results
             .into_iter()
             .map(|test| test.reify(&data_types))
             .collect()

--- a/crates/aiken-project/src/test_framework.rs
+++ b/crates/aiken-project/src/test_framework.rs
@@ -28,7 +28,10 @@ mod test {
 
     const TEST_KIND: ModuleKind = ModuleKind::Lib;
 
-    pub fn test_from_source(src: &str) -> (Test, IndexMap<DataTypeKey, TypedDataType>) {
+    pub fn with_test_from_source<R>(
+        src: &str,
+        and_then: impl FnOnce(Test, &mut CodeGenerator<'_>, &IndexMap<DataTypeKey, TypedDataType>) -> R,
+    ) -> R {
         let id_gen = IdGenerator::new();
 
         let module_name = "";
@@ -97,16 +100,21 @@ mod test {
             Tracing::All(TraceLevel::Verbose),
         );
 
-        (
-            Test::from_function_definition(
-                &mut generator,
-                test.to_owned(),
-                module_name.to_string(),
-                PathBuf::new(),
-                RunnableKind::Test,
-            ),
-            data_types,
-        )
+        let test = Test::from_function_definition(
+            &mut generator,
+            &test,
+            module_name.to_string(),
+            PathBuf::new(),
+            RunnableKind::Test,
+        );
+
+        and_then(test, &mut generator, &data_types)
+    }
+
+    pub fn test_from_source(src: &str) -> (Test, IndexMap<DataTypeKey, TypedDataType>) {
+        with_test_from_source(src, |test, _generator, data_types| {
+            (test, data_types.clone())
+        })
     }
 
     fn property(src: &str) -> (PropertyTest, impl Fn(PlutusData) -> String) {
@@ -225,28 +233,34 @@ mod test {
     }
 
     fn unit_test(src: &str) -> Option<String> {
-        match test_from_source(src) {
-            (Test::PropertyTest(..), _) => {
+        with_test_from_source(src, |test, generator, data_types| match test {
+            Test::PropertyTest(..) => {
                 panic!("Expected to yield a UnitTest but found a PropertyTest")
             }
-            (Test::UnitTest(test), data_types) => {
+            Test::UnitTest(mut test) => {
                 let expected_failure =
                     matches!(test.on_test_failure, OnTestFailure::SucceedImmediately);
+                let assertion = test.assertion.take();
+                let data_types_refs = utils::indexmap::as_ref_values(data_types);
+                let mut result = test.run(&PlutusVersion::V3, Tracing::verbose());
 
-                let data_types_refs = utils::indexmap::as_ref_values(&data_types);
+                if let Some(assertion) = assertion {
+                    if result.success {
+                        (*assertion).discard();
+                    } else {
+                        result.assertion =
+                            Some((*assertion).evaluate(generator, &result.test.module));
+                    }
+                }
 
-                let result = test
-                    .run(&PlutusVersion::V3, Tracing::verbose())
-                    .reify(&data_types_refs);
-
-                result
-                    .assertion
-                    .map(|a| a.to_string(expected_failure, &AssertionStyleOptions::new(None)))
+                result.reify(&data_types_refs).assertion.map(|assertion| {
+                    assertion.to_string(expected_failure, &AssertionStyleOptions::new(None))
+                })
             }
-            (Test::Benchmark(..), _) => {
+            Test::Benchmark(..) => {
                 panic!("Expected to yield a PropertyTest but found a Benchmark")
             }
-        }
+        })
     }
 
     fn expect_failure<'a>(
@@ -298,6 +312,57 @@ mod test {
                 .to_string()
             ),
         );
+    }
+
+    #[cfg(not(target_family = "wasm"))]
+    #[test]
+    fn deeply_nested_property_runs_on_a_small_native_stack() {
+        use std::thread;
+
+        let depth = 4_096;
+        let mut source = String::with_capacity(160 + depth * 3);
+        source.push_str(
+            "type Nested {\n  End(Int)\n  Next(Nested)\n}\n\ntest deep_property(n: Int via int()) {\n  let value = ",
+        );
+        for _ in 0..depth {
+            source.push_str("Next(");
+        }
+        source.push_str("End(n)");
+        for _ in 0..depth {
+            source.push(')');
+        }
+        source.push_str("\n  builtin.length_of_bytearray(builtin.serialise_data(value)) > 0\n}\n");
+
+        let property = thread::Builder::new()
+            .name("deep-property-compilation".to_string())
+            .stack_size(128 * 1024 * 1024)
+            .spawn(move || property(&source).0)
+            .expect("spawn deep property compilation thread")
+            .join()
+            .expect("compile deeply nested property");
+        assert!(
+            property.program.nesting_depth() > depth,
+            "generated property program depth: {}",
+            property.program.nesting_depth()
+        );
+
+        thread::Builder::new()
+            .name("deep-property-small-stack".to_string())
+            .stack_size(128 * 1024)
+            .spawn(move || {
+                let result = TestResult::<(), PlutusData>::PropertyTestResult(property.run(
+                    42,
+                    1,
+                    &PlutusVersion::default(),
+                ));
+
+                TestResult::with_native_stack(vec![result], |results| {
+                    assert!(results.first().is_some_and(TestResult::is_success));
+                });
+            })
+            .expect("spawn small-stack property thread")
+            .join()
+            .expect("run deeply nested property");
     }
 
     #[test]

--- a/crates/aiken/tests/deep_nesting.rs
+++ b/crates/aiken/tests/deep_nesting.rs
@@ -1,0 +1,185 @@
+use aiken_lang::expr::MAX_EXPRESSION_NESTING;
+use std::{
+    env,
+    ffi::OsString,
+    fs,
+    path::PathBuf,
+    process::{Command, Output},
+    sync::atomic::{AtomicUsize, Ordering},
+};
+
+static NEXT_PROJECT_ID: AtomicUsize = AtomicUsize::new(0);
+
+struct TestProject {
+    root: PathBuf,
+}
+
+impl TestProject {
+    fn new(depth: usize) -> Self {
+        Self::from_source(deep_module(depth))
+    }
+
+    fn from_source(source: String) -> Self {
+        let project_id = NEXT_PROJECT_ID.fetch_add(1, Ordering::Relaxed);
+        let root = std::env::temp_dir().join(format!(
+            "aiken-deep-nesting-{}-{project_id}",
+            std::process::id()
+        ));
+
+        fs::create_dir_all(root.join("lib")).expect("create temporary Aiken project");
+        fs::write(
+            root.join("aiken.toml"),
+            "name = \"local/deep_nesting\"\nversion = \"0.0.0\"\nplutusVersion = \"v3\"\n",
+        )
+        .expect("write temporary project manifest");
+        fs::write(root.join("lib/deep.ak"), source).expect("write deeply nested Aiken module");
+
+        Self { root }
+    }
+
+    fn check(&self, skip_tests: bool, debug: bool) -> Output {
+        let mut command = Command::new(aiken_binary());
+        command.arg("check").current_dir(&self.root);
+        command.env("NO_COLOR", "1");
+
+        if skip_tests {
+            command.arg("--skip-tests");
+        }
+        if debug {
+            command.arg("--debug");
+        }
+
+        command.output().expect("run aiken check subprocess")
+    }
+}
+
+impl Drop for TestProject {
+    fn drop(&mut self) {
+        let _ = fs::remove_dir_all(&self.root);
+    }
+}
+
+fn aiken_binary() -> OsString {
+    env::var_os("AIKEN_BIN").unwrap_or_else(|| env!("CARGO_BIN_EXE_aiken").into())
+}
+
+fn deep_module(depth: usize) -> String {
+    let mut source = String::with_capacity(160 + depth * 3);
+    source.push_str("type Natural {\n  Z\n  S(Natural)\n}\n\ntest deeply_nested_constructor() {\n  let value = ");
+
+    for _ in 0..depth {
+        source.push_str("S(");
+    }
+
+    source.push('Z');
+
+    for _ in 0..depth {
+        source.push(')');
+    }
+
+    source.push_str("\n  value == value\n}\n");
+    source
+}
+
+fn deep_failing_module(depth: usize) -> String {
+    let mut source = String::with_capacity(160 + depth * 3);
+    source.push_str(
+        "type Natural {\n  Z\n  S(Natural)\n}\n\ntest deeply_nested_failure() {\n  let value = ",
+    );
+
+    for _ in 0..depth {
+        source.push_str("S(");
+    }
+
+    source.push('Z');
+
+    for _ in 0..depth {
+        source.push(')');
+    }
+
+    source.push_str("\n  value == Z\n}\n");
+    source
+}
+
+fn assert_check_succeeds(depth: usize, skip_tests: bool) {
+    let project = TestProject::new(depth);
+    let output = project.check(skip_tests, false);
+
+    assert!(
+        output.status.success(),
+        "aiken check failed at depth {depth} (skip_tests={skip_tests}) with status {}\nstdout:\n{}\nstderr:\n{}",
+        output.status,
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr),
+    );
+}
+
+fn assert_depth_limit_exits_normally(depth: usize, skip_tests: bool) {
+    let project = TestProject::new(depth);
+    let output = project.check(skip_tests, false);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    let stdout = String::from_utf8_lossy(&output.stdout);
+
+    assert_eq!(
+        output.status.code(),
+        Some(1),
+        "aiken check did not return a normal diagnostic exit at depth {depth} (skip_tests={skip_tests})\nstdout:\n{}\nstderr:\n{stderr}",
+        stdout,
+    );
+
+    #[cfg(unix)]
+    {
+        use std::os::unix::process::ExitStatusExt;
+        assert_eq!(
+            output.status.signal(),
+            None,
+            "aiken check terminated by signal at depth {depth}"
+        );
+    }
+}
+
+fn assert_failing_test_exits_normally(depth: usize) {
+    let project = TestProject::from_source(deep_failing_module(depth));
+    let output = project.check(false, true);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+
+    assert_eq!(
+        output.status.code(),
+        Some(1),
+        "failing deep test did not return a normal diagnostic exit at depth {depth}\nstdout:\n{}\nstderr:\n{stderr}",
+        String::from_utf8_lossy(&output.stdout),
+    );
+
+    #[cfg(unix)]
+    {
+        use std::os::unix::process::ExitStatusExt;
+        assert_eq!(
+            output.status.signal(),
+            None,
+            "failing deep test terminated by signal at depth {depth}"
+        );
+    }
+}
+
+#[test]
+fn check_accepts_deep_constructor_chains() {
+    for depth in [2_048, 4_096, 6_144] {
+        assert_check_succeeds(depth, false);
+    }
+}
+
+#[test]
+fn skip_tests_still_checks_deep_constructor_chains() {
+    assert_check_succeeds(4_096, true);
+}
+
+#[test]
+fn excessive_nesting_exits_normally() {
+    assert_depth_limit_exits_normally(MAX_EXPRESSION_NESTING + 1, false);
+    assert_depth_limit_exits_normally(MAX_EXPRESSION_NESTING * 10, true);
+}
+
+#[test]
+fn failing_deep_test_renders_and_exits_normally() {
+    assert_failing_test_exits_normally(4_096);
+}

--- a/crates/uplc/src/ast.rs
+++ b/crates/uplc/src/ast.rs
@@ -41,6 +41,14 @@ pub struct Program<T> {
     pub term: Term<T>,
 }
 
+impl<T> Program<T> {
+    /// Maximum recursive depth across terms and constants embedded in this
+    /// program. The traversal itself is iterative.
+    pub fn nesting_depth(&self) -> usize {
+        uplc_nesting_depth(NestedUplc::Term(&self.term))
+    }
+}
+
 impl<T> Program<T>
 where
     T: Clone,
@@ -415,6 +423,140 @@ pub enum Constant {
     Bls12_381G1Element(Box<blst::blst_p1>),
     Bls12_381G2Element(Box<blst::blst_p2>),
     Bls12_381MlResult(Box<blst::blst_fp12>),
+}
+
+impl Constant {
+    /// Maximum recursive depth across this constant, its type descriptors, and
+    /// any nested constants or Plutus data. The traversal itself is iterative.
+    pub fn nesting_depth(&self) -> usize {
+        uplc_nesting_depth::<()>(NestedUplc::Constant(self))
+    }
+}
+
+enum NestedUplc<'a, T> {
+    Term(&'a Term<T>),
+    Constant(&'a Constant),
+    Data(&'a PlutusData),
+    Type(&'a Type),
+}
+
+/// Maximum recursive depth of a Plutus data value. The traversal is iterative.
+pub fn plutus_data_nesting_depth(root: &PlutusData) -> usize {
+    uplc_nesting_depth::<()>(NestedUplc::Data(root))
+}
+
+fn uplc_nesting_depth<T>(root: NestedUplc<'_, T>) -> usize {
+    let mut maximum = 0;
+    let mut pending = vec![(root, 1)];
+
+    while let Some((node, depth)) = pending.pop() {
+        maximum = maximum.max(depth);
+        let child_depth = depth + 1;
+
+        match node {
+            NestedUplc::Term(term) => match term {
+                Term::Delay(term) | Term::Force(term) => {
+                    pending.push((NestedUplc::Term(term.as_ref()), child_depth));
+                }
+                Term::Lambda { body, .. } => {
+                    pending.push((NestedUplc::Term(body.as_ref()), child_depth));
+                }
+                Term::Apply { function, argument } => {
+                    pending.push((NestedUplc::Term(function.as_ref()), child_depth));
+                    pending.push((NestedUplc::Term(argument.as_ref()), child_depth));
+                }
+                Term::Constant(constant) => {
+                    pending.push((NestedUplc::Constant(constant.as_ref()), child_depth));
+                }
+                Term::Constr { fields, .. } => {
+                    pending.extend(
+                        fields
+                            .iter()
+                            .map(|field| (NestedUplc::Term(field), child_depth)),
+                    );
+                }
+                Term::Case { constr, branches } => {
+                    pending.push((NestedUplc::Term(constr.as_ref()), child_depth));
+                    pending.extend(
+                        branches
+                            .iter()
+                            .map(|branch| (NestedUplc::Term(branch), child_depth)),
+                    );
+                }
+                Term::Var(_) | Term::Error | Term::Builtin(_) => {}
+            },
+            NestedUplc::Constant(constant) => match constant {
+                Constant::ProtoList(tipo, elements) => {
+                    pending.push((NestedUplc::Type(tipo), child_depth));
+                    pending.extend(
+                        elements
+                            .iter()
+                            .map(|element| (NestedUplc::Constant(element), child_depth)),
+                    );
+                }
+                Constant::ProtoPair(left_type, right_type, first, second) => {
+                    pending.push((NestedUplc::Type(left_type), child_depth));
+                    pending.push((NestedUplc::Type(right_type), child_depth));
+                    pending.push((NestedUplc::Constant(first.as_ref()), child_depth));
+                    pending.push((NestedUplc::Constant(second.as_ref()), child_depth));
+                }
+                Constant::Data(data) => {
+                    pending.push((NestedUplc::Data(data), child_depth));
+                }
+                Constant::Integer(_)
+                | Constant::ByteString(_)
+                | Constant::String(_)
+                | Constant::Unit
+                | Constant::Bool(_)
+                | Constant::Bls12_381G1Element(_)
+                | Constant::Bls12_381G2Element(_)
+                | Constant::Bls12_381MlResult(_) => {}
+            },
+            NestedUplc::Type(tipo) => match tipo {
+                Type::List(element) => {
+                    pending.push((NestedUplc::Type(element.as_ref()), child_depth));
+                }
+                Type::Pair(first, second) => {
+                    pending.push((NestedUplc::Type(first.as_ref()), child_depth));
+                    pending.push((NestedUplc::Type(second.as_ref()), child_depth));
+                }
+                Type::Bool
+                | Type::Integer
+                | Type::String
+                | Type::ByteString
+                | Type::Unit
+                | Type::Data
+                | Type::Bls12_381G1Element
+                | Type::Bls12_381G2Element
+                | Type::Bls12_381MlResult => {}
+            },
+            NestedUplc::Data(data) => match data {
+                PlutusData::Constr(Constr { fields, .. }) => {
+                    pending.extend(
+                        fields
+                            .iter()
+                            .map(|field| (NestedUplc::Data(field), child_depth)),
+                    );
+                }
+                PlutusData::Map(entries) => {
+                    for (key, value) in entries.iter() {
+                        pending.push((NestedUplc::Data(key), child_depth));
+                        pending.push((NestedUplc::Data(value), child_depth));
+                    }
+                }
+                PlutusData::Array(elements) => {
+                    pending.extend(
+                        elements
+                            .iter()
+                            .map(|element| (NestedUplc::Data(element), child_depth)),
+                    );
+                }
+                PlutusData::BigInt(_) | PlutusData::BoundedBytes(_) => {}
+            },
+        }
+    }
+
+    maximum
 }
 
 pub struct Data;
@@ -1032,9 +1174,39 @@ impl Term<NamedDeBruijn> {
 
 #[cfg(test)]
 mod tests {
-    use crate::ast::Data;
+    use super::{Constant, Data, Program, Term, Type};
     use num_bigint::{BigInt, Sign};
     use pallas_codec::minicbor;
+    use std::rc::Rc;
+
+    #[test]
+    fn program_nesting_depth_includes_recursive_constants_and_data() {
+        let nested_pair = Constant::ProtoPair(
+            Type::Unit,
+            Type::Unit,
+            Rc::new(Constant::Unit),
+            Rc::new(Constant::ProtoPair(
+                Type::Unit,
+                Type::Unit,
+                Rc::new(Constant::Unit),
+                Rc::new(Constant::Unit),
+            )),
+        );
+        let nested_data =
+            Constant::Data(Data::list(vec![Data::list(vec![Data::integer(1.into())])]));
+        let nested_type =
+            Constant::ProtoList(Type::List(Rc::new(Type::List(Rc::new(Type::Unit)))), vec![]);
+
+        assert_eq!(nested_pair.nesting_depth(), 3);
+        assert_eq!(nested_data.nesting_depth(), 4);
+        assert_eq!(nested_type.nesting_depth(), 4);
+
+        let program = Program {
+            version: (1, 0, 0),
+            term: Term::<()>::Constant(Rc::new(nested_pair)),
+        };
+        assert_eq!(program.nesting_depth(), 4);
+    }
 
     // Data's negative integers are encoded with an offset of 1, as an unsigned payload. This is unlike
     // num_bigint's BigInt; so both types representations aren't quite compatible with one another.


### PR DESCRIPTION
Deeply nested constructor literals (~2,048 levels of S(S(...Z))) crashed aiken check with SIGSEGV by exhausting the native call stack.

- ast: append_in_sequence now matches on owned values instead of cloning both expression trees while building sequences
- tipo: module inference moves owned definitions instead of cloning; function-body retry and assignment inference no longer deep-clone expressions unconditionally
- tipo: recursive expression inference grows the stack via stacker::maybe_grow on supported native targets
- tipo: an iterative depth guard returns a normal diagnostic instead of crashing when nesting exceeds the supported limit (set well above the legitimate ~4,000-level use case)
- tests: subprocess-based regression harness covering depths up to 4,096+, --skip-tests, stage isolation, explicit AST destruction, release mode, and a small-stack thread

Closes #1390