### PR TITLE
perf(uplc): make CEK list builtins linear in host memory and time

### DIFF
--- a/crates/aiken-lang/src/expr.rs
+++ b/crates/aiken-lang/src/expr.rs
@@ -900,7 +900,11 @@ impl UntypedExpr {
                             elements: args
                                 .into_iter()
                                 .map(|arg| {
-                                    UntypedExpr::do_reify_constant(data_types, arg, inner.clone())
+                                    UntypedExpr::do_reify_constant(
+                                        data_types,
+                                        Rc::unwrap_or_clone(arg),
+                                        inner.clone(),
+                                    )
                                 })
                                 .collect::<Result<Vec<_>, _>>()?,
                             tail: None,
@@ -918,7 +922,11 @@ impl UntypedExpr {
                         .into_iter()
                         .zip(elems)
                         .map(|(arg, arg_type)| {
-                            UntypedExpr::do_reify_constant(data_types, arg, arg_type.clone())
+                            UntypedExpr::do_reify_constant(
+                                data_types,
+                                Rc::unwrap_or_clone(arg),
+                                arg_type.clone(),
+                            )
                         })
                         .collect::<Result<Vec<_>, _>>()?,
                 }),

--- a/crates/aiken-lang/src/gen_uplc.rs
+++ b/crates/aiken-lang/src/gen_uplc.rs
@@ -4182,12 +4182,12 @@ impl<'a> CodeGenerator<'a> {
                                     .into_iter()
                                     .zip(convert_values)
                                     .map(|(key, value)| {
-                                        UplcConstant::ProtoPair(
+                                        Rc::new(UplcConstant::ProtoPair(
                                             UplcType::Data,
                                             UplcType::Data,
                                             key.into(),
                                             value.into(),
-                                        )
+                                        ))
                                     })
                                     .collect_vec(),
                             )
@@ -4197,7 +4197,10 @@ impl<'a> CodeGenerator<'a> {
                         Term::Constant(
                             UplcConstant::ProtoList(
                                 UplcType::Data,
-                                builder::convert_constants_to_data(constants),
+                                builder::convert_constants_to_data(constants)
+                                    .into_iter()
+                                    .map(Rc::new)
+                                    .collect(),
                             )
                             .into(),
                         )
@@ -5058,7 +5061,10 @@ impl<'a> CodeGenerator<'a> {
                 }
 
                 if constants.len() == args.len() {
-                    let data_constants = builder::convert_constants_to_data(constants);
+                    let data_constants = builder::convert_constants_to_data(constants)
+                        .into_iter()
+                        .map(Rc::new)
+                        .collect();
 
                     let term = Term::Constant(
                         UplcConstant::ProtoList(UplcType::Data, data_constants).into(),

--- a/crates/aiken-lang/src/gen_uplc.rs
+++ b/crates/aiken-lang/src/gen_uplc.rs
@@ -327,6 +327,28 @@ impl<'a> CodeGenerator<'a> {
         args: &[TypedArg],
         module_name: &str,
     ) -> Program<Name> {
+        self.generate_raw_inner(body, args, module_name, true)
+    }
+
+    /// Like [`Self::generate_raw`], but skips the UPLC shrinker so the caller
+    /// can run `aiken_optimize_and_intern` later (e.g. off-thread, once per
+    /// test run) instead of paying for it during code generation.
+    pub fn generate_raw_unoptimized(
+        &mut self,
+        body: &TypedExpr,
+        args: &[TypedArg],
+        module_name: &str,
+    ) -> Program<Name> {
+        self.generate_raw_inner(body, args, module_name, false)
+    }
+
+    fn generate_raw_inner(
+        &mut self,
+        body: &TypedExpr,
+        args: &[TypedArg],
+        module_name: &str,
+        optimize: bool,
+    ) -> Program<Name> {
         args.iter().for_each(|arg| {
             arg.get_variable_name()
                 .iter()
@@ -356,7 +378,7 @@ impl<'a> CodeGenerator<'a> {
                 .for_each(|arg_name| self.interner.pop_text(arg_name.to_string()))
         });
 
-        self.finalize(term)
+        self.finalize_with(term, optimize)
     }
 
     fn new_program<T>(&self, term: Term<T>) -> Program<T> {
@@ -368,10 +390,20 @@ impl<'a> CodeGenerator<'a> {
         Program { version, term }
     }
 
-    fn finalize(&mut self, mut term: Term<Name>) -> Program<Name> {
+    fn finalize(&mut self, term: Term<Name>) -> Program<Name> {
+        self.finalize_with(term, true)
+    }
+
+    fn finalize_with(&mut self, mut term: Term<Name>, optimize: bool) -> Program<Name> {
         term = self.special_functions.apply_used_functions(term);
 
-        let program = aiken_optimize_and_intern(self.new_program(term));
+        let program = self.new_program(term);
+
+        let program = if optimize {
+            aiken_optimize_and_intern(program)
+        } else {
+            program
+        };
 
         // This is very important to call here.
         // If this isn't done, re-using the same instance

--- a/crates/aiken-lang/src/gen_uplc/builder.rs
+++ b/crates/aiken-lang/src/gen_uplc/builder.rs
@@ -140,7 +140,13 @@ impl CodeGenSpecialFuncs {
     }
 
     pub fn get_function(&self, func_name: &String) -> Term<Name> {
-        self.key_to_func[func_name].0.clone()
+        // A deep copy, not an Rc clone: these bodies are applied into test
+        // programs which cross thread boundaries for the parallel test runs,
+        // and cloned generators (property tests) would otherwise embed the
+        // same Rc allocations into several tests' programs — Rc's non-atomic
+        // reference counts forbid that. The bodies are small, so copying is
+        // negligible next to the rest of code generation.
+        self.key_to_func[func_name].0.deep_clone()
     }
 
     pub fn apply_used_functions(&self, mut term: Term<Name>) -> Term<Name> {

--- a/crates/aiken-lang/src/gen_uplc/builder.rs
+++ b/crates/aiken-lang/src/gen_uplc/builder.rs
@@ -687,10 +687,9 @@ pub fn convert_constants_to_data(constants: Vec<Rc<UplcConstant>>) -> Vec<UplcCo
                 if matches!(list_type, UplcType::Pair(_, _)) {
                     let inner_constants = constants
                         .iter()
-                        .cloned()
-                        .map(|pair| match pair {
+                        .map(|pair| match pair.as_ref() {
                             UplcConstant::ProtoPair(_, _, left, right) => {
-                                let inner_constants = vec![left, right];
+                                let inner_constants = vec![Rc::clone(left), Rc::clone(right)];
                                 let inner_constants = convert_constants_to_data(inner_constants)
                                     .into_iter()
                                     .map(|constant| match constant {
@@ -706,14 +705,13 @@ pub fn convert_constants_to_data(constants: Vec<Rc<UplcConstant>>) -> Vec<UplcCo
 
                     UplcConstant::Data(PlutusData::Map(KeyValuePairs::Def(inner_constants)))
                 } else {
-                    let inner_constants =
-                        convert_constants_to_data(constants.iter().cloned().map(Rc::new).collect())
-                            .into_iter()
-                            .map(|constant| match constant {
-                                UplcConstant::Data(d) => d,
-                                _ => todo!(),
-                            })
-                            .collect_vec();
+                    let inner_constants = convert_constants_to_data(constants.clone())
+                        .into_iter()
+                        .map(|constant| match constant {
+                            UplcConstant::Data(d) => d,
+                            _ => todo!(),
+                        })
+                        .collect_vec();
 
                     UplcConstant::Data(Data::list(inner_constants))
                 }

--- a/crates/aiken-lang/src/test_framework.rs
+++ b/crates/aiken-lang/src/test_framework.rs
@@ -29,6 +29,7 @@ use std::{
 use uplc::{
     ast::{Constant, Data, Name, NamedDeBruijn, Program, Term},
     machine::{cost_model::ExBudget, eval_result::EvalResult},
+    optimize::aiken_optimize_and_intern,
 };
 use vec1::{Vec1, vec1};
 
@@ -71,7 +72,10 @@ impl Test {
         module_name: String,
         input_path: PathBuf,
     ) -> Test {
-        let program = generator.generate_raw(&test.body, &[], &module_name);
+        // The UPLC shrinker dominates test collection time, so it is deferred
+        // to the (parallel) run phase; `run` optimizes this program before
+        // evaluating it.
+        let program = generator.generate_raw_unoptimized(&test.body, &[], &module_name);
 
         // Only the structural breakdown of the assertion is kept here; its
         // operands are only ever shown for failed tests, so generating and
@@ -129,7 +133,9 @@ impl Test {
 
             let stripped_type_info = convert_opaque_type(&type_info, generator.data_types(), true);
 
-            let program = generator.clone().generate_raw(
+            // As in `unit_test`, optimization of both programs is deferred to
+            // the run phase so the shrinker cost is paid in parallel.
+            let program = generator.clone().generate_raw_unoptimized(
                 &test.body,
                 &[TypedArg {
                     tipo: stripped_type_info.clone(),
@@ -141,7 +147,10 @@ impl Test {
             // NOTE: We need not to pass any parameter to the fuzzer/sampler here because the fuzzer
             // argument is a Data constructor which needs not any conversion. So we can just safely
             // apply onto it later.
-            let generator_program = generator.clone().generate_raw(&via, &[], &module_name);
+            let generator_program =
+                generator
+                    .clone()
+                    .generate_raw_unoptimized(&via, &[], &module_name);
 
             match kind {
                 RunnableKind::Bench => Test::Benchmark(Benchmark {
@@ -213,10 +222,14 @@ unsafe impl Send for UnitTest {}
 
 impl UnitTest {
     pub fn run(
-        self,
+        mut self,
         plutus_version: &PlutusVersion,
         tracing: Tracing,
     ) -> UnitTestResult<(Constant, Rc<Type>)> {
+        // Programs are collected unoptimized; the shrinker runs here so its
+        // cost is spread across the parallel test runs.
+        self.program = aiken_optimize_and_intern(self.program);
+
         let eval_result = Program::<NamedDeBruijn>::try_from(self.program.clone())
             .unwrap()
             .eval_version(ExBudget::max(), &plutus_version.into());
@@ -344,11 +357,16 @@ impl PropertyTest {
     /// Run a property test from a given seed. The property is run at most DEFAULT_MAX_SUCCESS times. It
     /// may stops earlier on failure; in which case a 'counterexample' is returned.
     pub fn run(
-        self,
+        mut self,
         seed: u32,
         n: usize,
         plutus_version: &PlutusVersion,
     ) -> PropertyTestResult<PlutusData> {
+        // Programs are collected unoptimized; the shrinker runs here so its
+        // cost is spread across the parallel test runs.
+        self.program = aiken_optimize_and_intern(self.program);
+        self.fuzzer.program = aiken_optimize_and_intern(self.fuzzer.program);
+
         let mut labels = BTreeMap::new();
         let mut remaining = n;
 
@@ -535,11 +553,16 @@ impl Benchmark {
     pub const DEFAULT_MAX_SIZE: usize = 30;
 
     pub fn run(
-        self,
+        mut self,
         seed: u32,
         max_size: usize,
         plutus_version: &PlutusVersion,
     ) -> BenchmarkResult {
+        // Programs are collected unoptimized; the shrinker runs here so its
+        // cost is spread across the parallel benchmark runs.
+        self.program = aiken_optimize_and_intern(self.program);
+        self.sampler.program = aiken_optimize_and_intern(self.sampler.program);
+
         let mut measures = Vec::with_capacity(max_size);
         let mut prng = Prng::from_seed(seed);
         let mut error = None;

--- a/crates/aiken-project/src/blueprint/parameter.rs
+++ b/crates/aiken-project/src/blueprint/parameter.rs
@@ -421,7 +421,7 @@ fn expect_pair(term: &Constant) -> Result<(Constant, Constant), Error> {
 
 fn expect_list(term: &Constant) -> Result<Vec<Constant>, Error> {
     if let Constant::ProtoList(_, elems) = term {
-        return Ok(elems.to_owned());
+        return Ok(elems.iter().map(|elem| elem.as_ref().clone()).collect());
     }
 
     Err(mismatch(

--- a/crates/aiken-project/src/test_framework.rs
+++ b/crates/aiken-project/src/test_framework.rs
@@ -24,7 +24,7 @@ mod test {
         collections::{BTreeMap, HashMap},
         path::PathBuf,
     };
-    use uplc::PlutusData;
+    use uplc::{PlutusData, optimize::aiken_optimize_and_intern};
 
     const TEST_KIND: ModuleKind = ModuleKind::Lib;
 
@@ -117,7 +117,21 @@ mod test {
         })
     }
 
+    /// Like [`property_raw`], but with the test and fuzzer programs already
+    /// optimized, for tests that drive `run_n_times`/`eval` directly instead
+    /// of going through `PropertyTest::run` (which optimizes on its own —
+    /// never call it on the result, the shrinker cannot re-run on its own
+    /// output).
     fn property(src: &str) -> (PropertyTest, impl Fn(PlutusData) -> String) {
+        let (mut test, reify) = property_raw(src);
+
+        test.program = aiken_optimize_and_intern(test.program);
+        test.fuzzer.program = aiken_optimize_and_intern(test.fuzzer.program);
+
+        (test, reify)
+    }
+
+    fn property_raw(src: &str) -> (PropertyTest, impl Fn(PlutusData) -> String) {
         let prelude = indoc! { r#"
             use aiken/builtin
 
@@ -318,7 +332,7 @@ mod test {
 
     #[test]
     fn test_prop_basic() {
-        let (prop, _) = property(indoc! { r#"
+        let (prop, _) = property_raw(indoc! { r#"
             test foo(n: Int via int()) {
                 n >= 0
             }
@@ -336,7 +350,7 @@ mod test {
 
     #[test]
     fn test_prop_labels() {
-        let (prop, _) = property(indoc! { r#"
+        let (prop, _) = property_raw(indoc! { r#"
             fn label(str: String) -> Void {
               str
                 |> builtin.append_string(@"\0", _)

--- a/crates/aiken-project/src/tests/gen_uplc.rs
+++ b/crates/aiken-project/src/tests/gen_uplc.rs
@@ -754,8 +754,8 @@ fn acceptance_test_6_equals_tuple() {
                 Constant::ProtoList(
                     Type::Data,
                     vec![
-                        Constant::Data(Data::integer(1.into())),
-                        Constant::Data(Data::list(vec![])),
+                        Constant::Data(Data::integer(1.into())).into(),
+                        Constant::Data(Data::list(vec![])).into(),
                     ],
                 )
                 .into(),
@@ -766,8 +766,8 @@ fn acceptance_test_6_equals_tuple() {
                 Constant::ProtoList(
                     Type::Data,
                     vec![
-                        Constant::Data(Data::integer(1.into())),
-                        Constant::Data(Data::list(vec![])),
+                        Constant::Data(Data::integer(1.into())).into(),
+                        Constant::Data(Data::list(vec![])).into(),
                     ],
                 )
                 .into(),
@@ -6007,7 +6007,7 @@ fn mk_cons_direct_invoke_2() {
             .apply(
                 Term::list_data().apply(Term::mk_cons().apply(Term::data(some)).apply(
                     Term::Constant(
-                        Constant::ProtoList(Type::Data, vec![Constant::Data(none)]).into(),
+                        Constant::ProtoList(Type::Data, vec![Constant::Data(none).into()]).into(),
                     ),
                 )),
             ),

--- a/crates/uplc/src/ast.rs
+++ b/crates/uplc/src/ast.rs
@@ -405,7 +405,10 @@ pub enum Constant {
     // tag: 4
     Bool(bool),
     // tag: 5
-    ProtoList(Type, Vec<Constant>),
+    // Elements are `Rc`-shared so list builtins (mkCons, tailList) can build
+    // derived lists without deep-cloning every element; see `deep_clone` for
+    // the thread-isolation caveat.
+    ProtoList(Type, Vec<Rc<Constant>>),
     // tag: 6
     ProtoPair(Type, Type, Rc<Constant>, Rc<Constant>),
     // tag: 7
@@ -504,7 +507,10 @@ impl Constant {
         match self {
             Constant::ProtoList(tipo, items) => Constant::ProtoList(
                 tipo.deep_clone(),
-                items.iter().map(|item| item.deep_clone()).collect(),
+                items
+                    .iter()
+                    .map(|item| Rc::new(item.deep_clone()))
+                    .collect(),
             ),
             Constant::ProtoPair(fst_tipo, snd_tipo, fst, snd) => Constant::ProtoPair(
                 fst_tipo.deep_clone(),

--- a/crates/uplc/src/ast.rs
+++ b/crates/uplc/src/ast.rs
@@ -331,6 +331,43 @@ pub enum Term<T> {
     },
 }
 
+impl<T: Clone> Term<T> {
+    /// Rebuild the term with every `Rc` allocation freshly boxed, sharing
+    /// nothing with `self`. Unlike `clone`, this only ever borrows existing
+    /// allocations (it never bumps a reference count), so it is safe to call
+    /// from several threads on terms that share `Rc` nodes — which `Rc`'s
+    /// non-atomic counts would otherwise forbid.
+    pub fn deep_clone(&self) -> Term<T> {
+        match self {
+            Term::Var(name) => Term::Var(Rc::new(name.as_ref().clone())),
+            Term::Delay(term) => Term::Delay(Rc::new(term.deep_clone())),
+            Term::Lambda {
+                parameter_name,
+                body,
+            } => Term::Lambda {
+                parameter_name: Rc::new(parameter_name.as_ref().clone()),
+                body: Rc::new(body.deep_clone()),
+            },
+            Term::Apply { function, argument } => Term::Apply {
+                function: Rc::new(function.deep_clone()),
+                argument: Rc::new(argument.deep_clone()),
+            },
+            Term::Constant(constant) => Term::Constant(Rc::new(constant.deep_clone())),
+            Term::Force(term) => Term::Force(Rc::new(term.deep_clone())),
+            Term::Error => Term::Error,
+            Term::Builtin(fun) => Term::Builtin(*fun),
+            Term::Constr { tag, fields } => Term::Constr {
+                tag: *tag,
+                fields: fields.iter().map(|field| field.deep_clone()).collect(),
+            },
+            Term::Case { constr, branches } => Term::Case {
+                constr: Rc::new(constr.deep_clone()),
+                branches: branches.iter().map(|branch| branch.deep_clone()).collect(),
+            },
+        }
+    }
+}
+
 impl<T> Term<T> {
     pub fn is_constant(&self) -> bool {
         matches!(self, Term::Constant(..))

--- a/crates/uplc/src/builder.rs
+++ b/crates/uplc/src/builder.rs
@@ -82,11 +82,15 @@ where
     }
 
     pub fn list_values(vals: Vec<Constant>) -> Self {
-        Term::Constant(Constant::ProtoList(Type::Data, vals).into())
+        Term::Constant(
+            Constant::ProtoList(Type::Data, vals.into_iter().map(Rc::new).collect()).into(),
+        )
     }
 
     pub fn int_values(vals: Vec<Constant>) -> Self {
-        Term::Constant(Constant::ProtoList(Type::Integer, vals).into())
+        Term::Constant(
+            Constant::ProtoList(Type::Integer, vals.into_iter().map(Rc::new).collect()).into(),
+        )
     }
 
     pub fn empty_map() -> Self {
@@ -97,7 +101,11 @@ where
 
     pub fn map_values(vals: Vec<Constant>) -> Self {
         Term::Constant(
-            Constant::ProtoList(Type::Pair(Type::Data.into(), Type::Data.into()), vals).into(),
+            Constant::ProtoList(
+                Type::Pair(Type::Data.into(), Type::Data.into()),
+                vals.into_iter().map(Rc::new).collect(),
+            )
+            .into(),
         )
     }
 

--- a/crates/uplc/src/flat.rs
+++ b/crates/uplc/src/flat.rs
@@ -525,7 +525,7 @@ impl Encode for Constant {
 
                 encode_constant(&type_encode, e)?;
 
-                e.encode_list_with(list, encode_constant_value)?;
+                e.encode_list_with(list, |item, e| encode_constant_value(item, e))?;
             }
             Constant::ProtoPair(type1, type2, a, b) => {
                 let mut type_encode = vec![7, 7, 6];
@@ -582,7 +582,7 @@ fn encode_constant_value(x: &Constant, e: &mut Encoder) -> Result<(), en::Error>
         Constant::Unit => Ok(()),
         Constant::Bool(b) => b.encode(e),
         Constant::ProtoList(_, list) => {
-            e.encode_list_with(list, encode_constant_value)?;
+            e.encode_list_with(list, |item, e| encode_constant_value(item, e))?;
             Ok(())
         }
         Constant::ProtoPair(_, _, a, b) => {
@@ -645,8 +645,9 @@ impl Decode<'_> for Constant {
 
                 let typ = decode_type(&mut rest)?;
 
-                let list: Vec<Constant> =
-                    d.decode_list_with(|d| decode_constant_value(typ.clone().into(), d))?;
+                let list: Vec<Rc<Constant>> = d.decode_list_with(|d| {
+                    decode_constant_value(typ.clone().into(), d).map(Rc::new)
+                })?;
 
                 Ok(Constant::ProtoList(typ, list))
             }
@@ -708,8 +709,8 @@ fn decode_constant_value(typ: Rc<Type>, d: &mut Decoder) -> Result<Constant, de:
         Type::Unit => Ok(Constant::Unit),
         Type::Bool => Ok(Constant::Bool(bool::decode(d)?)),
         Type::List(sub_type) => {
-            let list: Vec<Constant> =
-                d.decode_list_with(|d| decode_constant_value(sub_type.clone(), d))?;
+            let list: Vec<Rc<Constant>> =
+                d.decode_list_with(|d| decode_constant_value(sub_type.clone(), d).map(Rc::new))?;
 
             Ok(Constant::ProtoList(sub_type.as_ref().clone(), list))
         }
@@ -1030,8 +1031,16 @@ mod tests {
                 Constant::ProtoList(
                     Type::List(Type::Integer.into()),
                     vec![
-                        Constant::ProtoList(Type::Integer, vec![Constant::Integer(7.into())]),
-                        Constant::ProtoList(Type::Integer, vec![Constant::Integer(5.into())]),
+                        Constant::ProtoList(
+                            Type::Integer,
+                            vec![Constant::Integer(7.into()).into()],
+                        )
+                        .into(),
+                        Constant::ProtoList(
+                            Type::Integer,
+                            vec![Constant::Integer(5.into()).into()],
+                        )
+                        .into(),
                     ],
                 )
                 .into(),
@@ -1092,8 +1101,16 @@ mod tests {
                 Constant::ProtoList(
                     Type::List(Type::Integer.into()),
                     vec![
-                        Constant::ProtoList(Type::Integer, vec![Constant::Integer(7.into())]),
-                        Constant::ProtoList(Type::Integer, vec![Constant::Integer(5.into())]),
+                        Constant::ProtoList(
+                            Type::Integer,
+                            vec![Constant::Integer(7.into()).into()],
+                        )
+                        .into(),
+                        Constant::ProtoList(
+                            Type::Integer,
+                            vec![Constant::Integer(5.into()).into()],
+                        )
+                        .into(),
                     ],
                 )
                 .into(),

--- a/crates/uplc/src/machine.rs
+++ b/crates/uplc/src/machine.rs
@@ -372,7 +372,7 @@ impl Machine {
                             let head = items[0].clone();
                             let tail = Constant::ProtoList(item_type.clone(), items[1..].to_vec());
 
-                            (0, vec![Value::Con(head.into()), Value::Con(tail.into())], 2)
+                            (0, vec![Value::Con(head), Value::Con(tail.into())], 2)
                         }
                         Constant::ProtoPair(_, _, first, second) => (
                             0,

--- a/crates/uplc/src/machine/cost_model.rs
+++ b/crates/uplc/src/machine/cost_model.rs
@@ -2128,40 +2128,76 @@ impl BuiltinCosts {
                 mem: self.snd_pair.mem.cost(args[0].to_ex_mem()),
                 cpu: self.snd_pair.cpu.cost(args[0].to_ex_mem()),
             },
-            DefaultFunction::ChooseList => ExBudget {
-                mem: self.choose_list.mem.cost(
-                    args[0].to_ex_mem(),
-                    args[1].to_ex_mem(),
-                    args[2].to_ex_mem(),
-                ),
-                cpu: self.choose_list.cpu.cost(
-                    args[0].to_ex_mem(),
-                    args[1].to_ex_mem(),
-                    args[2].to_ex_mem(),
-                ),
-            },
-            DefaultFunction::MkCons => ExBudget {
-                mem: self
-                    .mk_cons
-                    .mem
-                    .cost(args[0].to_ex_mem(), args[1].to_ex_mem()),
-                cpu: self
-                    .mk_cons
-                    .cpu
-                    .cost(args[0].to_ex_mem(), args[1].to_ex_mem()),
-            },
-            DefaultFunction::HeadList => ExBudget {
-                mem: self.head_list.mem.cost(args[0].to_ex_mem()),
-                cpu: self.head_list.cpu.cost(args[0].to_ex_mem()),
-            },
-            DefaultFunction::TailList => ExBudget {
-                mem: self.tail_list.mem.cost(args[0].to_ex_mem()),
-                cpu: self.tail_list.cpu.cost(args[0].to_ex_mem()),
-            },
-            DefaultFunction::NullList => ExBudget {
-                mem: self.null_list.mem.cost(args[0].to_ex_mem()),
-                cpu: self.null_list.cpu.cost(args[0].to_ex_mem()),
-            },
+            // The list builtins below are constant-cost on every published cost
+            // model, yet `to_ex_mem()` on a list walks every element (including
+            // nested `Data`). Computing that size on each call turns list
+            // traversal/accumulation quadratic in wall time, so skip the walk
+            // whenever the costing functions cannot observe the argument sizes.
+            DefaultFunction::ChooseList => {
+                let (x, y, z) =
+                    if self.choose_list.mem.is_constant() && self.choose_list.cpu.is_constant() {
+                        (0, 0, 0)
+                    } else {
+                        (
+                            args[0].to_ex_mem(),
+                            args[1].to_ex_mem(),
+                            args[2].to_ex_mem(),
+                        )
+                    };
+
+                ExBudget {
+                    mem: self.choose_list.mem.cost(x, y, z),
+                    cpu: self.choose_list.cpu.cost(x, y, z),
+                }
+            }
+            DefaultFunction::MkCons => {
+                let (x, y) = if self.mk_cons.mem.is_constant() && self.mk_cons.cpu.is_constant() {
+                    (0, 0)
+                } else {
+                    (args[0].to_ex_mem(), args[1].to_ex_mem())
+                };
+
+                ExBudget {
+                    mem: self.mk_cons.mem.cost(x, y),
+                    cpu: self.mk_cons.cpu.cost(x, y),
+                }
+            }
+            DefaultFunction::HeadList => {
+                let x = if self.head_list.mem.is_constant() && self.head_list.cpu.is_constant() {
+                    0
+                } else {
+                    args[0].to_ex_mem()
+                };
+
+                ExBudget {
+                    mem: self.head_list.mem.cost(x),
+                    cpu: self.head_list.cpu.cost(x),
+                }
+            }
+            DefaultFunction::TailList => {
+                let x = if self.tail_list.mem.is_constant() && self.tail_list.cpu.is_constant() {
+                    0
+                } else {
+                    args[0].to_ex_mem()
+                };
+
+                ExBudget {
+                    mem: self.tail_list.mem.cost(x),
+                    cpu: self.tail_list.cpu.cost(x),
+                }
+            }
+            DefaultFunction::NullList => {
+                let x = if self.null_list.mem.is_constant() && self.null_list.cpu.is_constant() {
+                    0
+                } else {
+                    args[0].to_ex_mem()
+                };
+
+                ExBudget {
+                    mem: self.null_list.mem.cost(x),
+                    cpu: self.null_list.cpu.cost(x),
+                }
+            }
             DefaultFunction::ChooseData => ExBudget {
                 mem: self.choose_data.mem.cost(
                     args[0].to_ex_mem(),
@@ -2573,7 +2609,14 @@ impl BuiltinCosts {
                 // saturated to `i64::MAX`, rather than the integer's word size.
                 let literal = args[0].unwrap_integer()?;
                 let arg0 = literal_abs_as_i64_saturating(literal);
-                let arg1 = args[1].to_ex_mem();
+                // Both published costing functions for `dropList` depend only on
+                // the literal count, so avoid the O(list) size walk unless a
+                // cost model actually reads it.
+                let arg1 = if self.drop_list.mem.ignores_y() && self.drop_list.cpu.ignores_y() {
+                    0
+                } else {
+                    args[1].to_ex_mem()
+                };
 
                 ExBudget {
                     mem: self.drop_list.mem.cost(arg0, arg1),
@@ -3636,6 +3679,12 @@ impl Default for OneArgument {
 }
 
 impl OneArgument {
+    /// True when the function ignores its argument, so the caller can skip
+    /// computing a (potentially expensive) argument size.
+    pub fn is_constant(&self) -> bool {
+        matches!(self, OneArgument::ConstantCost(_))
+    }
+
     pub fn cost(&self, x: i64) -> i64 {
         match self {
             OneArgument::ConstantCost(c) => *c,
@@ -3674,6 +3723,20 @@ impl Default for TwoArguments {
 }
 
 impl TwoArguments {
+    /// True when the function ignores both arguments, so the caller can skip
+    /// computing (potentially expensive) argument sizes.
+    pub fn is_constant(&self) -> bool {
+        matches!(self, TwoArguments::ConstantCost(_))
+    }
+
+    /// True when the function's result never depends on `y`.
+    pub fn ignores_y(&self) -> bool {
+        matches!(
+            self,
+            TwoArguments::ConstantCost(_) | TwoArguments::LinearInX(_)
+        )
+    }
+
     pub fn cost(&self, x: i64, y: i64) -> i64 {
         match self {
             TwoArguments::ConstantCost(c) => *c,
@@ -3769,6 +3832,12 @@ impl Default for ThreeArguments {
 }
 
 impl ThreeArguments {
+    /// True when the function ignores all arguments, so the caller can skip
+    /// computing (potentially expensive) argument sizes.
+    pub fn is_constant(&self) -> bool {
+        matches!(self, ThreeArguments::ConstantCost(_))
+    }
+
     pub fn cost(&self, x: i64, y: i64, z: i64) -> i64 {
         match self {
             ThreeArguments::ConstantCost(c) => *c,
@@ -4213,7 +4282,10 @@ mod tests {
         let malformed = Value::bool(true);
         let proper_list = Value::list(
             Type::Integer,
-            vec![Constant::Integer(1.into()), Constant::Integer(2.into())],
+            vec![
+                Constant::Integer(1.into()).into(),
+                Constant::Integer(2.into()).into(),
+            ],
         );
 
         assert_eq!(1, list_len_or_value_ex_mem(&malformed));

--- a/crates/uplc/src/machine/runtime.rs
+++ b/crates/uplc/src/machine/runtime.rs
@@ -875,16 +875,23 @@ impl DefaultFunction {
                 }
             }
             DefaultFunction::MkCons => {
-                let item = args[0].unwrap_constant()?;
+                let item = args[0].unwrap_constant_rc()?;
                 let (r#type, list) = args[1].unwrap_list()?;
 
-                if *r#type != Type::from(item) {
-                    return Err(Error::TypeMismatch(Type::from(item), r#type.clone()));
+                if *r#type != Type::from(item.as_ref()) {
+                    return Err(Error::TypeMismatch(
+                        Type::from(item.as_ref()),
+                        r#type.clone(),
+                    ));
                 }
 
-                let mut ret = vec![item.clone()];
-
-                ret.extend(list.clone());
+                // Share the spine's elements instead of deep-cloning them:
+                // consing onto a list must stay O(len) in pointer copies, not
+                // O(total element size), or deep recursion over accumulated
+                // lists goes quadratic in host memory.
+                let mut ret = Vec::with_capacity(list.len() + 1);
+                ret.push(item);
+                ret.extend(list.iter().map(Rc::clone));
 
                 let value = Value::list(r#type.clone(), ret);
 
@@ -896,7 +903,7 @@ impl DefaultFunction {
                 if list.is_empty() {
                     Err(Error::EmptyList(args[0].clone()))
                 } else {
-                    let value = Value::Con(list[0].clone().into());
+                    let value = Value::Con(list[0].clone());
 
                     Ok(value)
                 }
@@ -936,7 +943,7 @@ impl DefaultFunction {
 
                 let data_list: Vec<PlutusData> = l
                     .iter()
-                    .map(|item| match item {
+                    .map(|item| match item.as_ref() {
                         Constant::Data(d) => d.clone(),
                         _ => unreachable!(),
                     })
@@ -966,7 +973,8 @@ impl DefaultFunction {
                 let mut map = Vec::new();
 
                 for item in list {
-                    let Constant::ProtoPair(Type::Data, Type::Data, left, right) = item else {
+                    let Constant::ProtoPair(Type::Data, Type::Data, left, right) = item.as_ref()
+                    else {
                         unreachable!()
                     };
 
@@ -988,7 +996,7 @@ impl DefaultFunction {
 
                 let data_list: Vec<PlutusData> = list
                     .iter()
-                    .map(|item| match item {
+                    .map(|item| match item.as_ref() {
                         Constant::Data(d) => d.clone(),
                         _ => unreachable!(),
                     })
@@ -1035,7 +1043,7 @@ impl DefaultFunction {
                             c.fields
                                 .deref()
                                 .iter()
-                                .map(|d| Constant::Data(d.clone()))
+                                .map(|d| Rc::new(Constant::Data(d.clone())))
                                 .collect(),
                         )
                         .into(),
@@ -1060,13 +1068,13 @@ impl DefaultFunction {
                         Type::Pair(Type::Data.into(), Type::Data.into()),
                         m.deref()
                             .iter()
-                            .map(|p| -> Constant {
-                                Constant::ProtoPair(
+                            .map(|p| -> Rc<Constant> {
+                                Rc::new(Constant::ProtoPair(
                                     Type::Data,
                                     Type::Data,
                                     Constant::Data(p.0.clone()).into(),
                                     Constant::Data(p.1.clone()).into(),
-                                )
+                                ))
                             })
                             .collect(),
                     );
@@ -1090,7 +1098,7 @@ impl DefaultFunction {
                         Type::Data,
                         l.deref()
                             .iter()
-                            .map(|d| Constant::Data(d.clone()))
+                            .map(|d| Rc::new(Constant::Data(d.clone())))
                             .collect(),
                     );
 
@@ -1394,8 +1402,11 @@ impl DefaultFunction {
                 // Every scalar (in the full first list, regardless of the
                 // point list length) must fit within the 512-byte bound.
                 for scalar in scalars {
-                    let Constant::Integer(scalar) = scalar else {
-                        return Err(Error::TypeMismatch(Type::Integer, Type::from(scalar)));
+                    let Constant::Integer(scalar) = scalar.as_ref() else {
+                        return Err(Error::TypeMismatch(
+                            Type::Integer,
+                            Type::from(scalar.as_ref()),
+                        ));
                     };
 
                     if scalar < &MSM_SCALAR_LB || scalar > &MSM_SCALAR_UB {
@@ -1412,14 +1423,17 @@ impl DefaultFunction {
                 let mut blst_points: Vec<blst::blst_p2> = Vec::with_capacity(points.len());
 
                 for (scalar, point) in scalars.iter().zip(points.iter()) {
-                    let Constant::Integer(scalar) = scalar else {
-                        return Err(Error::TypeMismatch(Type::Integer, Type::from(scalar)));
+                    let Constant::Integer(scalar) = scalar.as_ref() else {
+                        return Err(Error::TypeMismatch(
+                            Type::Integer,
+                            Type::from(scalar.as_ref()),
+                        ));
                     };
 
-                    let Constant::Bls12_381G2Element(point) = point else {
+                    let Constant::Bls12_381G2Element(point) = point.as_ref() else {
                         return Err(Error::TypeMismatch(
                             Type::Bls12_381G2Element,
-                            Type::from(point),
+                            Type::from(point.as_ref()),
                         ));
                     };
 
@@ -1770,7 +1784,7 @@ impl DefaultFunction {
                 let set_bit = args[2].unwrap_bool()?;
 
                 for index in indices {
-                    let Constant::Integer(bit_index) = index else {
+                    let Constant::Integer(bit_index) = index.as_ref() else {
                         unreachable!()
                     };
 
@@ -1938,8 +1952,8 @@ impl DefaultFunction {
                 let mut scalar_values = Vec::with_capacity(scalars.len());
 
                 for constant in scalars {
-                    let Constant::Integer(scalar) = constant else {
-                        return Err(Error::TypeMismatch(Type::Integer, constant.into()));
+                    let Constant::Integer(scalar) = constant.as_ref() else {
+                        return Err(Error::TypeMismatch(Type::Integer, constant.as_ref().into()));
                     };
 
                     if scalar < &MSM_SCALAR_LB || scalar > &MSM_SCALAR_UB {
@@ -1952,10 +1966,10 @@ impl DefaultFunction {
                 let mut point_values = Vec::with_capacity(points.len());
 
                 for constant in points {
-                    let Constant::Bls12_381G1Element(point) = constant else {
+                    let Constant::Bls12_381G1Element(point) = constant.as_ref() else {
                         return Err(Error::TypeMismatch(
                             Type::Bls12_381G1Element,
-                            constant.into(),
+                            constant.as_ref().into(),
                         ));
                     };
 

--- a/crates/uplc/src/machine/value.rs
+++ b/crates/uplc/src/machine/value.rs
@@ -57,7 +57,7 @@ impl Value {
         Value::Con(constant.into())
     }
 
-    pub fn list(typ: Type, n: Vec<Constant>) -> Self {
+    pub fn list(typ: Type, n: Vec<Rc<Constant>>) -> Self {
         let constant = Constant::ProtoList(typ, n);
 
         Value::Con(constant.into())
@@ -122,7 +122,7 @@ impl Value {
         Ok((t1, t2, first, second))
     }
 
-    pub(super) fn unwrap_list(&self) -> Result<(&Type, &Vec<Constant>), Error> {
+    pub(super) fn unwrap_list(&self) -> Result<(&Type, &Vec<Rc<Constant>>), Error> {
         let inner = self.unwrap_constant()?;
 
         let Constant::ProtoList(t, list) = inner else {
@@ -152,6 +152,16 @@ impl Value {
         Ok(())
     }
 
+    /// Like `unwrap_constant`, but hands out the shared allocation itself so
+    /// the caller can store it (e.g. as a list element) without a deep clone.
+    pub(super) fn unwrap_constant_rc(&self) -> Result<Rc<Constant>, Error> {
+        let Value::Con(item) = self else {
+            return Err(Error::NotAConstant(self.clone()));
+        };
+
+        Ok(Rc::clone(item))
+    }
+
     pub(super) fn unwrap_constant(&self) -> Result<&Constant, Error> {
         let Value::Con(item) = self else {
             return Err(Error::NotAConstant(self.clone()));
@@ -160,7 +170,7 @@ impl Value {
         Ok(item.as_ref())
     }
 
-    pub(super) fn unwrap_data_list(&self) -> Result<&Vec<Constant>, Error> {
+    pub(super) fn unwrap_data_list(&self) -> Result<&Vec<Rc<Constant>>, Error> {
         let inner = self.unwrap_constant()?;
 
         let Constant::ProtoList(Type::Data, list) = inner else {
@@ -173,7 +183,7 @@ impl Value {
         Ok(list)
     }
 
-    pub(super) fn unwrap_int_list(&self) -> Result<&Vec<Constant>, Error> {
+    pub(super) fn unwrap_int_list(&self) -> Result<&Vec<Rc<Constant>>, Error> {
         let inner = self.unwrap_constant()?;
 
         let Constant::ProtoList(Type::Integer, list) = inner else {
@@ -290,7 +300,9 @@ impl Value {
                     };
                 }
                 Constant::Unit | Constant::Bool(_) => total += 1,
-                Constant::ProtoList(_, items) => stack.extend(items.iter()),
+                Constant::ProtoList(_, items) => {
+                    stack.extend(items.iter().map(|item| item.as_ref()))
+                }
                 Constant::ProtoPair(_, _, l, r) => {
                     stack.push(l.as_ref());
                     stack.push(r.as_ref());
@@ -674,9 +686,9 @@ mod tests {
             Rc::new(Constant::ProtoList(
                 Type::String,
                 vec![
-                    Constant::String("abcd".to_string()),
-                    Constant::String("é".to_string()),
-                    Constant::ByteString(vec![1, 2, 3, 4, 5, 6, 7, 8, 9]),
+                    Constant::String("abcd".to_string()).into(),
+                    Constant::String("é".to_string()).into(),
+                    Constant::ByteString(vec![1, 2, 3, 4, 5, 6, 7, 8, 9]).into(),
                 ],
             )),
         );

--- a/crates/uplc/src/optimize/shrinker.rs
+++ b/crates/uplc/src/optimize/shrinker.rs
@@ -2140,11 +2140,11 @@ impl Term<Name> {
                             *tipo = Type::Integer;
 
                             for item in items {
-                                let Constant::Data(PlutusData::BigInt(i)) = item else {
+                                let Constant::Data(PlutusData::BigInt(i)) = item.as_ref() else {
                                     unreachable!("unexpected item in integer list arg: {item:#?}");
                                 };
 
-                                *item = Constant::Integer(from_pallas_bigint(i));
+                                *item = Rc::new(Constant::Integer(from_pallas_bigint(i)));
                             }
                         }
                         arg => {
@@ -2594,7 +2594,7 @@ impl Term<Name> {
                             context.inlined_apply_ids.push(arg_id);
                             *self = Term::data(Data::list(
                                 l.iter()
-                                    .map(|item| match item {
+                                    .map(|item| match item.as_ref() {
                                         Constant::Data(d) => d.clone(),
                                         _ => unreachable!(),
                                     })
@@ -2606,7 +2606,7 @@ impl Term<Name> {
                             context.inlined_apply_ids.push(arg_id);
                             *self = Term::data(Data::map(
                                 m.iter()
-                                    .map(|m| match m {
+                                    .map(|m| match m.as_ref() {
                                         Constant::ProtoPair(_, _, f, s) => {
                                             match (f.as_ref(), s.as_ref()) {
                                                 (Constant::Data(d), Constant::Data(d2)) => {

--- a/crates/uplc/src/parser.rs
+++ b/crates/uplc/src/parser.rs
@@ -188,7 +188,7 @@ peg::parser! {
 
         rule constant_list() -> Constant
           = "(" _* "list" _* t:type_info() _* ")" _+ ls:list(Some(&t)) {
-            Constant::ProtoList(t, ls)
+            Constant::ProtoList(t, ls.into_iter().map(Rc::new).collect())
           }
 
         rule constant_pair() -> Constant
@@ -331,7 +331,10 @@ peg::parser! {
             }
             / ls:list(list_sub_type(type_info)) {?
                 match type_info {
-                    Some(Type::List(t)) => Ok(Constant::ProtoList(t.as_ref().clone(), ls)),
+                    Some(Type::List(t)) => Ok(Constant::ProtoList(
+                        t.as_ref().clone(),
+                        ls.into_iter().map(Rc::new).collect(),
+                    )),
                     _ => Err("found 'List' instead of expected type")
                 }
             }
@@ -864,7 +867,9 @@ mod tests {
             super::program(uplc).unwrap(),
             Program::<Name> {
                 version: (0, 0, 0),
-                term: Term::Constant(Constant::ProtoList(Type::Unit, vec![Constant::Unit]).into())
+                term: Term::Constant(
+                    Constant::ProtoList(Type::Unit, vec![Constant::Unit.into()]).into()
+                )
             }
         )
     }
@@ -880,9 +885,9 @@ mod tests {
                     Constant::ProtoList(
                         Type::Bool,
                         vec![
-                            Constant::Bool(true),
-                            Constant::Bool(false),
-                            Constant::Bool(true)
+                            Constant::Bool(true).into(),
+                            Constant::Bool(false).into(),
+                            Constant::Bool(true).into()
                         ]
                     )
                     .into()
@@ -902,8 +907,8 @@ mod tests {
                     Constant::ProtoList(
                         Type::ByteString,
                         vec![
-                            Constant::ByteString(vec![0x00]),
-                            Constant::ByteString(vec![0x01]),
+                            Constant::ByteString(vec![0x00]).into(),
+                            Constant::ByteString(vec![0x01]).into(),
                         ]
                     )
                     .into()
@@ -925,12 +930,17 @@ mod tests {
                         vec![
                             Constant::ProtoList(
                                 Type::Integer,
-                                vec![Constant::Integer(14.into()), Constant::Integer(42.into())]
-                            ),
+                                vec![
+                                    Constant::Integer(14.into()).into(),
+                                    Constant::Integer(42.into()).into()
+                                ]
+                            )
+                            .into(),
                             Constant::ProtoList(
                                 Type::Integer,
-                                vec![Constant::Integer(1337.into())]
+                                vec![Constant::Integer(1337.into()).into()]
                             )
+                            .into()
                         ]
                     )
                     .into()
@@ -956,7 +966,10 @@ mod tests {
                 term: Term::Constant(
                     Constant::ProtoList(
                         Type::Integer,
-                        vec![Constant::Integer(14.into()), Constant::Integer(42.into())],
+                        vec![
+                            Constant::Integer(14.into()).into(),
+                            Constant::Integer(42.into()).into()
+                        ],
                     )
                     .into()
                 )
@@ -1024,7 +1037,10 @@ mod tests {
                         Constant::String(String::from("foo")).into(),
                         Constant::ProtoList(
                             Type::Integer,
-                            vec![Constant::Integer(14.into()), Constant::Integer(42.into())],
+                            vec![
+                                Constant::Integer(14.into()).into(),
+                                Constant::Integer(42.into()).into()
+                            ],
                         )
                         .into()
                     )

--- a/crates/uplc/tests/pretty_tests.rs
+++ b/crates/uplc/tests/pretty_tests.rs
@@ -21,9 +21,9 @@ fn constant_list_integer() {
             Constant::ProtoList(
                 Type::Integer,
                 vec![
-                    Constant::Integer(0.to_bigint().unwrap()),
-                    Constant::Integer(1.to_bigint().unwrap()),
-                    Constant::Integer(2.to_bigint().unwrap()),
+                    Constant::Integer(0.to_bigint().unwrap()).into(),
+                    Constant::Integer(1.to_bigint().unwrap()).into(),
+                    Constant::Integer(2.to_bigint().unwrap()).into(),
                 ],
             )
             .into(),
@@ -79,24 +79,28 @@ fn constant_deeply_nested_list() {
                         vec![
                             Constant::ProtoList(
                                 t0.clone(),
-                                vec![Constant::Integer((-1).to_bigint().unwrap())],
-                            ),
-                            Constant::ProtoList(t0.clone(), vec![]),
+                                vec![Constant::Integer((-1).to_bigint().unwrap()).into()],
+                            )
+                            .into(),
+                            Constant::ProtoList(t0.clone(), vec![]).into(),
                         ],
-                    ),
+                    )
+                    .into(),
                     Constant::ProtoList(
                         t1,
                         vec![
-                            Constant::ProtoList(t0.clone(), vec![]),
+                            Constant::ProtoList(t0.clone(), vec![]).into(),
                             Constant::ProtoList(
                                 t0,
                                 vec![
-                                    Constant::Integer(2.to_bigint().unwrap()),
-                                    Constant::Integer(3.to_bigint().unwrap()),
+                                    Constant::Integer(2.to_bigint().unwrap()).into(),
+                                    Constant::Integer(3.to_bigint().unwrap()).into(),
                                 ],
-                            ),
+                            )
+                            .into(),
                         ],
-                    ),
+                    )
+                    .into(),
                 ],
             )
             .into(),


### PR DESCRIPTION
Related to #1389; follows up on #1399 (now merged) — two commits on top of it: a CEK list fix and a test-runner parallelization.

## Problem

Evaluating deeply recursive tests that accumulate lists (e.g. structural predicates over nested `Data`) is quadratic in both host RSS and wall time, even though the on-chain mem budget is linear. At depth 10,921 (a 32,768-byte payload bound in a real project) `aiken check` needs ~48 GB of host RAM and OOM-kills the machine. Reproduces on stock v1.1.22/v1.1.23 as well.

## Causes

Two independent quadratic mechanisms in the CEK machine:

1. **`mkCons` deep-cloned the entire accumulated list on every cons** (and `tailList` cloned every element on every pop), so building an N-element list copies O(N²) element payloads.
2. **The cost model computed `to_ex_mem()` for the list argument on every call** to `mkCons`/`headList`/`tailList`/`nullList`/`chooseList`/`dropList`. For lists this walks every element including nested `Data` — O(list size) per call — even though the published costing functions for these builtins are all constant (or, for `dropList`, depend only on the literal count).

## Fix

1. `Constant::ProtoList` now stores `Rc<Constant>` elements, mirroring what `ProtoPair` already does, so cons/tail are O(len) pointer copies.
2. The budgeting arms skip the `to_ex_mem()` walk when the loaded costing function cannot observe the argument size (`is_constant()` / `ignores_y()` guards), and fall back to the full computation otherwise — a future non-constant cost model keeps exact semantics automatically.

## Results

`aiken check` on a 32 KiB-bound recursive predicate (8 GiB `ulimit -v`):

| depth | before | after |
|---|---|---|
| 2,048 | 1.80 GB / 5.5 s | 132 MB / 1.2 s |
| 4,096 | aborts at 8 GiB cap | 247 MB / 1.9 s |
| 5,446 | needs >16 GiB | 356 MB / 2.4 s |
| 10,921 | ~48 GB → OOM | 1.10 GB / 4.6 s |

## Verification

- Execution units byte-identical at every measured depth (e.g. depth 5,446: mem 1,072,613,416 / cpu 359,509,531,738) against a binary built from the parent commit.
- Blueprint output (`aiken build`) on a large real-world project: `plutus.json` byte-identical (same md5).
- Full real-world tree check: 2142/2142 tests pass with unchanged peak memory and wall time — no regression at normal recursion depths.
- `cargo test --workspace` green, all 131 acceptance-test scenarios plus script_context sims pass, examples and benchmarks check clean, clippy warning-free, rustfmt applied.



---

## Second commit: run the UPLC shrinker during parallel test runs

Profiling `aiken check` on a 2,199-test project showed 17:06 wall at ~1.15 cores average: almost all the time was `aiken_optimize_and_intern` running once per test on the single-threaded collection path, while the rayon-parallel run phase only evaluated the already-optimized programs (~0.1% of the work).

Test collection now stores the raw code-generated program (new `generate_raw_unoptimized`, which still applies used special functions and resets the generator, but skips the shrinker), and each `UnitTest`/`PropertyTest`/`Benchmark` optimizes its own programs at the top of `run()`, inside the parallel phase. Since `aiken_optimize_and_intern` is a pure function of the program, the optimized output — and therefore every trace, verdict, and execution-unit count — is unchanged.

Because tests cross thread boundaries as `unsafe impl Send` while holding `Rc`-based programs, raw programs must not share allocations across tests. The one new sharing source was the special-function bodies (cloned generators hand out `Rc` clones of the same `key_to_func` entries), so `CodeGenSpecialFuncs::get_function` now emits a deep copy of those small terms via a new `Term::deep_clone` (which only borrows existing allocations — it never touches a reference count). A whole-program deep clone is deliberately avoided: raw codegen output is a DAG with heavy subtree sharing, and expanding it into a tree multiplies the shrinker's input size and peak memory.

### Results (same 2,199-test project)

| | before | after |
|---|---|---|
| wall | 17:06 | 4:55 |
| cores utilized | ~1.15 | ~4.6 |

Per-test statuses and execution units verified identical across all 2,199 tests (same seed). `cargo test --workspace` green, all 132 acceptance scenarios pass, clippy warning-free, rustfmt applied.
