### PR TITLE
fix(uplc): avoid panics during constant folding (minor)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - **aiken-lang**: Correctly prevent upcasting `Data` from types containing opaque types or aliasing opaque types. @KtorZ
 - **uplc**: Convert `bls12_381_g1_multi_scalar_mul` / `bls12_381_g2_multi_scalar_mul` arguments from Aiken's data-encoded lists to the typed `List<Int>` and `List<G1Element>` / `List<G2Element>` constants expected by the builtins, like already done for `write_bits`. Fixes [#1378](https://github.com/aiken-lang/aiken/issues/1378). @perturbing
+- **uplc**: Keep a builtin call untouched when constant folding cannot evaluate it (e.g. `replicate_byte` with a size above the 8192-byte limit) instead of crashing the optimizer on an `unwrap`; the optimizer now only commits its bookkeeping once the evaluation succeeded. @jtranq
 
 
 ## v1.1.23 - 2026-06-26

--- a/crates/uplc/src/optimize/shrinker.rs
+++ b/crates/uplc/src/optimize/shrinker.rs
@@ -2678,8 +2678,6 @@ impl Term<Name> {
         _scope: &Scope,
         context: &mut Context,
     ) -> bool {
-        let mut changed = false;
-
         match self {
             Term::Builtin(func) => {
                 let applies = arg_stack
@@ -2694,37 +2692,49 @@ impl Term<Name> {
                     .iter()
                     .map(|(_, term)| term.pierce_no_inlines_ref())
                     .collect_vec();
-                if applies.len() == func.arity() && func.is_error_safe(&args) {
-                    changed = true;
-                    let applied_term =
-                        applies
-                            .into_iter()
-                            .fold(Term::Builtin(*func), |acc, (arg_id, arg)| {
-                                context.inlined_apply_ids.push(arg_id);
-                                acc.apply(arg.pierce_no_inlines_ref().clone())
-                            });
 
-                    // The check above is to make sure the program is error safe
-                    let eval_term: Term<Name> = Program {
-                        version: (1, 0, 0),
-                        term: applied_term,
-                    }
-                    .to_named_debruijn()
-                    .unwrap()
-                    .eval(ExBudget::default())
-                    .result()
-                    .unwrap()
-                    .try_into()
-                    .unwrap();
-
-                    *self = eval_term;
+                if applies.len() != func.arity() || !func.is_error_safe(&args) {
+                    return false;
                 }
+
+                let applied_term = args
+                    .iter()
+                    .fold(Term::Builtin(*func), |acc, arg| acc.apply((*arg).clone()));
+
+                // Static checks can miss evaluation errors or budget exhaustion.
+                // Only record applications for removal after a successful fold.
+                let Some(eval_term) = Self::eval_saturated_builtin(applied_term) else {
+                    return false;
+                };
+
+                for (arg_id, _) in applies {
+                    context.inlined_apply_ids.push(arg_id);
+                }
+
+                *self = eval_term;
+
+                true
             }
             Term::Constr { .. } => todo!(),
             Term::Case { .. } => todo!(),
-            _ => (),
+            _ => false,
         }
-        changed
+    }
+
+    fn eval_saturated_builtin(applied_term: Term<Name>) -> Option<Term<Name>> {
+        let program = Program {
+            version: (1, 0, 0),
+            term: applied_term,
+        }
+        .to_named_debruijn()
+        .ok()?;
+
+        program
+            .eval(ExBudget::default())
+            .result()
+            .ok()?
+            .try_into()
+            .ok()
     }
 
     fn remove_inlined_ids(
@@ -4510,5 +4520,71 @@ mod tests {
                 term.case_constr_apply_reducer(id, arg_stack, scope, context);
             })
         });
+    }
+
+    #[test]
+    fn builtin_eval_reducer_keeps_call_the_evaluator_rejects() {
+        // `is_error_safe` accepts 8193, but the evaluator's limit is 8192.
+        // Delaying the call makes the program valid.
+        let program = Program {
+            version: (1, 1, 0),
+            term: Term::Builtin(DefaultFunction::ReplicateByte)
+                .apply(Term::integer(8193.into()))
+                .apply(Term::integer(0.into()))
+                .delay(),
+        };
+
+        let expected = program.clone();
+
+        compare_optimization(expected, program, |program| program.multi_pass().0);
+    }
+
+    #[test]
+    fn builtin_eval_reducer_failed_fold_leaves_arguments_in_place() {
+        // Preserve the failed call's arguments while folding its sibling.
+        let unfoldable = Term::Builtin(DefaultFunction::ReplicateByte)
+            .apply(Term::integer(8193.into()))
+            .apply(Term::integer(0.into()));
+
+        let program = Program {
+            version: (1, 1, 0),
+            term: Term::append_bytearray()
+                .apply(unfoldable.clone())
+                .apply(
+                    Term::Builtin(DefaultFunction::ReplicateByte)
+                        .apply(Term::integer(3.into()))
+                        .apply(Term::integer(0.into())),
+                )
+                .delay(),
+        };
+
+        let expected = Program {
+            version: (1, 1, 0),
+            term: Term::append_bytearray()
+                .apply(unfoldable)
+                .apply(Term::byte_string(vec![0, 0, 0]))
+                .delay(),
+        };
+
+        compare_optimization(expected, program, |program| program.multi_pass().0);
+    }
+
+    #[test]
+    fn aiken_optimize_keeps_call_the_evaluator_rejects() {
+        let program = Program {
+            version: (1, 1, 0),
+            term: Term::Builtin(DefaultFunction::ReplicateByte)
+                .apply(Term::integer(8193.into()))
+                .apply(Term::integer(0.into()))
+                .delay(),
+        };
+
+        let expected = program.clone();
+
+        compare_optimization(
+            expected,
+            program,
+            crate::optimize::aiken_optimize_and_intern,
+        );
     }
 }


### PR DESCRIPTION
Constant folding examples include evaluations like `let seconds_per_hour = 60 * 60` evaluating as `60 * 60 = 3600`, also ` x + (some arithmetic)` = `x + (evaluated arithmetic)`,  also certain builtin function calls which it seems like is where a bug is happening, `replicateByte(8193, 0)`.

In this case both arguments are known so the optimizer tries to calculate the result but the byte string exceeds the builtin's limit, evaluation returns an err and the optimizers `.unwrap()` crashes the compiler, this is straightforward to repro with `aiken check` and either of the examples below.

The proposed fix is to just make the optimization optional so if calculating the result fails you just keep the original expression instead of crashing. The program can then handle it through normal execution including never evaluating it if that code isn't reached. 

You can induce this running `aiken check` with a really small example:

```aiken 
use aiken/builtin

test replicate_byte_rejects_oversized_output() fail {
builtin.replicate_byte(8193, 0) == #""
}

pub fn pad(flag: Bool) -> ByteArray {
    if flag {
       builtin.replicate_byte(8193, 0)
    }
    else {
    #"00"
    }
}
```

This seems to have slipped through because all the shrinker tests referenced the reducer or the allowlist, every existing test is a path where folding succeeds. My local repro of this bug used aiken `v1.1.23+bd0e4e3` built from `bd0e4e30`.

I think a more intuitive/less obscure way:

```aiken

// a helper for zero-padding or bitsets
pub fn zeros(n: Int) -> ByteArray {
   builtin.replicate_byte(n,0)
}

const max_tx_size = 16 * 1024

test handles_max_size_payload() {
   /// zeros(max_tx_size) compiles to a lambda applied to 16384, the shrinker substitutes the arugment
   /// into the body so the program now contains replicate_byte(16384, 0) with both arguments constant, 
   ///that call is what fails
   builtin.length_of_bytearray(zeros(max_tx_size)) == max_tx_size
}

```

and if you run `aiken check` on that you get the  "You found a bug in the Aiken compiler" banner. 

Probably a realistic way to encounter this IRL would be writing a test for  a validator that rejects oversized redeemers so you might want a dummy payload bigger than the limit, maybe build that with `builtin.replicate_bytes(size, 0)` with `size` as a module constant, then `aiken check` would also crash there. 

Noteworthy that it would technically be impossible for this to be induced in production because the call could never succeed on-chain, i.e, no working contract could contain this type of call because the 8192 byte cap is enforced by the plutus evaluator itself and not by aiken so `replicateByte` with a size above 8192 is just a hard error on every cardano node.