### PR TITLE
fix(parser): use byte offsets for EOF diagnostics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Fixed
 
+- **aiken-lang**: Report unexpected end-of-file errors at the source byte offset instead of the token count. @jtranq
 - **aiken-lang**: Correctly prevent upcasting `Data` from types containing opaque types or aliasing opaque types. @KtorZ
 - **uplc**: Convert `bls12_381_g1_multi_scalar_mul` / `bls12_381_g2_multi_scalar_mul` arguments from Aiken's data-encoded lists to the typed `List<Int>` and `List<G1Element>` / `List<G2Element>` constants expected by the builtins, like already done for `write_bits`. Fixes [#1378](https://github.com/aiken-lang/aiken/issues/1378). @perturbing
 

--- a/crates/aiken-lang/src/parser.rs
+++ b/crates/aiken-lang/src/parser.rs
@@ -26,7 +26,7 @@ pub fn module(
 ) -> Result<(ast::UntypedModule, ModuleExtra), Vec<ParseError>> {
     let lexer::LexInfo { tokens, extra } = lexer::run(src)?;
 
-    let stream = chumsky::Stream::from_iter(ast::Span::create(tokens.len(), 1), tokens.into_iter());
+    let stream = chumsky::Stream::from_iter(ast::Span::create(src.len(), 1), tokens.into_iter());
 
     let definitions = import()
         .repeated()
@@ -87,7 +87,29 @@ pub fn module(
 
 #[cfg(test)]
 mod tests {
+    use super::{error::ErrorKind, module};
     use crate::assert_module;
+    use crate::ast::ModuleKind;
+    use miette::Diagnostic;
+
+    #[test]
+    fn unexpected_eof_uses_source_byte_offset() {
+        for src in [
+            "fn foo() { 42",
+            "fn foo() {\n  42\n\n   ",
+            "fn foo() { \"héllo 🌍\"",
+            "fn foo() { 42\n// trailing comment 🌍\n",
+        ] {
+            let errors = module(src, ModuleKind::Lib).unwrap_err();
+            assert_eq!(errors.len(), 1, "source: {src:?}");
+            assert!(matches!(errors[0].kind.as_ref(), ErrorKind::UnexpectedEnd));
+
+            let labels = errors[0].labels().unwrap().collect::<Vec<_>>();
+            assert_eq!(labels.len(), 1);
+            assert_eq!(labels[0].offset(), src.len(), "source: {src:?}");
+            assert_eq!(labels[0].len(), 1);
+        }
+    }
 
     #[test]
     fn merge_imports() {

--- a/crates/aiken-lang/src/parser/utils.rs
+++ b/crates/aiken-lang/src/parser/utils.rs
@@ -23,9 +23,11 @@ macro_rules! assert_expr {
     ($code:expr) => {
         use chumsky::Parser;
 
-        match $crate::parser::lexer::run(indoc::indoc! { $code }) {
+        let src = indoc::indoc! { $code };
+
+        match $crate::parser::lexer::run(src) {
             Ok($crate::parser::lexer::LexInfo { tokens, .. }) => {
-                let stream = chumsky::Stream::from_iter($crate::ast::Span::create(tokens.len(), 1), tokens.into_iter());
+                let stream = chumsky::Stream::from_iter($crate::ast::Span::create(src.len(), 1), tokens.into_iter());
 
                 let result = $crate::parser::expr::sequence().parse(stream);
 
@@ -68,9 +70,10 @@ macro_rules! assert_annotation {
     ($code:expr) => {
         use chumsky::Parser;
 
-        let $crate::parser::lexer::LexInfo { tokens, .. } = $crate::parser::lexer::run(indoc::indoc! { $code }).unwrap();
+        let src = indoc::indoc! { $code };
+        let $crate::parser::lexer::LexInfo { tokens, .. } = $crate::parser::lexer::run(src).unwrap();
 
-        let stream = chumsky::Stream::from_iter($crate::ast::Span::create(tokens.len(), 1), tokens.into_iter());
+        let stream = chumsky::Stream::from_iter($crate::ast::Span::create(src.len(), 1), tokens.into_iter());
 
         let result = $crate::parser::annotation().parse(stream).unwrap();
 
@@ -89,9 +92,10 @@ macro_rules! assert_pattern {
     ($code:expr) => {
         use chumsky::Parser;
 
-        let $crate::parser::lexer::LexInfo { tokens, .. } = $crate::parser::lexer::run(indoc::indoc! { $code }).unwrap();
+        let src = indoc::indoc! { $code };
+        let $crate::parser::lexer::LexInfo { tokens, .. } = $crate::parser::lexer::run(src).unwrap();
 
-        let stream = chumsky::Stream::from_iter($crate::ast::Span::create(tokens.len(), 1), tokens.into_iter());
+        let stream = chumsky::Stream::from_iter($crate::ast::Span::create(src.len(), 1), tokens.into_iter());
 
         let result = $crate::parser::pattern().parse(stream).unwrap();
 
@@ -126,9 +130,10 @@ macro_rules! assert_definition {
     ($code:expr) => {
         use chumsky::Parser;
 
-        let $crate::parser::lexer::LexInfo { tokens, .. } = $crate::parser::lexer::run(indoc::indoc! { $code }).unwrap();
+        let src = indoc::indoc! { $code };
+        let $crate::parser::lexer::LexInfo { tokens, .. } = $crate::parser::lexer::run(src).unwrap();
 
-        let stream = chumsky::Stream::from_iter($crate::ast::Span::create(tokens.len(), 1), tokens.into_iter());
+        let stream = chumsky::Stream::from_iter($crate::ast::Span::create(src.len(), 1), tokens.into_iter());
 
         let result = $crate::parser::definition().parse(stream);
 
@@ -160,9 +165,10 @@ macro_rules! assert_import {
     ($code:expr) => {
         use chumsky::Parser;
 
-        let $crate::parser::lexer::LexInfo { tokens, .. } = $crate::parser::lexer::run(indoc::indoc! { $code }).unwrap();
+        let src = indoc::indoc! { $code };
+        let $crate::parser::lexer::LexInfo { tokens, .. } = $crate::parser::lexer::run(src).unwrap();
 
-        let stream = chumsky::Stream::from_iter($crate::ast::Span::create(tokens.len(), 1), tokens.into_iter());
+        let stream = chumsky::Stream::from_iter($crate::ast::Span::create(src.len(), 1), tokens.into_iter());
 
         let result = $crate::parser::import().parse(stream).unwrap();
 


### PR DESCRIPTION
Looks like there was a lot of known issues with the parser in the past, I think this could explain some of them, it's an EOF-offset bug which seems like a straightforward fix.

In March 2024, [issue #854](https://github.com/aiken-lang/aiken/issues/854) reported confusing EOF errors for mismatched braces which could be related, unsure. Other related conversation at [issue #650](https://github.com/aiken-lang/aiken/issues/650) and [pr #627](https://github.com/aiken-lang/aiken/issues/650), and [issue #627 ](https://github.com/aiken-lang/aiken/issues/587)

Commit 5a6cc855e6083e4291015f9b257492bc0730f10f changed lexer locations from character counts to byte offsets because that is what the diagnostic renderer expects but that commit left the parser’s separate EOF location using `tokens.len()` which leaves EOF diagnostics using a token count where a source-byte offset is expected. 

The regression test verifies that an unexpected end of file error points to the actual end of the source measured in bytes.